### PR TITLE
Capture jitterbuffer drop counters in receiver stats

### DIFF
--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -50,6 +50,12 @@ typedef struct {
     double jitter_avg;
     double bitrate_mbps;
     double bitrate_avg_mbps;
+    guint64 pipeline_dropped_total;
+    guint64 pipeline_dropped_too_late;
+    guint64 pipeline_dropped_on_latency;
+    guint32 pipeline_last_drop_seqnum;
+    guint64 pipeline_last_drop_timestamp;
+    char pipeline_last_drop_reason[32];
     guint32 last_video_timestamp;
     guint16 expected_sequence;
     size_t history_count;
@@ -65,6 +71,8 @@ void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);
 void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats);
 void udp_receiver_set_stats_enabled(UdpReceiver *ur, gboolean enabled);
+void udp_receiver_record_pipeline_drop(UdpReceiver *ur, guint32 seqnum, guint64 timestamp,
+                                       const char *reason, guint num_too_late, guint num_drop_on_latency);
 
 #ifdef __cplusplus
 }

--- a/src/osd.c
+++ b/src/osd.c
@@ -1219,10 +1219,22 @@ void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const 
         double jitter_ms = stats.jitter / 90.0;
         double jitter_avg_ms = stats.jitter_avg / 90.0;
         snprintf(text_lines[line_count], sizeof(text_lines[line_count]),
-                 "RTP vpkts=%llu loss=%llu reo=%llu dup=%llu jitter=%.2f/%.2fms br=%.2f/%.2fMbps",
+                 "RTP vpkts=%llu net-loss=%llu reo=%llu dup=%llu jitter=%.2f/%.2fms br=%.2f/%.2fMbps",
                  (unsigned long long)stats.video_packets, (unsigned long long)stats.lost_packets,
                  (unsigned long long)stats.reordered_packets, (unsigned long long)stats.duplicate_packets, jitter_ms,
                  jitter_avg_ms, stats.bitrate_mbps, stats.bitrate_avg_mbps);
+        line_ptrs[line_count] = text_lines[line_count];
+        line_count++;
+
+        const char *drop_reason = stats.pipeline_last_drop_reason[0] != '\0'
+                                      ? stats.pipeline_last_drop_reason
+                                      : "n/a";
+        snprintf(text_lines[line_count], sizeof(text_lines[line_count]),
+                 "Pipe drop=%llu late=%llu latency=%llu last=%s seq=%u",
+                 (unsigned long long)stats.pipeline_dropped_total,
+                 (unsigned long long)stats.pipeline_dropped_too_late,
+                 (unsigned long long)stats.pipeline_dropped_on_latency, drop_reason,
+                 stats.pipeline_last_drop_seqnum);
         line_ptrs[line_count] = text_lines[line_count];
         line_count++;
 

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -542,6 +542,26 @@ void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats) {
     g_mutex_unlock(&ur->lock);
 }
 
+void udp_receiver_record_pipeline_drop(UdpReceiver *ur, guint32 seqnum, guint64 timestamp, const char *reason,
+                                       guint num_too_late, guint num_drop_on_latency) {
+    if (ur == NULL) {
+        return;
+    }
+
+    g_mutex_lock(&ur->lock);
+    ur->stats.pipeline_dropped_too_late += (guint64)num_too_late;
+    ur->stats.pipeline_dropped_on_latency += (guint64)num_drop_on_latency;
+    ur->stats.pipeline_dropped_total += (guint64)num_too_late + (guint64)num_drop_on_latency;
+    ur->stats.pipeline_last_drop_seqnum = seqnum;
+    ur->stats.pipeline_last_drop_timestamp = timestamp;
+    if (reason != NULL) {
+        g_strlcpy(ur->stats.pipeline_last_drop_reason, reason, sizeof(ur->stats.pipeline_last_drop_reason));
+    } else {
+        ur->stats.pipeline_last_drop_reason[0] = '\0';
+    }
+    g_mutex_unlock(&ur->lock);
+}
+
 void udp_receiver_set_stats_enabled(UdpReceiver *ur, gboolean enabled) {
     if (ur == NULL) {
         return;


### PR DESCRIPTION
## Summary
- extend `UdpReceiverStats` with pipeline drop accounting and expose a thread-safe update API
- have the bus thread record rtpjitterbuffer drop messages and log aggregated totals
- show pipeline drop counters alongside existing network stats in the OSD overlay

## Testing
- make *(fails: missing libdrm/drm.h in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dacd9f68d4832b871ceac9180113a6