### PR TITLE
Implement in-process GStreamer pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CC ?= gcc
 PKG_CONFIG ?= pkg-config
 PKG_DRMCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags libdrm libudev)
 PKG_DRMLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs libdrm libudev)
+PKG_GSTCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags gstreamer-1.0 gstreamer-video-1.0)
+PKG_GSTLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs gstreamer-1.0 gstreamer-video-1.0)
 
 CFLAGS ?= -O2 -Wall
 CFLAGS += -Iinclude
@@ -11,10 +13,20 @@ else
 CFLAGS += $(PKG_DRMCFLAGS)
 endif
 
+ifneq ($(strip $(PKG_GSTCFLAGS)),)
+CFLAGS += $(PKG_GSTCFLAGS)
+endif
+
 ifneq ($(strip $(PKG_DRMLIBS)),)
 LDFLAGS += $(PKG_DRMLIBS)
 else
 LDFLAGS += -ldrm -ludev
+endif
+
+ifneq ($(strip $(PKG_GSTLIBS)),)
+LDFLAGS += $(PKG_GSTLIBS)
+else
+LDFLAGS += -lgstreamer-1.0 -lgstvideo-1.0 -lgobject-2.0 -lglib-2.0
 endif
 
 SRC := $(wildcard src/*.c)

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -1,7 +1,8 @@
 #ifndef PIPELINE_H
 #define PIPELINE_H
 
-#include <sys/types.h>
+#include <glib.h>
+#include <gst/gst.h>
 
 typedef enum {
     PIPELINE_STOPPED = 0,
@@ -10,9 +11,21 @@ typedef enum {
 } PipelineStateEnum;
 
 typedef struct {
-    pid_t pid;
-    pid_t pgid;
     PipelineStateEnum state;
+    GstElement *pipeline;
+    GstElement *source;
+    GstElement *tee;
+    GstElement *video_sink;
+    GstPad *video_pad;
+    GstPad *audio_pad;
+    GThread *bus_thread;
+    GMutex lock;
+    GCond cond;
+    gboolean initialized;
+    gboolean bus_thread_running;
+    gboolean stop_requested;
+    gboolean encountered_error;
+    int audio_disabled;
 } PipelineState;
 
 #include "config.h"

--- a/src/main.c
+++ b/src/main.c
@@ -51,7 +51,8 @@ int main(int argc, char **argv) {
     struct timespec window_start = {0, 0};
 
     ModesetResult ms = {0};
-    PipelineState ps = {.pid = 0, .pgid = 0, .state = PIPELINE_STOPPED};
+    PipelineState ps = {0};
+    ps.state = PIPELINE_STOPPED;
     UdevMonitor um = {0};
     OSD osd;
     osd_init(&osd);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1,137 +1,475 @@
 #include "pipeline.h"
 #include "logging.h"
 
-#include <errno.h>
-#include <signal.h>
-#include <stdio.h>
+#include <glib.h>
+#include <gst/gst.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/prctl.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
-static void build_gst_cmd(const AppCfg *cfg, int audio_disabled, char *out, size_t outsz) {
-    const char *audio_branch;
-    char audio_real[512];
+#define CHECK_ELEM(elem, name)                                                                      \
+    do {                                                                                            \
+        if ((elem) == NULL) {                                                                       \
+            LOGE("Failed to create GStreamer element '%s'", (name));                               \
+            goto fail;                                                                              \
+        }                                                                                           \
+    } while (0)
 
-    if (cfg->no_audio) {
-        audio_branch = "";
-    } else if (audio_disabled) {
-        audio_branch = "t. ! queue leaky=downstream max-size-time=0 max-size-bytes=0 ! fakesink sync=false ";
+static void ensure_gst_initialized(const AppCfg *cfg) {
+    static gsize inited = 0;
+    if (cfg->gst_log && getenv("GST_DEBUG") == NULL) {
+        setenv("GST_DEBUG", "3", 1);
+    }
+    if (g_once_init_enter(&inited)) {
+        gst_init(NULL, NULL);
+        g_once_init_leave(&inited, 1);
+    }
+}
+
+// Keep the ingress creation isolated so we can later replace udpsrc with an
+// appsrc that is fed by a custom UDP receiver (for packet accounting, source
+// identification, etc.).
+static GstElement *create_udp_source(const AppCfg *cfg) {
+    GstElement *udpsrc = gst_element_factory_make("udpsrc", "udp_source");
+    CHECK_ELEM(udpsrc, "udpsrc");
+
+    g_object_set(udpsrc, "port", cfg->udp_port, "buffer-size", 262144, NULL);
+    return udpsrc;
+
+fail:
+    if (udpsrc != NULL) {
+        gst_object_unref(udpsrc);
+    }
+    return NULL;
+}
+
+static GstCaps *make_rtp_caps(int payload_type, int clock_rate, const char *encoding_name) {
+    return gst_caps_new_simple("application/x-rtp", "payload", G_TYPE_INT, payload_type, "clock-rate",
+                               G_TYPE_INT, clock_rate, "encoding-name", G_TYPE_STRING, encoding_name, NULL);
+}
+
+static GstCaps *make_raw_audio_caps(void) {
+    return gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "S16LE", "rate", G_TYPE_INT, 48000,
+                               "channels", G_TYPE_INT, 2, NULL);
+}
+
+static gboolean link_tee_branch(GstElement *tee, GstElement *branch, GstPad **stored_src_pad, const char *name) {
+    GstPad *src_pad = gst_element_get_request_pad(tee, "src_%u");
+    if (src_pad == NULL) {
+        LOGE("Failed to request tee pad for %s branch", name);
+        return FALSE;
+    }
+    GstPad *sink_pad = gst_element_get_static_pad(branch, "sink");
+    if (sink_pad == NULL) {
+        LOGE("Failed to get sink pad for %s branch", name);
+        gst_element_release_request_pad(tee, src_pad);
+        gst_object_unref(src_pad);
+        return FALSE;
+    }
+    if (gst_pad_link(src_pad, sink_pad) != GST_PAD_LINK_OK) {
+        LOGE("Failed to link tee to %s branch", name);
+        gst_object_unref(sink_pad);
+        gst_element_release_request_pad(tee, src_pad);
+        gst_object_unref(src_pad);
+        return FALSE;
+    }
+    gst_object_unref(sink_pad);
+    if (stored_src_pad != NULL) {
+        *stored_src_pad = src_pad;
     } else {
-        snprintf(audio_real, sizeof(audio_real),
-                 "t. ! queue leaky=downstream max-size-time=0 max-size-bytes=0 ! "
-                 "application/x-rtp,payload=%d,clock-rate=48000,encoding-name=OPUS ! "
-                 "rtpjitterbuffer latency=%d drop-on-latency=true do-lost=true ! "
-                 "rtpopusdepay ! opusdec ! audioconvert ! audioresample ! "
-                 "audio/x-raw,format=S16LE,rate=48000,channels=2 ! "
-                 "queue leaky=downstream ! "
-                 "alsasink device=%s sync=false ",
-                 cfg->aud_pt, cfg->latency_ms, cfg->aud_dev);
-        audio_branch = audio_real;
+        gst_object_unref(src_pad);
+    }
+    return TRUE;
+}
+
+static gboolean build_video_branch(PipelineState *ps, GstElement *pipeline, GstElement *tee, const AppCfg *cfg) {
+    GstElement *queue_pre = gst_element_factory_make("queue", "video_queue_pre");
+    GstElement *caps_rtp = gst_element_factory_make("capsfilter", "video_caps_rtp");
+    GstElement *jitter = gst_element_factory_make("rtpjitterbuffer", "video_jitter");
+    GstElement *depay = gst_element_factory_make("rtph265depay", "video_depay");
+    GstElement *parser = gst_element_factory_make("h265parse", "video_parser");
+    GstElement *caps_stream = gst_element_factory_make("capsfilter", "video_caps_stream");
+    GstElement *queue_post = gst_element_factory_make("queue", "video_queue_post");
+    GstElement *decoder = gst_element_factory_make("mppvideodec", "video_decoder");
+    GstElement *queue_sink = gst_element_factory_make("queue", "video_queue_sink");
+    GstElement *sink = gst_element_factory_make("kmssink", "video_sink");
+
+    CHECK_ELEM(queue_pre, "queue");
+    CHECK_ELEM(caps_rtp, "capsfilter");
+    CHECK_ELEM(jitter, "rtpjitterbuffer");
+    CHECK_ELEM(depay, "rtph265depay");
+    CHECK_ELEM(parser, "h265parse");
+    CHECK_ELEM(caps_stream, "capsfilter");
+    CHECK_ELEM(queue_post, "queue");
+    CHECK_ELEM(decoder, "mppvideodec");
+    CHECK_ELEM(queue_sink, "queue");
+    CHECK_ELEM(sink, "kmssink");
+
+    g_object_set(queue_pre, "leaky", 2, "max-size-buffers", 96, "max-size-time", (guint64)0, "max-size-bytes",
+                 (guint64)0, NULL);
+    g_object_set(queue_post, "leaky", 2, "max-size-buffers", 8, "max-size-time", (guint64)0, "max-size-bytes",
+                 (guint64)0, NULL);
+    g_object_set(queue_sink, "leaky", 2, "max-size-buffers", 8, "max-size-time", (guint64)0, "max-size-bytes",
+                 (guint64)0, NULL);
+
+    GstCaps *caps_rtp_cfg = make_rtp_caps(cfg->vid_pt, 90000, "H265");
+    g_object_set(jitter, "latency", cfg->latency_ms, "drop-on-latency", TRUE, "do-lost", TRUE,
+                 "post-drop-messages", TRUE, NULL);
+    g_object_set(parser, "config-interval", -1, "disable-passthrough", TRUE, NULL);
+
+    GstCaps *caps_stream_cfg =
+        gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "byte-stream", "alignment",
+                             G_TYPE_STRING, "au", NULL);
+
+    g_object_set(caps_rtp, "caps", caps_rtp_cfg, NULL);
+    g_object_set(caps_stream, "caps", caps_stream_cfg, NULL);
+    gst_caps_unref(caps_rtp_cfg);
+    gst_caps_unref(caps_stream_cfg);
+
+    g_object_set(sink, "plane-id", cfg->plane_id, "sync", cfg->kmssink_sync ? TRUE : FALSE, "qos",
+                 cfg->kmssink_qos ? TRUE : FALSE, "max-lateness", (gint64)cfg->max_lateness_ns, NULL);
+
+    gst_bin_add_many(GST_BIN(pipeline), queue_pre, caps_rtp, jitter, depay, parser, caps_stream, queue_post, decoder,
+                     queue_sink, sink, NULL);
+
+    if (!gst_element_link_many(queue_pre, caps_rtp, jitter, depay, parser, caps_stream, queue_post, decoder,
+                               queue_sink, sink, NULL)) {
+        LOGE("Failed to link video branch");
+        return FALSE;
     }
 
-    snprintf(out, outsz,
-             "gst-launch-1.0 -v "
-             "udpsrc port=%d buffer-size=262144 ! tee name=t "
-             "t. ! queue leaky=downstream max-size-buffers=96 max-size-time=0 max-size-bytes=0 ! "
-             "application/x-rtp,payload=%d,clock-rate=90000,encoding-name=H265 ! "
-             "rtpjitterbuffer latency=%d drop-on-latency=true do-lost=true post-drop-messages=true ! "
-             "rtph265depay ! h265parse config-interval=-1 disable-passthrough=true ! "
-             "video/x-h265,stream-format=byte-stream,alignment=au ! "
-             "queue leaky=downstream max-size-buffers=8 max-size-time=0 max-size-bytes=0 ! "
-             "mppvideodec ! queue leaky=downstream max-size-buffers=8 ! "
-             "kmssink plane-id=%d sync=%s qos=%s max-lateness=%d "
-             "%s",
-             cfg->udp_port, cfg->vid_pt, cfg->latency_ms, cfg->plane_id,
-             cfg->kmssink_sync ? "true" : "false",
-             cfg->kmssink_qos ? "true" : "false",
-             cfg->max_lateness_ns,
-             audio_branch);
+    if (!link_tee_branch(tee, queue_pre, &ps->video_pad, "video")) {
+        return FALSE;
+    }
+
+    ps->video_sink = sink;
+    return TRUE;
+
+fail:
+    return FALSE;
+}
+
+static gboolean build_audio_branch(PipelineState *ps, GstElement *pipeline, GstElement *tee, const AppCfg *cfg,
+                                   int audio_disabled) {
+    if (cfg->no_audio) {
+        return TRUE;
+    }
+
+    GstElement *queue_start = gst_element_factory_make("queue", "audio_queue_start");
+    CHECK_ELEM(queue_start, "queue");
+    g_object_set(queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0, NULL);
+
+    if (audio_disabled) {
+        GstElement *fakesink = gst_element_factory_make("fakesink", "audio_fakesink");
+        CHECK_ELEM(fakesink, "fakesink");
+        g_object_set(fakesink, "sync", FALSE, NULL);
+
+        gst_bin_add_many(GST_BIN(pipeline), queue_start, fakesink, NULL);
+        if (!gst_element_link(queue_start, fakesink)) {
+            LOGE("Failed to link audio fakesink branch");
+            return FALSE;
+        }
+        if (!link_tee_branch(tee, queue_start, &ps->audio_pad, "audio")) {
+            return FALSE;
+        }
+        ps->audio_disabled = 1;
+        return TRUE;
+    }
+
+    GstElement *caps_rtp = gst_element_factory_make("capsfilter", "audio_caps_rtp");
+    GstElement *jitter = gst_element_factory_make("rtpjitterbuffer", "audio_jitter");
+    GstElement *depay = gst_element_factory_make("rtpopusdepay", "audio_depay");
+    GstElement *decoder = gst_element_factory_make("opusdec", "audio_decoder");
+    GstElement *aconv = gst_element_factory_make("audioconvert", "audio_convert");
+    GstElement *ares = gst_element_factory_make("audioresample", "audio_resample");
+    GstElement *caps_raw = gst_element_factory_make("capsfilter", "audio_caps_raw");
+    GstElement *queue_sink = gst_element_factory_make("queue", "audio_queue_sink");
+    GstElement *alsa = gst_element_factory_make("alsasink", "audio_sink");
+
+    CHECK_ELEM(caps_rtp, "capsfilter");
+    CHECK_ELEM(jitter, "rtpjitterbuffer");
+    CHECK_ELEM(depay, "rtpopusdepay");
+    CHECK_ELEM(decoder, "opusdec");
+    CHECK_ELEM(aconv, "audioconvert");
+    CHECK_ELEM(ares, "audioresample");
+    CHECK_ELEM(caps_raw, "capsfilter");
+    CHECK_ELEM(queue_sink, "queue");
+    CHECK_ELEM(alsa, "alsasink");
+
+    g_object_set(jitter, "latency", cfg->latency_ms, "drop-on-latency", TRUE, "do-lost", TRUE, NULL);
+    GstCaps *caps_rtp_cfg = make_rtp_caps(cfg->aud_pt, 48000, "OPUS");
+    GstCaps *caps_raw_cfg = make_raw_audio_caps();
+    g_object_set(caps_rtp, "caps", caps_rtp_cfg, NULL);
+    g_object_set(caps_raw, "caps", caps_raw_cfg, NULL);
+    gst_caps_unref(caps_rtp_cfg);
+    gst_caps_unref(caps_raw_cfg);
+    g_object_set(queue_sink, "leaky", 2, NULL);
+    g_object_set(alsa, "device", cfg->aud_dev, "sync", FALSE, NULL);
+
+    gst_bin_add_many(GST_BIN(pipeline), queue_start, caps_rtp, jitter, depay, decoder, aconv, ares, caps_raw,
+                     queue_sink, alsa, NULL);
+
+    if (!gst_element_link_many(queue_start, caps_rtp, jitter, depay, decoder, aconv, ares, caps_raw, queue_sink, alsa,
+                               NULL)) {
+        LOGE("Failed to link audio branch");
+        return FALSE;
+    }
+
+    if (!link_tee_branch(tee, queue_start, &ps->audio_pad, "audio")) {
+        return FALSE;
+    }
+
+    ps->audio_disabled = 0;
+    return TRUE;
+
+fail:
+    return FALSE;
+}
+
+static void release_request_pad(GstElement *tee, GstPad **pad) {
+    if (tee != NULL && pad != NULL && *pad != NULL) {
+        gst_element_release_request_pad(tee, *pad);
+        gst_object_unref(*pad);
+        *pad = NULL;
+    }
+}
+
+static gpointer bus_thread_func(gpointer data) {
+    PipelineState *ps = (PipelineState *)data;
+    GstBus *bus = gst_element_get_bus(ps->pipeline);
+    if (bus == NULL) {
+        LOGE("Failed to get pipeline bus");
+        g_mutex_lock(&ps->lock);
+        ps->encountered_error = TRUE;
+        ps->bus_thread_running = FALSE;
+        ps->state = PIPELINE_STOPPED;
+        g_cond_signal(&ps->cond);
+        g_mutex_unlock(&ps->lock);
+        return NULL;
+    }
+
+    gboolean running = TRUE;
+    while (running) {
+        GstMessage *msg = gst_bus_timed_pop(bus, GST_MSECOND * 100);
+        if (msg == NULL) {
+            g_mutex_lock(&ps->lock);
+            running = ps->stop_requested ? FALSE : TRUE;
+            g_mutex_unlock(&ps->lock);
+            continue;
+        }
+
+        switch (GST_MESSAGE_TYPE(msg)) {
+        case GST_MESSAGE_ERROR: {
+            GError *err = NULL;
+            gchar *dbg = NULL;
+            gst_message_parse_error(msg, &err, &dbg);
+            LOGE("Pipeline error: %s (debug=%s)", err != NULL ? err->message : "unknown",
+                 dbg != NULL ? dbg : "none");
+            if (err != NULL) {
+                g_error_free(err);
+            }
+            g_free(dbg);
+            g_mutex_lock(&ps->lock);
+            ps->encountered_error = TRUE;
+            ps->stop_requested = TRUE;
+            g_mutex_unlock(&ps->lock);
+            running = FALSE;
+            break;
+        }
+        case GST_MESSAGE_EOS:
+            LOGI("Pipeline reached EOS");
+            g_mutex_lock(&ps->lock);
+            ps->stop_requested = TRUE;
+            g_mutex_unlock(&ps->lock);
+            running = FALSE;
+            break;
+        case GST_MESSAGE_STATE_CHANGED: {
+            if (GST_MESSAGE_SRC(msg) == GST_OBJECT(ps->pipeline)) {
+                GstState old_state, new_state, pending;
+                gst_message_parse_state_changed(msg, &old_state, &new_state, &pending);
+                LOGV("Pipeline state changed: %s -> %s", gst_element_state_get_name(old_state),
+                     gst_element_state_get_name(new_state));
+                if (new_state == GST_STATE_NULL) {
+                    g_mutex_lock(&ps->lock);
+                    ps->stop_requested = TRUE;
+                    g_mutex_unlock(&ps->lock);
+                    running = FALSE;
+                }
+            }
+            break;
+        }
+        default:
+            break;
+        }
+        gst_message_unref(msg);
+    }
+
+    if (ps->pipeline != NULL) {
+        gst_element_set_state(ps->pipeline, GST_STATE_NULL);
+    }
+    gst_object_unref(bus);
+
+    g_mutex_lock(&ps->lock);
+    ps->bus_thread_running = FALSE;
+    ps->state = PIPELINE_STOPPED;
+    g_cond_signal(&ps->cond);
+    g_mutex_unlock(&ps->lock);
+
+    return NULL;
+}
+
+static void cleanup_pipeline(PipelineState *ps) {
+    release_request_pad(ps->tee, &ps->video_pad);
+    release_request_pad(ps->tee, &ps->audio_pad);
+    ps->video_sink = NULL;
+    ps->tee = NULL;
+    ps->source = NULL;
+    if (ps->pipeline != NULL) {
+        gst_object_unref(ps->pipeline);
+        ps->pipeline = NULL;
+    }
+    g_mutex_lock(&ps->lock);
+    ps->bus_thread_running = FALSE;
+    ps->encountered_error = FALSE;
+    ps->stop_requested = FALSE;
+    g_mutex_unlock(&ps->lock);
 }
 
 int pipeline_start(const AppCfg *cfg, int audio_disabled, PipelineState *ps) {
-    if (ps->state != PIPELINE_STOPPED && ps->pid > 0) {
-        LOGW("pipeline_start: refused (state=%d pid=%d)", ps->state, ps->pid);
+    if (ps->state != PIPELINE_STOPPED) {
+        LOGW("pipeline_start: refused (state=%d)", ps->state);
         return -1;
     }
-    char cmd[2500];
-    build_gst_cmd(cfg, audio_disabled, cmd, sizeof(cmd));
-    LOGI("Starting pipeline: %s", cmd);
 
-    pid_t pid = fork();
-    if (pid < 0) {
-        LOGE("fork failed: %s", strerror(errno));
-        return -1;
+    ensure_gst_initialized(cfg);
+
+    if (!ps->initialized) {
+        g_mutex_init(&ps->lock);
+        g_cond_init(&ps->cond);
+        ps->initialized = TRUE;
     }
-    if (pid == 0) {
-        if (cfg->gst_log && getenv("GST_DEBUG") == NULL) {
-            setenv("GST_DEBUG", "3", 1);
-        }
-        prctl(PR_SET_PDEATHSIG, SIGHUP);
-        setpgid(0, 0);
-        execl("/bin/sh", "sh", "-c", cmd, (char *)NULL);
-        _exit(127);
+
+    GstElement *pipeline = gst_pipeline_new("pixelpilot-pipeline");
+    CHECK_ELEM(pipeline, "pipeline");
+    ps->pipeline = pipeline;
+    ps->source = NULL;
+    ps->tee = NULL;
+    ps->video_pad = NULL;
+    ps->audio_pad = NULL;
+
+    GstElement *source = create_udp_source(cfg);
+    if (source == NULL) {
+        goto fail;
     }
-    ps->pid = pid;
-    ps->pgid = pid;
+    GstElement *tee = gst_element_factory_make("tee", "stream_tee");
+    CHECK_ELEM(tee, "tee");
+
+    gst_bin_add_many(GST_BIN(pipeline), source, tee, NULL);
+    if (!gst_element_link(source, tee)) {
+        LOGE("Failed to link source to tee");
+        goto fail;
+    }
+
+    ps->source = source;
+    ps->tee = tee;
+
+    if (!build_video_branch(ps, pipeline, tee, cfg)) {
+        goto fail;
+    }
+
+    if (!build_audio_branch(ps, pipeline, tee, cfg, audio_disabled)) {
+        goto fail;
+    }
+
+    GstStateChangeReturn ret = gst_element_set_state(pipeline, GST_STATE_PLAYING);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        LOGE("Failed to set pipeline to PLAYING");
+        goto fail;
+    }
+
+    ps->bus_thread_running = TRUE;
+    ps->stop_requested = FALSE;
+    ps->encountered_error = FALSE;
+    ps->audio_disabled = audio_disabled ? 1 : 0;
+    ps->bus_thread = g_thread_new("gst-bus", bus_thread_func, ps);
+    if (ps->bus_thread == NULL) {
+        LOGE("Failed to start bus thread");
+        goto fail;
+    }
+
     ps->state = PIPELINE_RUNNING;
     return 0;
+
+fail:
+    if (ps->bus_thread != NULL) {
+        g_thread_join(ps->bus_thread);
+        ps->bus_thread = NULL;
+    }
+    if (pipeline != NULL) {
+        gst_element_set_state(pipeline, GST_STATE_NULL);
+    }
+    cleanup_pipeline(ps);
+    ps->state = PIPELINE_STOPPED;
+    return -1;
 }
 
 void pipeline_stop(PipelineState *ps, int wait_ms_total) {
-    if (ps->pid <= 0) {
-        ps->state = PIPELINE_STOPPED;
-        ps->pgid = 0;
+    if (ps->state == PIPELINE_STOPPED) {
         return;
     }
-    if (ps->state == PIPELINE_STOPPING) {
-        return;
-    }
+
+    g_mutex_lock(&ps->lock);
     ps->state = PIPELINE_STOPPING;
-    LOGI("Stopping pipeline pid=%d pgid=%d", ps->pid, ps->pgid);
-    if (ps->pgid > 0) {
-        killpg(ps->pgid, SIGINT);
-    } else {
-        kill(ps->pid, SIGINT);
+    ps->stop_requested = TRUE;
+    g_mutex_unlock(&ps->lock);
+
+    if (ps->pipeline != NULL) {
+        gst_element_send_event(ps->pipeline, gst_event_new_eos());
+        gst_element_set_state(ps->pipeline, GST_STATE_NULL);
     }
-    int waited = 0;
-    while (waited < wait_ms_total) {
-        int status;
-        pid_t r = waitpid(ps->pid, &status, WNOHANG);
-        if (r == ps->pid) {
-            ps->pid = 0;
-            ps->pgid = 0;
-            ps->state = PIPELINE_STOPPED;
-            return;
+
+    if (ps->bus_thread != NULL) {
+        if (wait_ms_total > 0) {
+            gint64 deadline = g_get_monotonic_time() + (gint64)wait_ms_total * G_TIME_SPAN_MILLISECOND;
+            g_mutex_lock(&ps->lock);
+            while (ps->bus_thread_running) {
+                if (!g_cond_wait_until(&ps->cond, &ps->lock, deadline)) {
+                    break;
+                }
+            }
+            gboolean still_running = ps->bus_thread_running;
+            g_mutex_unlock(&ps->lock);
+            if (still_running) {
+                LOGW("Pipeline bus thread did not exit in time; forcing join");
+            }
         }
-        usleep(50 * 1000);
-        waited += 50;
+        g_thread_join(ps->bus_thread);
+        ps->bus_thread = NULL;
     }
-    LOGW("Pipeline didn’t exit in time, SIGKILL group");
-    if (ps->pgid > 0) {
-        killpg(ps->pgid, SIGKILL);
-    } else {
-        kill(ps->pid, SIGKILL);
-    }
-    int status;
-    (void)waitpid(ps->pid, &status, 0);
-    ps->pid = 0;
-    ps->pgid = 0;
+
+    cleanup_pipeline(ps);
     ps->state = PIPELINE_STOPPED;
 }
 
 void pipeline_poll_child(PipelineState *ps) {
-    if (ps->pid <= 0) {
+    if (ps->bus_thread == NULL) {
         return;
     }
-    int status = 0;
-    pid_t r = waitpid(ps->pid, &status, WNOHANG);
-    if (r == ps->pid) {
-        LOGI("Pipeline exited (status=0x%x)", status);
-        ps->pid = 0;
-        ps->pgid = 0;
+
+    gboolean running;
+    gboolean had_error;
+    g_mutex_lock(&ps->lock);
+    running = ps->bus_thread_running;
+    had_error = ps->encountered_error;
+    g_mutex_unlock(&ps->lock);
+
+    if (!running) {
+        g_thread_join(ps->bus_thread);
+        ps->bus_thread = NULL;
+        cleanup_pipeline(ps);
         ps->state = PIPELINE_STOPPED;
+        if (had_error) {
+            LOGI("Pipeline exited due to error");
+        } else {
+            LOGI("Pipeline exited cleanly");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the shell-launched gst-launch command with an in-process GStreamer pipeline built through the C API, including dedicated bus monitoring and graceful shutdown
- expose the richer pipeline state and initialization helpers so future sources (e.g. appsrc-fed receivers) can plug in, while mirroring the original video/audio branches and fakesink fallback
- extend the build system to pull in the required GStreamer headers and libraries and update the main entry point to use the new pipeline state

## Testing
- `make` *(fails: missing libdrm headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97dc4f864832b87c8a5a7a08596d1