### PR TITLE
Add custom UDP RTP receiver feeding appsrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CC ?= gcc
 PKG_CONFIG ?= pkg-config
 PKG_DRMCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags libdrm libudev)
 PKG_DRMLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs libdrm libudev)
-PKG_GSTCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags gstreamer-1.0 gstreamer-video-1.0)
-PKG_GSTLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs gstreamer-1.0 gstreamer-video-1.0)
+PKG_GSTCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0)
+PKG_GSTLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0)
 
 CFLAGS ?= -O2 -Wall
 CFLAGS += -Iinclude
@@ -26,7 +26,7 @@ endif
 ifneq ($(strip $(PKG_GSTLIBS)),)
 LDFLAGS += $(PKG_GSTLIBS)
 else
-LDFLAGS += -lgstreamer-1.0 -lgstvideo-1.0 -lgobject-2.0 -lglib-2.0
+LDFLAGS += -lgstreamer-1.0 -lgstvideo-1.0 -lgstapp-1.0 -lgobject-2.0 -lglib-2.0
 endif
 
 SRC := $(wildcard src/*.c)

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -4,6 +4,8 @@
 #include <glib.h>
 #include <gst/gst.h>
 
+#include "udp_receiver.h"
+
 typedef enum {
     PIPELINE_STOPPED = 0,
     PIPELINE_RUNNING = 1,
@@ -18,6 +20,7 @@ typedef struct {
     GstElement *video_sink;
     GstPad *video_pad;
     GstPad *audio_pad;
+    UdpReceiver *udp_receiver;
     GThread *bus_thread;
     GMutex lock;
     GCond cond;
@@ -33,5 +36,6 @@ typedef struct {
 int pipeline_start(const AppCfg *cfg, int audio_disabled, PipelineState *ps);
 void pipeline_stop(PipelineState *ps, int wait_ms_total);
 void pipeline_poll_child(PipelineState *ps);
+int pipeline_get_receiver_stats(const PipelineState *ps, UdpReceiverStats *stats);
 
 #endif // PIPELINE_H

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -1,0 +1,70 @@
+#ifndef UDP_RECEIVER_H
+#define UDP_RECEIVER_H
+
+#include <glib.h>
+#include <gst/gst.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <gst/app/gstappsrc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define UDP_RECEIVER_HISTORY 512
+
+#define UDP_SAMPLE_FLAG_LOSS 0x01
+#define UDP_SAMPLE_FLAG_REORDER 0x02
+#define UDP_SAMPLE_FLAG_DUPLICATE 0x04
+#define UDP_SAMPLE_FLAG_FRAME_END 0x08
+
+typedef struct {
+    guint16 sequence;
+    guint32 timestamp;
+    guint8 payload_type;
+    guint8 marker;
+    guint8 flags;
+    guint32 size;
+    guint64 arrival_ns;
+} UdpReceiverPacketSample;
+
+typedef struct {
+    guint64 total_packets;
+    guint64 video_packets;
+    guint64 audio_packets;
+    guint64 ignored_packets;
+    guint64 duplicate_packets;
+    guint64 lost_packets;
+    guint64 reordered_packets;
+    guint64 total_bytes;
+    guint64 video_bytes;
+    guint64 audio_bytes;
+    guint64 frame_count;
+    guint64 incomplete_frames;
+    guint64 last_frame_bytes;
+    double frame_size_avg;
+    double jitter;
+    double jitter_avg;
+    double bitrate_mbps;
+    double bitrate_avg_mbps;
+    guint32 last_video_timestamp;
+    guint16 expected_sequence;
+    size_t history_count;
+    size_t history_head;
+    UdpReceiverPacketSample history[UDP_RECEIVER_HISTORY];
+} UdpReceiverStats;
+
+typedef struct UdpReceiver UdpReceiver;
+
+UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *appsrc);
+int udp_receiver_start(UdpReceiver *ur);
+void udp_receiver_stop(UdpReceiver *ur);
+void udp_receiver_destroy(UdpReceiver *ur);
+void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UDP_RECEIVER_H

--- a/src/osd.c
+++ b/src/osd.c
@@ -517,8 +517,8 @@ int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plan
     }
 
     o->scale = (ms->mode_w >= 1280) ? 2 : 1;
-    o->w = 480 * o->scale;
-    o->h = 120 * o->scale;
+    o->w = 800 * o->scale;
+    o->h = 160 * o->scale;
 
     if (create_argb_fb(fd, o->w, o->h, 0x80000000u, &o->fb) != 0) {
         LOGW("OSD: create fb failed. Disabling OSD.");

--- a/src/osd.c
+++ b/src/osd.c
@@ -559,6 +559,25 @@ void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const 
              restart_count, audio_disabled ? " audio=fakesink" : "");
     osd_draw_text(o, 10 * o->scale, 50 * o->scale, line3, 0xB0FFFFFFu, o->scale);
 
+    UdpReceiverStats stats;
+    if (pipeline_get_receiver_stats(ps, &stats) == 0) {
+        double jitter_ms = stats.jitter / 90.0;
+        double jitter_avg_ms = stats.jitter_avg / 90.0;
+        char line4[160];
+        snprintf(line4, sizeof(line4),
+                 "RTP vpkts=%llu loss=%llu reo=%llu dup=%llu jitter=%.2f/%.2fms br=%.2f/%.2fMbps",
+                 (unsigned long long)stats.video_packets, (unsigned long long)stats.lost_packets,
+                 (unsigned long long)stats.reordered_packets, (unsigned long long)stats.duplicate_packets, jitter_ms,
+                 jitter_avg_ms, stats.bitrate_mbps, stats.bitrate_avg_mbps);
+        osd_draw_text(o, 10 * o->scale, 70 * o->scale, line4, 0xB0FFFFFFu, o->scale);
+
+        char line5[160];
+        snprintf(line5, sizeof(line5), "Frames=%llu incomplete=%llu last=%lluB avg=%.0fB seq=%u",
+                 (unsigned long long)stats.frame_count, (unsigned long long)stats.incomplete_frames,
+                 (unsigned long long)stats.last_frame_bytes, stats.frame_size_avg, stats.expected_sequence);
+        osd_draw_text(o, 10 * o->scale, 90 * o->scale, line5, 0xB0FFFFFFu, o->scale);
+    }
+
     osd_commit_touch(fd, o->crtc_id, o);
 }
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -31,31 +31,9 @@ static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiv
     GstCaps *caps = NULL;
     CHECK_ELEM(appsrc_elem, "appsrc");
 
-    caps = gst_caps_new_empty();
+    caps = gst_caps_new_empty_simple("application/x-rtp");
     if (caps == NULL) {
         LOGE("Failed to allocate RTP caps for appsrc");
-        goto fail;
-    }
-
-    GstStructure *video_struct =
-        gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, "video", "clock-rate", G_TYPE_INT, 90000,
-                          "encoding-name", G_TYPE_STRING, "H265", "payload", G_TYPE_INT, cfg->vid_pt, NULL);
-    if (video_struct != NULL) {
-        gst_caps_append_structure(caps, video_struct);
-    }
-
-    if (!cfg->no_audio) {
-        GstStructure *audio_struct = gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, "audio",
-                                                       "clock-rate", G_TYPE_INT, 48000, "encoding-name",
-                                                       G_TYPE_STRING, "OPUS", "payload", G_TYPE_INT, cfg->aud_pt,
-                                                       NULL);
-        if (audio_struct != NULL) {
-            gst_caps_append_structure(caps, audio_struct);
-        }
-    }
-
-    if (gst_caps_is_empty(caps)) {
-        LOGE("Failed to build RTP caps for appsrc");
         goto fail;
     }
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -27,6 +27,7 @@ static void ensure_gst_initialized(const AppCfg *cfg) {
 
 static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiver_out) {
     GstElement *appsrc_elem = gst_element_factory_make("appsrc", "udp_appsrc");
+    UdpReceiver *receiver = NULL;
     CHECK_ELEM(appsrc_elem, "appsrc");
 
     GstCaps *caps = gst_caps_new_empty_simple("application/x-rtp");
@@ -46,7 +47,7 @@ static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiv
     gst_app_src_set_latency(appsrc, 0, 0);
     gst_app_src_set_max_bytes(appsrc, 4 * 1024 * 1024);
 
-    UdpReceiver *receiver = udp_receiver_create(cfg->udp_port, cfg->vid_pt, cfg->aud_pt, appsrc);
+    receiver = udp_receiver_create(cfg->udp_port, cfg->vid_pt, cfg->aud_pt, appsrc);
     if (receiver == NULL) {
         LOGE("Failed to create UDP receiver");
         goto fail;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -28,9 +28,10 @@ static void ensure_gst_initialized(const AppCfg *cfg) {
 static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiver_out) {
     GstElement *appsrc_elem = gst_element_factory_make("appsrc", "udp_appsrc");
     UdpReceiver *receiver = NULL;
+    GstCaps *caps = NULL;
     CHECK_ELEM(appsrc_elem, "appsrc");
 
-    GstCaps *caps = gst_caps_new_empty();
+    caps = gst_caps_new_empty();
     if (caps == NULL) {
         LOGE("Failed to allocate RTP caps for appsrc");
         goto fail;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -410,6 +410,20 @@ int udp_receiver_start(UdpReceiver *ur) {
         g_mutex_unlock(&ur->lock);
         return 0;
     }
+    ur->seq_initialized = FALSE;
+    ur->have_last_seq = FALSE;
+    ur->expected_seq = 0;
+    ur->last_seq = 0;
+    ur->frame_active = FALSE;
+    ur->frame_timestamp = 0;
+    ur->frame_bytes = 0;
+    ur->frame_missing = FALSE;
+    ur->transit_initialized = FALSE;
+    ur->last_transit = 0.0;
+    ur->bitrate_window_start_ns = 0;
+    ur->bitrate_window_bytes = 0;
+    memset(&ur->stats, 0, sizeof(ur->stats));
+    memset(ur->history, 0, sizeof(ur->history));
     g_mutex_unlock(&ur->lock);
 
     if (setup_socket(ur) != 0) {

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -1,0 +1,493 @@
+#include "udp_receiver.h"
+#include "logging.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <math.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef GST_USE_UNSTABLE_API
+#define GST_USE_UNSTABLE_API
+#endif
+
+#include <gst/app/gstappsrc.h>
+
+#define RTP_MIN_HEADER 12
+#define FRAME_EWMA_ALPHA 0.1
+#define JITTER_EWMA_ALPHA 0.1
+#define BITRATE_WINDOW_NS 100000000ULL // 100 ms
+#define BITRATE_EWMA_ALPHA 0.1
+
+typedef struct {
+    guint16 sequence;
+    guint32 timestamp;
+    guint8 payload_type;
+    guint8 marker;
+    guint8 has_padding;
+    guint8 has_extension;
+    guint8 csrc_count;
+    guint8 version;
+    guint payload_offset;
+    guint payload_size;
+} RtpParseResult;
+
+struct UdpReceiver {
+    GstAppSrc *appsrc;
+    GThread *thread;
+    GMutex lock;
+    gboolean running;
+    gboolean stop_requested;
+
+    int udp_port;
+    int vid_pt;
+    int aud_pt;
+    int sockfd;
+
+    gboolean seq_initialized;
+    guint16 expected_seq;
+    guint16 last_seq;
+    gboolean have_last_seq;
+    gboolean frame_active;
+    guint32 frame_timestamp;
+    guint64 frame_bytes;
+    gboolean frame_missing;
+
+    gboolean transit_initialized;
+    double last_transit;
+
+    guint64 bitrate_window_start_ns;
+    guint64 bitrate_window_bytes;
+
+    UdpReceiverStats stats;
+
+    UdpReceiverPacketSample history[UDP_RECEIVER_HISTORY];
+};
+
+static gboolean parse_rtp(const guint8 *data, gsize len, RtpParseResult *out) {
+    if (len < RTP_MIN_HEADER) {
+        return FALSE;
+    }
+
+    guint8 vpxcc = data[0];
+    guint8 mpayload = data[1];
+    guint8 version = vpxcc >> 6;
+    if (version != 2) {
+        return FALSE;
+    }
+
+    guint8 csrc_count = vpxcc & 0x0F;
+    gboolean padding = (vpxcc & 0x20u) != 0;
+    gboolean extension = (vpxcc & 0x10u) != 0;
+    gboolean marker = (mpayload & 0x80u) != 0;
+    guint8 payload_type = mpayload & 0x7Fu;
+
+    guint payload_offset = RTP_MIN_HEADER + csrc_count * 4u;
+    if (len < payload_offset) {
+        return FALSE;
+    }
+
+    if (extension) {
+        if (len < payload_offset + 4u) {
+            return FALSE;
+        }
+        guint16 ext_len = ((guint16)data[payload_offset + 2] << 8) | data[payload_offset + 3];
+        guint32 ext_bytes = 4u + ((guint32)ext_len * 4u);
+        if (len < payload_offset + ext_bytes) {
+            return FALSE;
+        }
+        payload_offset += ext_bytes;
+    }
+
+    guint payload_size = len > payload_offset ? (guint)(len - payload_offset) : 0u;
+    if (padding) {
+        guint8 pad = data[len - 1];
+        if (pad <= payload_size) {
+            payload_size -= pad;
+        } else {
+            payload_size = 0;
+        }
+    }
+
+    out->sequence = ((guint16)data[2] << 8) | data[3];
+    out->timestamp = ((guint32)data[4] << 24) | ((guint32)data[5] << 16) | ((guint32)data[6] << 8) | data[7];
+    out->payload_type = payload_type;
+    out->marker = marker ? 1 : 0;
+    out->has_padding = padding ? 1 : 0;
+    out->has_extension = extension ? 1 : 0;
+    out->csrc_count = csrc_count;
+    out->version = version;
+    out->payload_offset = payload_offset;
+    out->payload_size = payload_size;
+    return TRUE;
+}
+
+static inline guint16 seq_next(guint16 seq) {
+    return (guint16)(seq + 1u);
+}
+
+static inline gint16 seq_delta(guint16 a, guint16 b) {
+    return (gint16)(a - b);
+}
+
+static inline guint64 get_time_ns(void) {
+    return (guint64)g_get_monotonic_time() * 1000ull;
+}
+
+static void history_push(struct UdpReceiver *ur, const UdpReceiverPacketSample *sample) {
+    ur->history[ur->stats.history_head] = *sample;
+    ur->stats.history_head = (ur->stats.history_head + 1u) % UDP_RECEIVER_HISTORY;
+    if (ur->stats.history_count < UDP_RECEIVER_HISTORY) {
+        ur->stats.history_count++;
+    }
+}
+
+static void update_bitrate(struct UdpReceiver *ur, guint64 arrival_ns, guint32 bytes) {
+    if (ur->bitrate_window_start_ns == 0) {
+        ur->bitrate_window_start_ns = arrival_ns;
+    }
+    ur->bitrate_window_bytes += bytes;
+    guint64 elapsed_ns = arrival_ns - ur->bitrate_window_start_ns;
+    if (elapsed_ns >= BITRATE_WINDOW_NS && elapsed_ns > 0) {
+        double instant_mbps = ((double)ur->bitrate_window_bytes * 8.0) / ((double)elapsed_ns / 1e9) / 1e6;
+        ur->stats.bitrate_mbps = instant_mbps;
+        if (ur->stats.bitrate_avg_mbps == 0.0) {
+            ur->stats.bitrate_avg_mbps = instant_mbps;
+        } else {
+            ur->stats.bitrate_avg_mbps += (instant_mbps - ur->stats.bitrate_avg_mbps) * BITRATE_EWMA_ALPHA;
+        }
+        ur->bitrate_window_start_ns = arrival_ns;
+        ur->bitrate_window_bytes = 0;
+    }
+}
+
+static void finalize_frame(struct UdpReceiver *ur) {
+    if (!ur->frame_active) {
+        return;
+    }
+    ur->stats.frame_count++;
+    ur->stats.last_frame_bytes = ur->frame_bytes;
+    if (ur->stats.frame_size_avg == 0.0) {
+        ur->stats.frame_size_avg = (double)ur->frame_bytes;
+    } else {
+        ur->stats.frame_size_avg += ((double)ur->frame_bytes - ur->stats.frame_size_avg) * FRAME_EWMA_ALPHA;
+    }
+    if (ur->frame_missing) {
+        ur->stats.incomplete_frames++;
+    }
+    ur->frame_active = FALSE;
+    ur->frame_bytes = 0;
+    ur->frame_missing = FALSE;
+}
+
+static void process_rtp(struct UdpReceiver *ur, const guint8 *data, gsize len, guint64 arrival_ns) {
+    RtpParseResult rtp;
+    if (!parse_rtp(data, len, &rtp)) {
+        return;
+    }
+
+    gboolean is_video = (rtp.payload_type == ur->vid_pt);
+    gboolean is_audio = (rtp.payload_type == ur->aud_pt);
+
+    UdpReceiverPacketSample sample = {0};
+    sample.sequence = rtp.sequence;
+    sample.timestamp = rtp.timestamp;
+    sample.payload_type = rtp.payload_type;
+    sample.marker = rtp.marker;
+    sample.size = (guint32)len;
+    sample.arrival_ns = arrival_ns;
+
+    ur->stats.total_packets++;
+    ur->stats.total_bytes += len;
+
+    if (is_video) {
+        ur->stats.video_packets++;
+        ur->stats.video_bytes += len;
+        ur->stats.last_video_timestamp = rtp.timestamp;
+
+        if (!ur->frame_active || ur->frame_timestamp != rtp.timestamp) {
+            if (ur->frame_active) {
+                finalize_frame(ur);
+            }
+            ur->frame_active = TRUE;
+            ur->frame_timestamp = rtp.timestamp;
+            ur->frame_bytes = len;
+            ur->frame_missing = FALSE;
+        } else {
+            ur->frame_bytes += len;
+        }
+
+        if (!ur->seq_initialized) {
+            ur->seq_initialized = TRUE;
+            ur->expected_seq = seq_next(rtp.sequence);
+            ur->stats.expected_sequence = ur->expected_seq;
+        } else {
+            gint16 delta = seq_delta(rtp.sequence, ur->expected_seq);
+            if (delta == 0) {
+                ur->expected_seq = seq_next(rtp.sequence);
+            } else if (delta > 0) {
+                ur->stats.lost_packets += delta;
+                ur->expected_seq = seq_next(rtp.sequence);
+                ur->frame_missing = TRUE;
+                sample.flags |= UDP_SAMPLE_FLAG_LOSS;
+            } else { // delta < 0
+                ur->stats.reordered_packets++;
+                sample.flags |= UDP_SAMPLE_FLAG_REORDER;
+            }
+            ur->stats.expected_sequence = ur->expected_seq;
+        }
+
+        if (ur->have_last_seq && rtp.sequence == ur->last_seq) {
+            ur->stats.duplicate_packets++;
+            sample.flags |= UDP_SAMPLE_FLAG_DUPLICATE;
+        }
+        ur->last_seq = rtp.sequence;
+        ur->have_last_seq = TRUE;
+
+        double arrival_rtp = (double)arrival_ns / 1e9 * 90000.0;
+        double transit = arrival_rtp - (double)rtp.timestamp;
+        if (!ur->transit_initialized) {
+            ur->transit_initialized = TRUE;
+            ur->last_transit = transit;
+            ur->stats.jitter = 0.0;
+            ur->stats.jitter_avg = 0.0;
+        } else {
+            double d = transit - ur->last_transit;
+            ur->last_transit = transit;
+            ur->stats.jitter += (fabs(d) - ur->stats.jitter) / 16.0;
+            if (ur->stats.jitter_avg == 0.0) {
+                ur->stats.jitter_avg = ur->stats.jitter;
+            } else {
+                ur->stats.jitter_avg += (ur->stats.jitter - ur->stats.jitter_avg) * JITTER_EWMA_ALPHA;
+            }
+        }
+    } else if (is_audio) {
+        ur->stats.audio_packets++;
+        ur->stats.audio_bytes += len;
+    } else {
+        ur->stats.ignored_packets++;
+    }
+
+    if (rtp.marker && is_video) {
+        sample.flags |= UDP_SAMPLE_FLAG_FRAME_END;
+        finalize_frame(ur);
+    }
+
+    update_bitrate(ur, arrival_ns, (guint32)len);
+    history_push(ur, &sample);
+}
+
+static gpointer receiver_thread(gpointer data) {
+    struct UdpReceiver *ur = (struct UdpReceiver *)data;
+    const size_t max_pkt = 4096;
+    guint8 *buffer = g_malloc(max_pkt);
+    if (buffer == NULL) {
+        LOGE("UDP receiver: allocation failed");
+        return NULL;
+    }
+
+    while (TRUE) {
+        g_mutex_lock(&ur->lock);
+        gboolean stop = ur->stop_requested;
+        g_mutex_unlock(&ur->lock);
+        if (stop) {
+            break;
+        }
+
+        struct sockaddr_in src;
+        socklen_t slen = sizeof(src);
+        ssize_t n = recvfrom(ur->sockfd, buffer, max_pkt, 0, (struct sockaddr *)&src, &slen);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                g_usleep(1000);
+                continue;
+            }
+            if (!ur->stop_requested) {
+                LOGE("UDP receiver: recvfrom failed: %s", g_strerror(errno));
+            }
+            break;
+        }
+
+        guint64 arrival_ns = get_time_ns();
+        g_mutex_lock(&ur->lock);
+        process_rtp(ur, buffer, (gsize)n, arrival_ns);
+        g_mutex_unlock(&ur->lock);
+
+        GstBuffer *gstbuf = gst_buffer_new_allocate(NULL, (gsize)n, NULL);
+        if (gstbuf == NULL) {
+            continue;
+        }
+        gst_buffer_fill(gstbuf, 0, buffer, (gsize)n);
+        GstFlowReturn flow = gst_app_src_push_buffer(ur->appsrc, gstbuf);
+        if (flow != GST_FLOW_OK) {
+            LOGV("UDP receiver: push_buffer returned %s", gst_flow_get_name(flow));
+            gst_buffer_unref(gstbuf);
+            if (flow == GST_FLOW_FLUSHING) {
+                g_usleep(1000);
+            }
+        }
+    }
+
+    g_mutex_lock(&ur->lock);
+    ur->running = FALSE;
+    ur->stop_requested = FALSE;
+    g_mutex_unlock(&ur->lock);
+
+    g_free(buffer);
+    return NULL;
+}
+
+UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *appsrc) {
+    if (appsrc == NULL) {
+        return NULL;
+    }
+    struct UdpReceiver *ur = g_new0(struct UdpReceiver, 1);
+    if (ur == NULL) {
+        return NULL;
+    }
+    ur->udp_port = udp_port;
+    ur->vid_pt = vid_pt;
+    ur->aud_pt = aud_pt;
+    ur->sockfd = -1;
+    g_mutex_init(&ur->lock);
+    ur->appsrc = GST_APP_SRC(gst_object_ref(appsrc));
+    return ur;
+}
+
+static int setup_socket(struct UdpReceiver *ur) {
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        LOGE("UDP receiver: socket(): %s", g_strerror(errno));
+        return -1;
+    }
+
+    int reuse = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+        LOGW("UDP receiver: setsockopt(SO_REUSEADDR) failed: %s", g_strerror(errno));
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)ur->udp_port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        LOGE("UDP receiver: bind(%d): %s", ur->udp_port, g_strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 500000; // 500 ms timeout to allow graceful shutdown
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+        LOGW("UDP receiver: setsockopt(SO_RCVTIMEO) failed: %s", g_strerror(errno));
+    }
+
+    int buf_kb = 4 * 1024;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buf_kb, sizeof(buf_kb)) < 0) {
+        LOGW("UDP receiver: setsockopt(SO_RCVBUF) failed: %s", g_strerror(errno));
+    }
+
+    ur->sockfd = fd;
+    return 0;
+}
+
+int udp_receiver_start(UdpReceiver *ur) {
+    if (ur == NULL) {
+        return -1;
+    }
+    g_mutex_lock(&ur->lock);
+    if (ur->running) {
+        g_mutex_unlock(&ur->lock);
+        return 0;
+    }
+    g_mutex_unlock(&ur->lock);
+
+    if (setup_socket(ur) != 0) {
+        return -1;
+    }
+
+    g_mutex_lock(&ur->lock);
+    ur->stop_requested = FALSE;
+    ur->running = TRUE;
+    g_mutex_unlock(&ur->lock);
+
+    ur->thread = g_thread_new("udp-receiver", receiver_thread, ur);
+    if (ur->thread == NULL) {
+        LOGE("UDP receiver: failed to create thread");
+        g_mutex_lock(&ur->lock);
+        ur->running = FALSE;
+        g_mutex_unlock(&ur->lock);
+        close(ur->sockfd);
+        ur->sockfd = -1;
+        return -1;
+    }
+    return 0;
+}
+
+void udp_receiver_stop(UdpReceiver *ur) {
+    if (ur == NULL) {
+        return;
+    }
+    g_mutex_lock(&ur->lock);
+    if (!ur->running) {
+        g_mutex_unlock(&ur->lock);
+        return;
+    }
+    ur->stop_requested = TRUE;
+    g_mutex_unlock(&ur->lock);
+
+    if (ur->sockfd >= 0) {
+        shutdown(ur->sockfd, SHUT_RDWR);
+    }
+
+    if (ur->thread != NULL) {
+        g_thread_join(ur->thread);
+        ur->thread = NULL;
+    }
+
+    if (ur->sockfd >= 0) {
+        close(ur->sockfd);
+        ur->sockfd = -1;
+    }
+
+    gst_app_src_end_of_stream(ur->appsrc);
+
+    g_mutex_lock(&ur->lock);
+    ur->running = FALSE;
+    ur->stop_requested = FALSE;
+    g_mutex_unlock(&ur->lock);
+}
+
+void udp_receiver_destroy(UdpReceiver *ur) {
+    if (ur == NULL) {
+        return;
+    }
+    udp_receiver_stop(ur);
+    if (ur->appsrc != NULL) {
+        gst_object_unref(ur->appsrc);
+        ur->appsrc = NULL;
+    }
+    g_mutex_clear(&ur->lock);
+    g_free(ur);
+}
+
+void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats) {
+    if (ur == NULL || stats == NULL) {
+        return;
+    }
+    g_mutex_lock(&ur->lock);
+    *stats = ur->stats;
+    memcpy(stats->history, ur->history, sizeof(ur->history));
+    g_mutex_unlock(&ur->lock);
+}

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -393,8 +393,8 @@ static int setup_socket(struct UdpReceiver *ur) {
         LOGW("UDP receiver: setsockopt(SO_RCVTIMEO) failed: %s", g_strerror(errno));
     }
 
-    int buf_kb = 4 * 1024;
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buf_kb, sizeof(buf_kb)) < 0) {
+    int buf_bytes = 4 * 1024 * 1024;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buf_bytes, sizeof(buf_bytes)) < 0) {
         LOGW("UDP receiver: setsockopt(SO_RCVBUF) failed: %s", g_strerror(errno));
     }
 

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -330,7 +330,6 @@ static gpointer receiver_thread(gpointer data) {
         GstFlowReturn flow = gst_app_src_push_buffer(ur->appsrc, gstbuf);
         if (flow != GST_FLOW_OK) {
             LOGV("UDP receiver: push_buffer returned %s", gst_flow_get_name(flow));
-            gst_buffer_unref(gstbuf);
             if (flow == GST_FLOW_FLUSHING) {
                 g_usleep(1000);
             }


### PR DESCRIPTION
## Summary
- implement a custom UDP RTP receiver that feeds an appsrc, tracks packet/frame stats, and computes jitter/bitrate metrics
- switch the pipeline ingress from udpsrc to the new receiver, expose statistics, and surface them through the OSD overlay
- update build flags to pull in gstreamer-app and provide access to recent RTP samples for future consumers

## Testing
- make *(fails: missing libdrm headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d982185fa4832b829d2058f8bce9d8