### PR TITLE
Add bitrate plot overlay to the OSD

### DIFF
--- a/include/osd.h
+++ b/include/osd.h
@@ -22,6 +22,13 @@ typedef enum {
 
 #define OSD_PLOT_MAX_SAMPLES 1024
 
+typedef struct {
+    int x;
+    int y;
+    int w;
+    int h;
+} OSDRect;
+
 typedef struct OSD {
     int enabled;
     int active;
@@ -64,6 +71,8 @@ typedef struct OSD {
     int plot_x;
     int plot_y;
     OSDWidgetPosition plot_position;
+    OSDRect plot_rect;
+    OSDRect text_rect;
 } OSD;
 
 void osd_init(OSD *osd);

--- a/include/osd.h
+++ b/include/osd.h
@@ -8,6 +8,20 @@
 #include "drm_modeset.h"
 #include "pipeline.h"
 
+typedef enum {
+    OSD_POS_TOP_LEFT = 0,
+    OSD_POS_TOP_MID,
+    OSD_POS_TOP_RIGHT,
+    OSD_POS_MID_LEFT,
+    OSD_POS_MID_MID,
+    OSD_POS_MID_RIGHT,
+    OSD_POS_BOTTOM_LEFT,
+    OSD_POS_BOTTOM_MID,
+    OSD_POS_BOTTOM_RIGHT,
+} OSDWidgetPosition;
+
+#define OSD_PLOT_MAX_SAMPLES 1024
+
 typedef struct OSD {
     int enabled;
     int active;
@@ -30,6 +44,26 @@ typedef struct OSD {
     uint64_t alpha_min, alpha_max;
     uint32_t p_blend;
     int have_blend;
+
+    /* Layout helpers */
+    int margin_px;
+
+    /* Bitrate plot state */
+    int plot_window_seconds;
+    int plot_capacity;
+    int plot_size;
+    int plot_cursor;
+    double plot_sum;
+    double plot_latest;
+    double plot_min;
+    double plot_max;
+    double plot_avg;
+    double plot_samples[OSD_PLOT_MAX_SAMPLES];
+    int plot_w;
+    int plot_h;
+    int plot_x;
+    int plot_y;
+    OSDWidgetPosition plot_position;
 } OSD;
 
 void osd_init(OSD *osd);

--- a/include/osd.h
+++ b/include/osd.h
@@ -72,7 +72,10 @@ typedef struct OSD {
     int plot_y;
     OSDWidgetPosition plot_position;
     OSDRect plot_rect;
+    OSDRect plot_label_rect;
+    OSDRect plot_stats_rect;
     OSDRect text_rect;
+    int plot_clear_on_next_draw;
 } OSD;
 
 void osd_init(OSD *osd);

--- a/include/osd.h
+++ b/include/osd.h
@@ -65,6 +65,9 @@ typedef struct OSD {
     double plot_min;
     double plot_max;
     double plot_avg;
+    double plot_scale_min;
+    double plot_scale_max;
+    double plot_step_px;
     double plot_samples[OSD_PLOT_MAX_SAMPLES];
     int plot_w;
     int plot_h;
@@ -76,6 +79,11 @@ typedef struct OSD {
     OSDRect plot_stats_rect;
     OSDRect text_rect;
     int plot_clear_on_next_draw;
+    int plot_background_ready;
+    int plot_prev_valid;
+    int plot_prev_x;
+    int plot_prev_y;
+    int plot_rescale_countdown;
 } OSD;
 
 void osd_init(OSD *osd);


### PR DESCRIPTION
## Summary
- extend the OSD data structures to track a 60-second bitrate history and layout metadata
- add drawing helpers plus a reusable plotting routine with axes, gridlines, and statistics text
- resize the overlay and render the UDP bitrate plot in the lower-left corner alongside existing status text

## Testing
- make *(fails: libdrm/drm.h missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d998e7913c832b9ee6b83332024c2d