### PR TITLE
Add pipeline hooks for conditional UDP stats

### DIFF
--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -39,5 +39,6 @@ int pipeline_start(const AppCfg *cfg, int audio_disabled, PipelineState *ps);
 void pipeline_stop(PipelineState *ps, int wait_ms_total);
 void pipeline_poll_child(PipelineState *ps);
 int pipeline_get_receiver_stats(const PipelineState *ps, UdpReceiverStats *stats);
+void pipeline_set_receiver_stats_enabled(PipelineState *ps, gboolean enabled);
 
 #endif // PIPELINE_H

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -64,6 +64,7 @@ int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);
 void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats);
+void udp_receiver_set_stats_enabled(UdpReceiver *ur, gboolean enabled);
 
 #ifdef __cplusplus
 }

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -587,6 +587,19 @@ void pipeline_poll_child(PipelineState *ps) {
     }
 }
 
+void pipeline_set_receiver_stats_enabled(PipelineState *ps, gboolean enabled) {
+    if (ps == NULL) {
+        return;
+    }
+
+    g_mutex_lock(&ps->lock);
+    UdpReceiver *receiver = ps->udp_receiver;
+    if (receiver != NULL) {
+        udp_receiver_set_stats_enabled(receiver, enabled);
+    }
+    g_mutex_unlock(&ps->lock);
+}
+
 int pipeline_get_receiver_stats(const PipelineState *ps, UdpReceiverStats *stats) {
     if (ps == NULL || stats == NULL) {
         return -1;


### PR DESCRIPTION
## Summary
- add a runtime flag to the UDP receiver to gate stats collection and reset counters when re-enabled
- expose a pipeline helper that toggles the receiver statistics under the pipeline lock
- wire the main loop to enable stats when the OSD plane is active and disable them before it is torn down

## Testing
- make *(fails: missing libdrm/drm.h in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa4058400832ba8c92904ff1ae843