### PR TITLE
Add CPU affinity configuration and thread pinning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ else
 LDFLAGS += -lgstreamer-1.0 -lgstvideo-1.0 -lgstapp-1.0 -lgobject-2.0 -lglib-2.0
 endif
 
+LDFLAGS += -lpthread
+
 SRC := $(wildcard src/*.c)
 OBJ := $(SRC:.c=.o)
 TARGET := pixelpilot_mini_rk

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# PixelPilot Mini RK
+
+PixelPilot Mini RK is a lightweight receiver that ingests RTP video/audio over UDP and drives a KMS plane on Rockchip-based devices. The application wraps a GStreamer pipeline with DRM/KMS, OSD, and udev helpers.
+
+## CPU affinity control
+
+Use `--cpu-list` to provide a comma-separated list of CPU IDs that the process and its busy worker threads should run on. The main process mask is restricted to the specified CPUs and the UDP receiver and GStreamer bus threads are pinned in a round-robin fashion to spread the work across cores.
+
+Example:
+
+```sh
+./pixelpilot_mini_rk --udp-port 5600 --cpu-list 2,3
+```
+
+This constrains the process to CPUs 2 and 3 while placing the UDP receiver thread on CPU 2 and the GStreamer bus thread on CPU 3.

--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <sched.h>
+
 typedef struct {
     char card_path[64];
     char connector_name[32];
@@ -27,9 +29,17 @@ typedef struct {
     int osd_refresh_ms;
 
     int gst_log;
+
+    int cpu_affinity_present;
+    cpu_set_t cpu_affinity_mask;
+    int cpu_affinity_order[CPU_SETSIZE];
+    int cpu_affinity_count;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);
 void cfg_defaults(AppCfg *cfg);
+int cfg_has_cpu_affinity(const AppCfg *cfg);
+void cfg_get_process_affinity(const AppCfg *cfg, cpu_set_t *set_out);
+int cfg_get_thread_affinity(const AppCfg *cfg, int slot, cpu_set_t *set_out);
 
 #endif // CONFIG_H

--- a/include/config.h
+++ b/include/config.h
@@ -2,6 +2,11 @@
 #define CONFIG_H
 
 #include <sched.h>
+#include <limits.h>
+
+#ifndef CPU_SETSIZE
+#define CPU_SETSIZE ((int)(sizeof(cpu_set_t) * CHAR_BIT))
+#endif
 
 typedef struct {
     char card_path[64];

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -29,6 +29,8 @@ typedef struct {
     gboolean stop_requested;
     gboolean encountered_error;
     int audio_disabled;
+    const AppCfg *cfg;
+    int bus_thread_cpu_slot;
 } PipelineState;
 
 #include "config.h"

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -8,6 +8,8 @@
 
 #include <gst/app/gstappsrc.h>
 
+#include "config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,7 +60,7 @@ typedef struct {
 typedef struct UdpReceiver UdpReceiver;
 
 UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *appsrc);
-int udp_receiver_start(UdpReceiver *ur);
+int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);
 void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats);

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdio.h>
@@ -34,6 +35,14 @@ int main(int argc, char **argv) {
     AppCfg cfg;
     if (parse_cli(argc, argv, &cfg) != 0) {
         return 2;
+    }
+
+    if (cfg_has_cpu_affinity(&cfg)) {
+        cpu_set_t mask;
+        cfg_get_process_affinity(&cfg, &mask);
+        if (sched_setaffinity(0, sizeof(mask), &mask) != 0) {
+            LOGW("sched_setaffinity failed: %s", strerror(errno));
+        }
     }
 
     signal(SIGINT, on_sigint);


### PR DESCRIPTION
## Summary
- add a --cpu-list CLI option that records CPU affinity preferences and exposes helper APIs
- narrow the process mask and pin the UDP receiver and GStreamer bus threads when an affinity list is provided
- document the new option and provide an example command in the README

## Testing
- make *(fails: missing libdrm/drm.h on the build image)*

------
https://chatgpt.com/codex/tasks/task_e_68da9f306cdc832ba08b4dc5fbe9a551