### PR TITLE
Add CLI controls for video buffering behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,21 @@ Example:
 ```
 
 This constrains the process to CPUs 2 and 3 while placing the UDP receiver thread on CPU 2 and the GStreamer bus thread on CPU 3.
+
+## Video buffering controls
+
+When debugging decoder underruns or validating new transmitters it can be useful to temporarily increase buffering or disable
+latency-based drops in the video path. The following options expose the queue sizing and jitter buffer policy that are normally
+hard-coded for low-latency flight use:
+
+* `--video-queue-leaky MODE` sets the `leaky` mode on the pre-, post-, and sink-side video queues. The default `2` (downstream)
+  favors minimal latency by discarding the oldest buffers when the downstream stage stalls. Set `0` to disable dropping so the
+  pipeline accumulates backlog for analysis.
+* `--video-queue-pre-buffers N`, `--video-queue-post-buffers N`, and `--video-queue-sink-buffers N` adjust the queue depths for
+  each stage (defaults: 96/8/8). Raising these values increases tolerance for jitter at the cost of additional latency and
+  memory use.
+* `--video-drop-on-latency` / `--no-video-drop-on-latency` toggles the RTP jitter buffer's `drop-on-latency` behaviour. Disabling
+  the drops is useful when chasing decoder warnings so every frame is delivered, even if late.
+
+Keep the defaults for normal flying where latency is paramount. Switch to non-leaky queues and higher buffer counts only for
+short-term debugging sessions, as doing so can quickly introduce additional end-to-end delay.

--- a/include/config.h
+++ b/include/config.h
@@ -22,6 +22,11 @@ typedef struct {
     int kmssink_sync;
     int kmssink_qos;
     int max_lateness_ns;
+    int video_queue_leaky;
+    int video_queue_pre_buffers;
+    int video_queue_post_buffers;
+    int video_queue_sink_buffers;
+    int video_drop_on_latency;
     char aud_dev[128];
 
     int no_audio;

--- a/src/config.c
+++ b/src/config.c
@@ -21,6 +21,12 @@ static void usage(const char *prog) {
             "  --vid-pt N                   (default: 97 H265)\n"
             "  --aud-pt N                   (default: 98 Opus)\n"
             "  --latency-ms N               (default: 8)\n"
+            "  --video-queue-leaky MODE     (0=none,1=upstream,2=downstream; default: 2)\n"
+            "  --video-queue-pre-buffers N  (default: 96)\n"
+            "  --video-queue-post-buffers N (default: 8)\n"
+            "  --video-queue-sink-buffers N (default: 8)\n"
+            "  --video-drop-on-latency      (enable jitter drops; default)\n"
+            "  --no-video-drop-on-latency   (disable jitter drops)\n"
             "  --max-lateness NANOSECS      (default: 20000000)\n"
             "  --aud-dev STR                (default: plughw:CARD=rockchiphdmi0,DEV=0)\n"
             "  --no-audio                   (drop audio branch entirely)\n"
@@ -49,6 +55,11 @@ void cfg_defaults(AppCfg *c) {
     c->kmssink_sync = 0;
     c->kmssink_qos = 1;
     c->max_lateness_ns = 20000000;
+    c->video_queue_leaky = 2;
+    c->video_queue_pre_buffers = 96;
+    c->video_queue_post_buffers = 8;
+    c->video_queue_sink_buffers = 8;
+    c->video_drop_on_latency = 1;
     strcpy(c->aud_dev, "plughw:CARD=rockchiphdmi0,DEV=0");
 
     c->no_audio = 0;
@@ -152,6 +163,18 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->aud_pt = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--latency-ms") && i + 1 < argc) {
             cfg->latency_ms = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--video-queue-leaky") && i + 1 < argc) {
+            cfg->video_queue_leaky = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--video-queue-pre-buffers") && i + 1 < argc) {
+            cfg->video_queue_pre_buffers = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--video-queue-post-buffers") && i + 1 < argc) {
+            cfg->video_queue_post_buffers = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--video-queue-sink-buffers") && i + 1 < argc) {
+            cfg->video_queue_sink_buffers = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--video-drop-on-latency")) {
+            cfg->video_drop_on_latency = 1;
+        } else if (!strcmp(argv[i], "--no-video-drop-on-latency")) {
+            cfg->video_drop_on_latency = 0;
         } else if (!strcmp(argv[i], "--max-lateness") && i + 1 < argc) {
             cfg->max_lateness_ns = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--aud-dev") && i + 1 < argc) {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -171,15 +171,15 @@ static gboolean build_video_branch(PipelineState *ps, GstElement *pipeline, GstE
     CHECK_ELEM(queue_sink, "queue");
     CHECK_ELEM(sink, "kmssink");
 
-    g_object_set(queue_pre, "leaky", 2, "max-size-buffers", 96, "max-size-time", (guint64)0, "max-size-bytes",
-                 (guint64)0, NULL);
-    g_object_set(queue_post, "leaky", 2, "max-size-buffers", 8, "max-size-time", (guint64)0, "max-size-bytes",
-                 (guint64)0, NULL);
-    g_object_set(queue_sink, "leaky", 2, "max-size-buffers", 8, "max-size-time", (guint64)0, "max-size-bytes",
-                 (guint64)0, NULL);
+    g_object_set(queue_pre, "leaky", cfg->video_queue_leaky, "max-size-buffers", cfg->video_queue_pre_buffers,
+                 "max-size-time", (guint64)0, "max-size-bytes", (guint64)0, NULL);
+    g_object_set(queue_post, "leaky", cfg->video_queue_leaky, "max-size-buffers", cfg->video_queue_post_buffers,
+                 "max-size-time", (guint64)0, "max-size-bytes", (guint64)0, NULL);
+    g_object_set(queue_sink, "leaky", cfg->video_queue_leaky, "max-size-buffers", cfg->video_queue_sink_buffers,
+                 "max-size-time", (guint64)0, "max-size-bytes", (guint64)0, NULL);
 
     GstCaps *caps_rtp_cfg = make_rtp_caps(cfg->vid_pt, 90000, "H265");
-    g_object_set(jitter, "latency", cfg->latency_ms, "drop-on-latency", TRUE, "do-lost", TRUE,
+    g_object_set(jitter, "latency", cfg->latency_ms, "drop-on-latency", cfg->video_drop_on_latency ? TRUE : FALSE, "do-lost", TRUE,
                  "post-drop-messages", TRUE, NULL);
     g_object_set(parser, "config-interval", -1, "disable-passthrough", TRUE, NULL);
 


### PR DESCRIPTION
## Summary
- add configuration fields and CLI parsing to expose video queue sizing, leaky mode, and jitter drop settings
- apply the new configuration when building the video branch and document the operator guidance in the README

## Testing
- make *(fails: missing libdrm/drm.h in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68dab028b750832bb9b9a8f28e35860d