### PR TITLE
Remove legacy stay-blue troubleshooting path

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -6,8 +6,6 @@ typedef struct {
     char connector_name[32];
     int plane_id;
     int blank_primary;
-    int stay_blue;
-    int blue_hold_ms;
     int use_udev;
 
     int udp_port;

--- a/include/drm_fb.h
+++ b/include/drm_fb.h
@@ -14,7 +14,6 @@ struct DumbFB {
 };
 
 int create_argb_fb(int fd, int w, int h, uint32_t argb_fill, struct DumbFB *out);
-int create_blue_fb(int fd, int w, int h, struct DumbFB *out);
 void destroy_dumb_fb(int fd, struct DumbFB *fb);
 
 #endif // DRM_FB_H

--- a/src/config.c
+++ b/src/config.c
@@ -13,8 +13,6 @@ static void usage(const char *prog) {
             "  --plane-id N                 (video plane; default: 76)\n"
             "  --blank-primary              (detach primary plane on commit)\n"
             "  --no-udev                    (disable hotplug listener)\n"
-            "  --stay-blue                  (only do modeset & blue FB; no pipeline)\n"
-            "  --blue-hold-ms N             (hold blue for N ms after commit)\n"
             "  --udp-port N                 (default: 5600)\n"
             "  --vid-pt N                   (default: 97 H265)\n"
             "  --aud-pt N                   (default: 98 Opus)\n"
@@ -37,8 +35,6 @@ void cfg_defaults(AppCfg *c) {
     strcpy(c->card_path, "/dev/dri/card0");
     c->plane_id = 76;
     c->blank_primary = 0;
-    c->stay_blue = 0;
-    c->blue_hold_ms = 0;
     c->use_udev = 1;
 
     c->udp_port = 5600;
@@ -75,10 +71,6 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->blank_primary = 1;
         } else if (!strcmp(argv[i], "--no-udev")) {
             cfg->use_udev = 0;
-        } else if (!strcmp(argv[i], "--stay-blue")) {
-            cfg->stay_blue = 1;
-        } else if (!strcmp(argv[i], "--blue-hold-ms") && i + 1 < argc) {
-            cfg->blue_hold_ms = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--udp-port") && i + 1 < argc) {
             cfg->udp_port = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--vid-pt") && i + 1 < argc) {

--- a/src/drm_modeset.c
+++ b/src/drm_modeset.c
@@ -214,8 +214,8 @@ int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResu
     LOGI("Chosen: %s id=%u  %dx%d@%d  CRTC=%d  plane=%d", cname, conn->connector_id, w, h, hz, crtc->crtc_id, cfg->plane_id);
 
     struct DumbFB fb = {0};
-    if (create_blue_fb(fd, w, h, &fb) != 0) {
-        LOGE("create_blue_fb failed: %s", strerror(errno));
+    if (create_argb_fb(fd, w, h, 0xFF000000u, &fb) != 0) {
+        LOGE("create_argb_fb failed: %s", strerror(errno));
         drmModeFreeConnector(conn);
         drmModeFreeCrtc(crtc);
         drmModeFreeResources(res);
@@ -313,11 +313,7 @@ int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResu
         return -9;
     }
 
-    LOGI("Atomic COMMIT: %dx%d@%d on %s via plane %d — BLUE", w, h, hz, cname, cfg->plane_id);
-
-    if (cfg->blue_hold_ms > 0) {
-        usleep(cfg->blue_hold_ms * 1000);
-    }
+    LOGI("Atomic COMMIT: %dx%d@%d on %s via plane %d", w, h, hz, cname, cfg->plane_id);
 
     drmModeAtomicFree(req);
     drmModeDestroyPropertyBlob(fd, mode_blob);

--- a/src/main.c
+++ b/src/main.c
@@ -69,15 +69,11 @@ int main(int argc, char **argv) {
             if (cfg.osd_enable) {
                 osd_setup(fd, &cfg, &ms, cfg.plane_id, &osd);
             }
-            if (!cfg.stay_blue) {
-                if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
-                    LOGE("Failed to start pipeline");
-                }
-                clock_gettime(CLOCK_MONOTONIC, &window_start);
-                restart_count = 0;
-            } else {
-                LOGI("--stay-blue set, not starting pipeline");
+            if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
+                LOGE("Failed to start pipeline");
             }
+            clock_gettime(CLOCK_MONOTONIC, &window_start);
+            restart_count = 0;
         } else {
             LOGE("Initial modeset failed; will wait for hotplug events");
         }
@@ -130,16 +126,14 @@ int main(int argc, char **argv) {
                                 osd_teardown(fd, &osd);
                                 osd_setup(fd, &cfg, &ms, cfg.plane_id, &osd);
                             }
-                            if (!cfg.stay_blue) {
-                                if (ps.state != PIPELINE_STOPPED) {
-                                    pipeline_stop(&ps, 700);
-                                }
-                                if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
-                                    LOGE("Failed to start pipeline after hotplug");
-                                }
-                                clock_gettime(CLOCK_MONOTONIC, &window_start);
-                                restart_count = 0;
+                            if (ps.state != PIPELINE_STOPPED) {
+                                pipeline_stop(&ps, 700);
                             }
+                            if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
+                                LOGE("Failed to start pipeline after hotplug");
+                            }
+                            clock_gettime(CLOCK_MONOTONIC, &window_start);
+                            restart_count = 0;
                             backoff_ms = 0;
                         } else {
                             backoff_ms = backoff_ms == 0 ? 250 : (backoff_ms * 2);
@@ -163,7 +157,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        if (!cfg.stay_blue && connected && ps.state == PIPELINE_STOPPED) {
+        if (connected && ps.state == PIPELINE_STOPPED) {
             struct timespec now;
             clock_gettime(CLOCK_MONOTONIC, &now);
             long long elapsed_ms = ms_since(now, window_start);


### PR DESCRIPTION
## Summary
- drop the stay-blue CLI flag and related configuration from the application
- remove the dedicated blue framebuffer helper and use a solid black ARGB buffer for initial modesets
- ensure the video pipeline always starts after a successful modeset, including on hotplug events

## Testing
- `make` *(fails: libdrm headers not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d977591418832b9fcf8fc924a1e93a