### PR TITLE
Add INI configuration and flexible OSD layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ PixelPilot Mini RK is a lightweight receiver that ingests RTP video/audio over U
 All command-line options can be provided in an INI file and loaded with `--config /path/to/file.ini`. The parser merges the INI
 defaults first and then applies explicit CLI flags so ad-hoc overrides still work.
 
-The `config/osd-sample.ini` file documents every supported key, including the available OSD text tokens, line-plot metrics, and a
-quick reference for anchors, offsets, and color syntax.
+The `config/osd-sample.ini` file documents every supported key, including the available OSD text tokens, line-plot metrics, and a quick
+reference for anchors, offsets, color syntax, and the built-in named palette.
 Copy it next to the binary and launch the receiver as:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 PixelPilot Mini RK is a lightweight receiver that ingests RTP video/audio over UDP and drives a KMS plane on Rockchip-based devices. The application wraps a GStreamer pipeline with DRM/KMS, OSD, and udev helpers.
 
+## Configuration via INI
+
+All command-line options can be provided in an INI file and loaded with `--config /path/to/file.ini`. The parser merges the INI
+defaults first and then applies explicit CLI flags so ad-hoc overrides still work.
+
+The `config/osd-sample.ini` file documents every supported key, including the available OSD text tokens, line-plot metrics, and a
+quick reference for anchors, offsets, and color syntax.
+Copy it next to the binary and launch the receiver as:
+
+```sh
+./pixelpilot_mini_rk --config config/osd-sample.ini --osd
+```
+
+Any `line =` entry inside a `[osd.element.*]` section can reference `{token}` placeholders from the sample file's token table.
+Line plots accept metrics such as `udp.bitrate.latest_mbps`, `udp.jitter.avg_ms`, or counter-style values like
+`udp.pipeline.drop_total` and automatically handle scaling and rendering based on the INI-provided geometry.
+
 ## CPU affinity control
 
 Use `--cpu-list` to provide a comma-separated list of CPU IDs that the process and its busy worker threads should run on. The main process mask is restricted to the specified CPUs and the UDP receiver and GStreamer bus threads are pinned in a round-robin fashion to spread the work across cores.

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -55,16 +55,19 @@ elements = stats, bitrate_plot, jitter_plot
 ;   offset = X,Y pixel nudges applied after anchoring (positive values move
 ;            right/down, negative values move left/up)
 ;   size   = WxH in pixels (line plots only)
-; Colors accept 8-digit ARGB hex: 0xAARRGGBB. Prefixes `#` or `0x` are optional.
+; Colors accept 8-digit ARGB hex (0xAARRGGBB) or named presets: black, white,
+; blue, green, yellow, orange, purple, cyan, magenta, grey, light-grey,
+; dark-grey, transparent, transparent-grey, transparent-white, etc. Prefixes
+; `#` or `0x` are optional. 6-digit RGB hex implies opaque alpha.
 ; -----------------------------------------------------------------------------
 
 [osd.element.stats]
 type = text
 anchor = top-left
 padding = 8
-background = 0x40202020
-border = 0x60FFFFFF
-foreground = 0xB0FFFFFF
+background = transparent-grey
+border = transparent-white
+foreground = white
 line = HDMI {display.mode} plane={drm.video_plane_id}
 line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms
 line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
@@ -90,16 +93,17 @@ offset = 0,-12
 size = 360x90
 window-seconds = 60
 metric = udp.bitrate.latest_mbps
-label = Mbit/s
-line-color = 0xB0FF4040
-background = 0x40202020
-grid = 0x30909090
+label = Bitrate (Mbit/s)
+line-color = orange
+background = transparent-grey
+grid = transparent-white
 
 ; Line plots sample a single metric each refresh and keep a rolling history.
 ; - window-seconds controls the time axis.
 ; - size sets the pixel footprint (wider = longer time axis, taller = more
 ;   vertical resolution).
 ; - label is a free-form axis caption rendered along the Y axis.
+; - info-box toggles the small caption that hugs the plot border.
 
 [osd.element.jitter_plot]
 type = line
@@ -108,9 +112,10 @@ size = 320x90
 window-seconds = 30
 metric = udp.jitter.latest_ms
 label = Jitter (ms)
-line-color = 0xB0FFFFFF
-background = 0x40202020
-grid = 0x30909090
+info-box = false
+line-color = yellow
+background = transparent-grey
+grid = transparent-white
 
 ; -----------------------------------------------------------------------------
 ; Text template tokens

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -91,7 +91,7 @@ type = line
 anchor = bottom-left
 offset = 0,-12
 size = 360x90
-window-seconds = 60
+sample-spacing = 4
 metric = udp.bitrate.latest_mbps
 label = Bitrate (Mbit/s)
 line-color = orange
@@ -99,8 +99,9 @@ background = transparent-grey
 grid = transparent-white
 
 ; Line plots sample a single metric each refresh and keep a rolling history.
-; - window-seconds controls the time axis.
-; - size sets the pixel footprint (wider = longer time axis, taller = more
+; - sample-spacing sets the horizontal pixel gap between samples. The plot wraps
+;   when new samples no longer fit, keeping the spacing constant.
+; - size sets the pixel footprint (wider = more samples before wrap, taller = more
 ;   vertical resolution).
 ; - label is a free-form axis caption rendered along the Y axis.
 ; - info-box toggles the small badge with the latest sample (or a status
@@ -110,7 +111,7 @@ grid = transparent-white
 type = line
 anchor = bottom-right
 size = 320x90
-window-seconds = 30
+sample-spacing = 4
 metric = udp.jitter.latest_ms
 label = Jitter (ms)
 info-box = false

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -1,0 +1,170 @@
+; PixelPilot Mini sample configuration
+; Lines starting with ';' are comments. Values are case-insensitive unless noted.
+
+[drm]
+; Card/connector selection for the video plane
+card = /dev/dri/card0
+connector = HDMI-A-1
+video-plane-id = 76
+blank-primary = false
+use-udev = true
+osd-plane-id = 0
+
+[udp]
+port = 5600
+video-pt = 97
+audio-pt = 98
+
+[pipeline]
+latency-ms = 8
+video-queue-leaky = 2
+video-queue-pre-buffers = 96
+video-queue-post-buffers = 8
+video-queue-sink-buffers = 8
+video-drop-on-latency = true
+max-lateness-ns = 20000000
+
+[audio]
+device = plughw:CARD=rockchiphdmi0,DEV=0
+disable = false
+optional = true
+
+[restarts]
+limit = 3
+window-ms = 2000
+
+[gst]
+log = false
+
+[cpu]
+; Example: affinity = 3,4,5
+; affinity =
+
+[osd]
+enable = true
+refresh-ms = 500
+plane-id = 0
+; Order of elements rendered each update
+; The names reference [osd.element.NAME] sections below.
+elements = stats, bitrate_plot, jitter_plot
+
+; -----------------------------------------------------------------------------
+; Element placement quick reference
+;   anchor = top-left | top-mid | top-right | mid-left | mid | mid-right |
+;            bottom-left | bottom-mid | bottom-right
+;   offset = X,Y pixel nudges applied after anchoring (positive values move
+;            right/down, negative values move left/up)
+;   size   = WxH in pixels (line plots only)
+; Colors accept 8-digit ARGB hex: 0xAARRGGBB. Prefixes `#` or `0x` are optional.
+; -----------------------------------------------------------------------------
+
+[osd.element.stats]
+type = text
+anchor = top-left
+padding = 8
+background = 0x40202020
+border = 0x60FFFFFF
+foreground = 0xB0FFFFFF
+line = HDMI {display.mode} plane={drm.video_plane_id}
+line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms
+line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
+line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
+line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
+line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}B last={udp.frames.last_bytes}B seq={udp.expected_sequence}
+line = Drops total={udp.pipeline.drop_total} late={udp.pipeline.drop_too_late} latency={udp.pipeline.drop_on_latency} last={udp.pipeline.last_drop_reason}
+
+; To create additional text blocks duplicate the section with a new element
+; name and adjust the anchor/offset. Each `line =` entry appends to that block.
+; Example:
+; [osd.element.pipeline]
+; type = text
+; anchor = bottom-right
+; offset = -16,-16
+; background = 0x60101010
+; line = Pipeline {pipeline.state} restart={pipeline.restart_count}
+
+[osd.element.bitrate_plot]
+type = line
+anchor = bottom-left
+offset = 0,-12
+size = 360x90
+window-seconds = 60
+metric = udp.bitrate.latest_mbps
+label = Mbit/s
+line-color = 0xB0FF4040
+background = 0x40202020
+grid = 0x30909090
+
+; Line plots sample a single metric each refresh and keep a rolling history.
+; - window-seconds controls the time axis.
+; - size sets the pixel footprint (wider = longer time axis, taller = more
+;   vertical resolution).
+; - label is a free-form axis caption rendered along the Y axis.
+
+[osd.element.jitter_plot]
+type = line
+anchor = bottom-right
+size = 320x90
+window-seconds = 30
+metric = udp.jitter.latest_ms
+label = Jitter (ms)
+line-color = 0xB0FFFFFF
+background = 0x40202020
+grid = 0x30909090
+
+; -----------------------------------------------------------------------------
+; Text template tokens
+; Each {token} in a text line expands to the value listed below.
+; Display / DRM
+;   {display.mode}              => e.g. 1920x1080@60
+;   {display.width}             => active width in pixels
+;   {display.height}            => active height in pixels
+;   {display.refresh_hz}        => refresh rate in Hz
+;   {drm.video_plane_id}        => configured video plane id
+;   {drm.osd_plane_id}          => requested OSD plane id
+;   {osd.refresh_ms}            => OSD refresh interval
+;
+; Pipeline / configuration
+;   {pipeline.state}            => RUN / STOP / STOPPING
+;   {pipeline.restart_count}    => restart counter
+;   {pipeline.latency_ms}       => configured network latency target
+;   {pipeline.audio_suffix}     => " audio=fakesink" when the audio branch falls back
+;   {pipeline.audio_status}     => "fakesink" or "normal"
+;
+; UDP receiver stats (n/a if metrics disabled)
+;   {udp.stats.available}       => yes / no
+;   {udp.port} / {udp.vid_pt} / {udp.aud_pt}
+;   {udp.video_packets}, {udp.audio_packets}, {udp.total_packets}
+;   {udp.ignored_packets}, {udp.duplicate_packets}, {udp.lost_packets}, {udp.reordered_packets}
+;   {udp.total_bytes}, {udp.video_bytes}, {udp.audio_bytes}
+;   {udp.bitrate.latest_mbps}, {udp.bitrate.avg_mbps}
+;   {udp.jitter.latest_ms}, {udp.jitter.avg_ms}
+;   {udp.pipeline.drop_total}, {udp.pipeline.drop_too_late}, {udp.pipeline.drop_on_latency}
+;   {udp.pipeline.last_drop_reason}, {udp.pipeline.last_drop_seqnum}, {udp.pipeline.last_drop_timestamp_ns}
+;   {udp.frames.count}, {udp.frames.incomplete}, {udp.frames.last_bytes}, {udp.frames.avg_bytes}
+;   {udp.expected_sequence}, {udp.last_video_timestamp}
+;
+; -----------------------------------------------------------------------------
+; Plot metrics (line elements)
+; Assign these to `metric =` for each [osd.element.*] of type=line.
+; Units are already converted as noted.
+;   udp.bitrate.latest_mbps      (double, Mbps)
+;   udp.bitrate.avg_mbps         (double, Mbps)
+;   udp.jitter.latest_ms         (double, milliseconds)
+;   udp.jitter.avg_ms            (double, milliseconds)
+;   udp.pipeline.drop_total      (count)
+;   udp.pipeline.drop_on_latency (count)
+;   udp.pipeline.drop_too_late   (count)
+;   udp.frames.avg_bytes         (average frame size)
+;   udp.frames.count             (count)
+;   udp.video_packets            (count)
+;   udp.duplicate_packets        (count)
+;   udp.lost_packets             (count)
+;   udp.reordered_packets        (count)
+;   pipeline.restart_count       (count)
+;   pipeline.latency_ms          (milliseconds)
+;
+; Additional metrics or visual types (e.g. future bar elements) can be layered on
+; by adding new tokens to osd_token_format / osd_metric_sample in src/osd.c.
+; For now, the INI still accepts `type = bar` as a placeholder but the renderer
+; ignores it until the bar widget is implemented.

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -103,7 +103,8 @@ grid = transparent-white
 ; - size sets the pixel footprint (wider = longer time axis, taller = more
 ;   vertical resolution).
 ; - label is a free-form axis caption rendered along the Y axis.
-; - info-box toggles the small caption that hugs the plot border.
+; - info-box toggles the small badge with the latest sample (or a status
+;   message while the stream warms up).
 
 [osd.element.jitter_plot]
 type = line

--- a/include/config.h
+++ b/include/config.h
@@ -1,8 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include <sched.h>
 #include <limits.h>
+#include <sched.h>
+
+#include "osd_layout.h"
 
 #ifndef CPU_SETSIZE
 #define CPU_SETSIZE ((int)(sizeof(cpu_set_t) * CHAR_BIT))
@@ -11,6 +13,7 @@
 typedef struct {
     char card_path[64];
     char connector_name[32];
+    char config_path[PATH_MAX];
     int plane_id;
     int blank_primary;
     int use_udev;
@@ -44,10 +47,14 @@ typedef struct {
     cpu_set_t cpu_affinity_mask;
     int cpu_affinity_order[CPU_SETSIZE];
     int cpu_affinity_count;
+
+    OsdLayout osd_layout;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);
 void cfg_defaults(AppCfg *cfg);
+int cfg_load_file(const char *path, AppCfg *cfg);
+int cfg_parse_cpu_list(const char *list, AppCfg *cfg);
 int cfg_has_cpu_affinity(const AppCfg *cfg);
 void cfg_get_process_affinity(const AppCfg *cfg, cpu_set_t *set_out);
 int cfg_get_thread_affinity(const AppCfg *cfg, int slot, cpu_set_t *set_out);

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -52,7 +52,7 @@ typedef struct {
 typedef struct {
     int width;
     int height;
-    int window_seconds;
+    int sample_stride_px;
     char metric[64];
     char label[32];
     int show_info_box;

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -55,6 +55,7 @@ typedef struct {
     int window_seconds;
     char metric[64];
     char label[32];
+    int show_info_box;
     uint32_t fg;
     uint32_t grid;
     uint32_t bg;

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -1,0 +1,84 @@
+#ifndef OSD_LAYOUT_H
+#define OSD_LAYOUT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    OSD_WIDGET_TEXT = 0,
+    OSD_WIDGET_LINE,
+    OSD_WIDGET_BAR
+} OsdElementType;
+
+typedef enum {
+    OSD_POS_TOP_LEFT = 0,
+    OSD_POS_TOP_MID,
+    OSD_POS_TOP_RIGHT,
+    OSD_POS_MID_LEFT,
+    OSD_POS_MID,
+    OSD_POS_MID_RIGHT,
+    OSD_POS_BOTTOM_LEFT,
+    OSD_POS_BOTTOM_MID,
+    OSD_POS_BOTTOM_RIGHT
+} OSDWidgetPosition;
+
+#define OSD_MAX_ELEMENTS 8
+#define OSD_MAX_TEXT_LINES 24
+#define OSD_TEXT_MAX_LINE_CHARS 192
+
+typedef struct {
+    OSDWidgetPosition anchor;
+    int offset_x;
+    int offset_y;
+} OsdPlacement;
+
+typedef struct {
+    char raw[OSD_TEXT_MAX_LINE_CHARS];
+} OsdTextTemplate;
+
+typedef struct {
+    int line_count;
+    OsdTextTemplate lines[OSD_MAX_TEXT_LINES];
+    int padding;
+    uint32_t fg;
+    uint32_t bg;
+    uint32_t border;
+} OsdTextConfig;
+
+typedef struct {
+    int width;
+    int height;
+    int window_seconds;
+    char metric[64];
+    char label[32];
+    uint32_t fg;
+    uint32_t grid;
+    uint32_t bg;
+} OsdLineConfig;
+
+typedef struct {
+    OsdElementType type;
+    char name[48];
+    OsdPlacement placement;
+    union {
+        OsdTextConfig text;
+        OsdLineConfig line;
+    } data;
+} OsdElementConfig;
+
+typedef struct {
+    int element_count;
+    OsdElementConfig elements[OSD_MAX_ELEMENTS];
+} OsdLayout;
+
+void osd_layout_defaults(OsdLayout *layout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OSD_LAYOUT_H

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -99,7 +99,7 @@ static void builder_reset_line(OsdElementConfig *elem) {
     elem->type = OSD_WIDGET_LINE;
     elem->data.line.width = 360;
     elem->data.line.height = 80;
-    elem->data.line.window_seconds = 60;
+    elem->data.line.sample_stride_px = 4;
     elem->data.line.metric[0] = '\0';
     elem->data.line.label[0] = '\0';
     elem->data.line.show_info_box = 1;
@@ -154,8 +154,8 @@ static int builder_finalize(OsdLayoutBuilder *b, OsdLayout *out_layout) {
             if (elem->data.line.height <= 0) {
                 elem->data.line.height = 80;
             }
-            if (elem->data.line.window_seconds <= 0) {
-                elem->data.line.window_seconds = 60;
+            if (elem->data.line.sample_stride_px <= 0) {
+                elem->data.line.sample_stride_px = 4;
             }
         } else {
             LOGE("config: osd element '%s' has unsupported type", elem->name);
@@ -386,8 +386,9 @@ static int parse_osd_element_line(OsdElementConfig *elem, const char *key, const
         elem->data.line.show_info_box = enabled;
         return 0;
     }
-    if (strcasecmp(key, "window-seconds") == 0) {
-        elem->data.line.window_seconds = atoi(value);
+    if (strcasecmp(key, "sample-spacing") == 0 || strcasecmp(key, "sample-stride") == 0 ||
+        strcasecmp(key, "sample_stride") == 0 || strcasecmp(key, "sample-spacing-px") == 0) {
+        elem->data.line.sample_stride_px = atoi(value);
         return 0;
     }
     if (strcasecmp(key, "size") == 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1,0 +1,658 @@
+#include "config.h"
+
+#include "logging.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#define MAX_INI_LINE 512
+
+static void ini_copy_string(char *dst, size_t dst_sz, const char *src) {
+    if (!dst || dst_sz == 0) {
+        return;
+    }
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+    strncpy(dst, src, dst_sz - 1);
+    dst[dst_sz - 1] = '\0';
+}
+
+typedef struct {
+    OsdLayout layout;
+    int type_set[OSD_MAX_ELEMENTS];
+    int order_overridden;
+    char order[OSD_MAX_ELEMENTS][48];
+    int order_count;
+} OsdLayoutBuilder;
+
+static void builder_init(OsdLayoutBuilder *b, const OsdLayout *defaults) {
+    memset(b, 0, sizeof(*b));
+    if (defaults) {
+        b->layout = *defaults;
+        for (int i = 0; i < b->layout.element_count && i < OSD_MAX_ELEMENTS; ++i) {
+            b->type_set[i] = 1;
+        }
+    } else {
+        osd_layout_defaults(&b->layout);
+        for (int i = 0; i < b->layout.element_count; ++i) {
+            b->type_set[i] = 1;
+        }
+    }
+}
+
+static OsdElementConfig *builder_find(OsdLayoutBuilder *b, const char *name, int *index_out) {
+    for (int i = 0; i < b->layout.element_count; ++i) {
+        if (strcmp(b->layout.elements[i].name, name) == 0) {
+            if (index_out) {
+                *index_out = i;
+            }
+            return &b->layout.elements[i];
+        }
+    }
+    return NULL;
+}
+
+static OsdElementConfig *builder_ensure(OsdLayoutBuilder *b, const char *name, int *index_out) {
+    OsdElementConfig *elem = builder_find(b, name, index_out);
+    if (elem) {
+        return elem;
+    }
+    if (b->layout.element_count >= OSD_MAX_ELEMENTS) {
+        return NULL;
+    }
+    int idx = b->layout.element_count++;
+    elem = &b->layout.elements[idx];
+    memset(elem, 0, sizeof(*elem));
+    ini_copy_string(elem->name, sizeof(elem->name), name);
+    elem->placement.anchor = OSD_POS_TOP_LEFT;
+    elem->placement.offset_x = 0;
+    elem->placement.offset_y = 0;
+    elem->type = OSD_WIDGET_TEXT;
+    elem->data.text.line_count = 0;
+    elem->data.text.padding = 6;
+    elem->data.text.fg = 0xB0FFFFFFu;
+    elem->data.text.bg = 0x40202020u;
+    elem->data.text.border = 0x60FFFFFFu;
+    b->type_set[idx] = 0;
+    if (index_out) {
+        *index_out = idx;
+    }
+    return elem;
+}
+
+static void builder_reset_text(OsdElementConfig *elem) {
+    elem->type = OSD_WIDGET_TEXT;
+    elem->data.text.line_count = 0;
+    elem->data.text.padding = 6;
+    elem->data.text.fg = 0xB0FFFFFFu;
+    elem->data.text.bg = 0x40202020u;
+    elem->data.text.border = 0x60FFFFFFu;
+}
+
+static void builder_reset_line(OsdElementConfig *elem) {
+    elem->type = OSD_WIDGET_LINE;
+    elem->data.line.width = 360;
+    elem->data.line.height = 80;
+    elem->data.line.window_seconds = 60;
+    elem->data.line.metric[0] = '\0';
+    elem->data.line.label[0] = '\0';
+    elem->data.line.fg = 0xFFFFFFFFu;
+    elem->data.line.grid = 0x20FFFFFFu;
+    elem->data.line.bg = 0x20000000u;
+}
+
+static int builder_finalize(OsdLayoutBuilder *b, OsdLayout *out_layout) {
+    if (!out_layout) {
+        return -1;
+    }
+    if (b->order_overridden) {
+        OsdLayout final = {0};
+        for (int i = 0; i < b->order_count; ++i) {
+            int idx = 0;
+            OsdElementConfig *elem = builder_find(b, b->order[i], &idx);
+            if (!elem) {
+                LOGE("config: osd element '%s' listed in order but not defined", b->order[i]);
+                return -1;
+            }
+            if (!b->type_set[idx]) {
+                LOGE("config: osd element '%s' missing type definition", b->order[i]);
+                return -1;
+            }
+            if (final.element_count >= OSD_MAX_ELEMENTS) {
+                LOGE("config: too many osd elements in order list (max %d)", OSD_MAX_ELEMENTS);
+                return -1;
+            }
+            final.elements[final.element_count++] = *elem;
+        }
+        *out_layout = final;
+    } else {
+        for (int i = 0; i < b->layout.element_count; ++i) {
+            if (!b->type_set[i]) {
+                LOGE("config: osd element '%s' missing type definition", b->layout.elements[i].name);
+                return -1;
+            }
+        }
+        *out_layout = b->layout;
+    }
+    for (int i = 0; i < out_layout->element_count; ++i) {
+        OsdElementConfig *elem = &out_layout->elements[i];
+        if (elem->type == OSD_WIDGET_TEXT) {
+            if (elem->data.text.padding <= 0) {
+                elem->data.text.padding = 6;
+            }
+        } else if (elem->type == OSD_WIDGET_LINE) {
+            if (elem->data.line.width <= 0) {
+                elem->data.line.width = 360;
+            }
+            if (elem->data.line.height <= 0) {
+                elem->data.line.height = 80;
+            }
+            if (elem->data.line.window_seconds <= 0) {
+                elem->data.line.window_seconds = 60;
+            }
+        } else {
+            LOGE("config: osd element '%s' has unsupported type", elem->name);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static char *trim(char *s) {
+    while (isspace((unsigned char)*s)) {
+        ++s;
+    }
+    char *end = s + strlen(s);
+    while (end > s && isspace((unsigned char)*(end - 1))) {
+        *(--end) = '\0';
+    }
+    return s;
+}
+
+static int parse_bool(const char *value, int *out) {
+    if (!value || !out) {
+        return -1;
+    }
+    if (strcasecmp(value, "true") == 0 || strcasecmp(value, "yes") == 0 || strcmp(value, "1") == 0 || strcasecmp(value, "on") == 0) {
+        *out = 1;
+        return 0;
+    }
+    if (strcasecmp(value, "false") == 0 || strcasecmp(value, "no") == 0 || strcmp(value, "0") == 0 || strcasecmp(value, "off") == 0) {
+        *out = 0;
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_color(const char *value, uint32_t *out) {
+    if (!value || !out) {
+        return -1;
+    }
+    const char *p = value;
+    if (p[0] == '#') {
+        ++p;
+    } else if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        p += 2;
+    }
+    size_t len = strlen(p);
+    if (len != 8) {
+        return -1;
+    }
+    char *endptr = NULL;
+    errno = 0;
+    unsigned long v = strtoul(p, &endptr, 16);
+    if (errno != 0 || !endptr || *endptr != '\0') {
+        return -1;
+    }
+    *out = (uint32_t)v;
+    return 0;
+}
+
+static int parse_anchor(const char *value, OSDWidgetPosition *pos) {
+    if (!value || !pos) {
+        return -1;
+    }
+    static const struct {
+        const char *name;
+        OSDWidgetPosition pos;
+    } table[] = {
+        {"top-left", OSD_POS_TOP_LEFT},     {"top-mid", OSD_POS_TOP_MID},       {"top-right", OSD_POS_TOP_RIGHT},
+        {"mid-left", OSD_POS_MID_LEFT},     {"center", OSD_POS_MID},            {"mid", OSD_POS_MID},
+        {"mid-mid", OSD_POS_MID},           {"mid-right", OSD_POS_MID_RIGHT},   {"bottom-left", OSD_POS_BOTTOM_LEFT},
+        {"bottom-mid", OSD_POS_BOTTOM_MID}, {"bottom-right", OSD_POS_BOTTOM_RIGHT}};
+    for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); ++i) {
+        if (strcasecmp(value, table[i].name) == 0) {
+            *pos = table[i].pos;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int parse_size(const char *value, int *w, int *h) {
+    if (!value || !w || !h) {
+        return -1;
+    }
+    int width = 0, height = 0;
+    if (sscanf(value, "%dx%d", &width, &height) != 2) {
+        return -1;
+    }
+    *w = width;
+    *h = height;
+    return 0;
+}
+
+static int parse_osd_section(OsdLayoutBuilder *builder, const char *key, const char *value) {
+    if (strcasecmp(key, "elements") == 0) {
+        builder->order_count = 0;
+        builder->order_overridden = 1;
+        char buf[256];
+        ini_copy_string(buf, sizeof(buf), value);
+        char *token = strtok(buf, ",");
+        while (token) {
+            char *name = trim(token);
+            if (*name) {
+                if (builder->order_count >= OSD_MAX_ELEMENTS) {
+                    LOGE("config: osd elements list exceeds limit %d", OSD_MAX_ELEMENTS);
+                    return -1;
+                }
+                ini_copy_string(builder->order[builder->order_count], sizeof(builder->order[0]), name);
+                builder->order_count++;
+            }
+            token = strtok(NULL, ",");
+        }
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_osd_element_text(OsdElementConfig *elem, const char *key, const char *value) {
+    if (strcasecmp(key, "line") == 0) {
+        if (elem->data.text.line_count >= OSD_MAX_TEXT_LINES) {
+            LOGE("config: osd text element '%s' has too many lines (max %d)", elem->name, OSD_MAX_TEXT_LINES);
+            return -1;
+        }
+        ini_copy_string(elem->data.text.lines[elem->data.text.line_count].raw,
+                        sizeof(elem->data.text.lines[0].raw), value);
+        elem->data.text.line_count++;
+        return 0;
+    }
+    if (strcasecmp(key, "padding") == 0) {
+        elem->data.text.padding = atoi(value);
+        return 0;
+    }
+    if (strcasecmp(key, "foreground") == 0 || strcasecmp(key, "text-color") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.text.fg = color;
+        return 0;
+    }
+    if (strcasecmp(key, "background") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.text.bg = color;
+        return 0;
+    }
+    if (strcasecmp(key, "border") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.text.border = color;
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_osd_element_line(OsdElementConfig *elem, const char *key, const char *value) {
+    if (strcasecmp(key, "metric") == 0) {
+    ini_copy_string(elem->data.line.metric, sizeof(elem->data.line.metric), value);
+        return 0;
+    }
+    if (strcasecmp(key, "label") == 0) {
+        ini_copy_string(elem->data.line.label, sizeof(elem->data.line.label), value);
+        return 0;
+    }
+    if (strcasecmp(key, "window-seconds") == 0) {
+        elem->data.line.window_seconds = atoi(value);
+        return 0;
+    }
+    if (strcasecmp(key, "size") == 0) {
+        int w = 0, h = 0;
+        if (parse_size(value, &w, &h) != 0) {
+            return -1;
+        }
+        elem->data.line.width = w;
+        elem->data.line.height = h;
+        return 0;
+    }
+    if (strcasecmp(key, "foreground") == 0 || strcasecmp(key, "line-color") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.line.fg = color;
+        return 0;
+    }
+    if (strcasecmp(key, "grid") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.line.grid = color;
+        return 0;
+    }
+    if (strcasecmp(key, "background") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.line.bg = color;
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name, const char *key, const char *value) {
+    const char *prefix = "osd.element.";
+    size_t prefix_len = strlen(prefix);
+    if (strncmp(section_name, prefix, prefix_len) != 0) {
+        return -1;
+    }
+    const char *name = section_name + prefix_len;
+    int idx = 0;
+    OsdElementConfig *elem = builder_ensure(builder, name, &idx);
+    if (!elem) {
+        LOGE("config: too many osd elements; increase OSD_MAX_ELEMENTS");
+        return -1;
+    }
+    if (strcasecmp(key, "type") == 0) {
+        if (strcasecmp(value, "text") == 0) {
+            builder_reset_text(elem);
+            builder->type_set[idx] = 1;
+            return 0;
+        }
+        if (strcasecmp(value, "line") == 0) {
+            builder_reset_line(elem);
+            builder->type_set[idx] = 1;
+            return 0;
+        }
+        if (strcasecmp(value, "bar") == 0) {
+            elem->type = OSD_WIDGET_BAR;
+            builder->type_set[idx] = 1;
+            return 0;
+        }
+        LOGE("config: unknown osd element type '%s' for '%s'", value, name);
+        return -1;
+    }
+    if (strcasecmp(key, "anchor") == 0) {
+        OSDWidgetPosition pos;
+        if (parse_anchor(value, &pos) != 0) {
+            return -1;
+        }
+        elem->placement.anchor = pos;
+        return 0;
+    }
+    if (strcasecmp(key, "offset") == 0) {
+        int ox = 0, oy = 0;
+        if (sscanf(value, "%d,%d", &ox, &oy) != 2) {
+            return -1;
+        }
+        elem->placement.offset_x = ox;
+        elem->placement.offset_y = oy;
+        return 0;
+    }
+    if (elem->type == OSD_WIDGET_TEXT) {
+        return parse_osd_element_text(elem, key, value);
+    }
+    if (elem->type == OSD_WIDGET_LINE) {
+        return parse_osd_element_line(elem, key, value);
+    }
+    return -1;
+}
+
+static int apply_general_key(AppCfg *cfg, const char *section, const char *key, const char *value) {
+    if (strcasecmp(section, "drm") == 0) {
+        if (strcasecmp(key, "card") == 0) {
+        ini_copy_string(cfg->card_path, sizeof(cfg->card_path), value);
+            return 0;
+        }
+        if (strcasecmp(key, "connector") == 0) {
+        ini_copy_string(cfg->connector_name, sizeof(cfg->connector_name), value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-plane-id") == 0) {
+            cfg->plane_id = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "blank-primary") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->blank_primary = v;
+            return 0;
+        }
+        if (strcasecmp(key, "osd-plane-id") == 0) {
+            cfg->osd_plane_id = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "use-udev") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->use_udev = v;
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "udp") == 0) {
+        if (strcasecmp(key, "port") == 0) {
+            cfg->udp_port = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-pt") == 0) {
+            cfg->vid_pt = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "audio-pt") == 0) {
+            cfg->aud_pt = atoi(value);
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "pipeline") == 0) {
+        if (strcasecmp(key, "latency-ms") == 0) {
+            cfg->latency_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-queue-leaky") == 0) {
+            cfg->video_queue_leaky = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-queue-pre-buffers") == 0) {
+            cfg->video_queue_pre_buffers = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-queue-post-buffers") == 0) {
+            cfg->video_queue_post_buffers = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-queue-sink-buffers") == 0) {
+            cfg->video_queue_sink_buffers = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "video-drop-on-latency") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->video_drop_on_latency = v;
+            return 0;
+        }
+        if (strcasecmp(key, "max-lateness-ns") == 0) {
+            cfg->max_lateness_ns = atoi(value);
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "audio") == 0) {
+        if (strcasecmp(key, "device") == 0) {
+            ini_copy_string(cfg->aud_dev, sizeof(cfg->aud_dev), value);
+            return 0;
+        }
+        if (strcasecmp(key, "disable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->no_audio = v;
+            return 0;
+        }
+        if (strcasecmp(key, "optional") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->audio_optional = v;
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "restart") == 0 || strcasecmp(section, "restarts") == 0) {
+        if (strcasecmp(key, "limit") == 0) {
+            cfg->restart_limit = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "window-ms") == 0) {
+            cfg->restart_window_ms = atoi(value);
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "osd") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->osd_enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "refresh-ms") == 0) {
+            cfg->osd_refresh_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "plane-id") == 0) {
+            cfg->osd_plane_id = atoi(value);
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "gst") == 0) {
+        if (strcasecmp(key, "log") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->gst_log = v;
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "cpu") == 0) {
+        if (strcasecmp(key, "affinity") == 0) {
+            return cfg_parse_cpu_list(value, cfg);
+        }
+        return -1;
+    }
+    return -1;
+}
+
+int cfg_load_file(const char *path, AppCfg *cfg) {
+    if (!path || !cfg) {
+        return -1;
+    }
+    FILE *fp = fopen(path, "r");
+    if (!fp) {
+        LOGE("config: failed to open %s", path);
+        return -1;
+    }
+
+    OsdLayoutBuilder builder;
+    builder_init(&builder, &cfg->osd_layout);
+
+    char line[MAX_INI_LINE];
+    char current_section[128] = "";
+    int lineno = 0;
+
+    while (fgets(line, sizeof(line), fp)) {
+        ++lineno;
+        char *trimmed = trim(line);
+        if (*trimmed == '\0' || *trimmed == '#' || *trimmed == ';') {
+            continue;
+        }
+        if (*trimmed == '[') {
+            char *end = strchr(trimmed, ']');
+            if (!end) {
+                LOGE("config:%d: missing closing ']'", lineno);
+                fclose(fp);
+                return -1;
+            }
+            *end = '\0';
+            ini_copy_string(current_section, sizeof(current_section), trimmed + 1);
+            continue;
+        }
+        char *eq = strchr(trimmed, '=');
+        if (!eq) {
+            LOGE("config:%d: expected key=value", lineno);
+            fclose(fp);
+            return -1;
+        }
+        *eq = '\0';
+        char *key = trim(trimmed);
+        char *value = trim(eq + 1);
+        if (*value == '"' && value[strlen(value) - 1] == '"' && strlen(value) >= 2) {
+            value[strlen(value) - 1] = '\0';
+            value = value + 1;
+        }
+
+        if (strncasecmp(current_section, "osd.element.", strlen("osd.element.")) == 0) {
+            if (parse_osd_element(&builder, current_section, key, value) != 0) {
+                LOGE("config:%d: failed to parse osd element setting %s", lineno, key);
+                fclose(fp);
+                return -1;
+            }
+            continue;
+        }
+        if (strcasecmp(current_section, "osd") == 0) {
+            if (parse_osd_section(&builder, key, value) == 0) {
+                continue;
+            }
+        }
+        if (apply_general_key(cfg, current_section, key, value) != 0) {
+            LOGE("config:%d: unknown setting %s in section [%s]", lineno, key, current_section);
+            fclose(fp);
+            return -1;
+        }
+    }
+
+    fclose(fp);
+
+    if (builder_finalize(&builder, &cfg->osd_layout) != 0) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/osd.c
+++ b/src/osd.c
@@ -3,6 +3,7 @@
 #include "drm_props.h"
 #include "logging.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -208,6 +209,367 @@ static void osd_store_rect(OSDRect *r, int x, int y, int w, int h) {
     r->h = h;
 }
 
+typedef struct {
+    const AppCfg *cfg;
+    const ModesetResult *ms;
+    const PipelineState *ps;
+    int audio_disabled;
+    int restart_count;
+    int have_stats;
+    UdpReceiverStats stats;
+} OsdRenderContext;
+
+static const char *osd_pipeline_state_name(const PipelineState *ps) {
+    if (!ps) {
+        return "UNKNOWN";
+    }
+    switch (ps->state) {
+    case PIPELINE_RUNNING:
+        return "RUN";
+    case PIPELINE_STOPPING:
+        return "STOPPING";
+    case PIPELINE_STOPPED:
+    default:
+        return "STOP";
+    }
+}
+
+static int osd_token_format(const OsdRenderContext *ctx, const char *token, char *buf, size_t buf_sz) {
+    if (!token || !buf || buf_sz == 0) {
+        return -1;
+    }
+
+    const AppCfg *cfg = ctx->cfg;
+    if (strcmp(token, "display.mode") == 0) {
+        if (ctx->ms) {
+            snprintf(buf, buf_sz, "%dx%d@%d", ctx->ms->mode_w, ctx->ms->mode_h, ctx->ms->mode_hz);
+        } else {
+            snprintf(buf, buf_sz, "n/a");
+        }
+        return 0;
+    }
+    if (strcmp(token, "display.width") == 0) {
+        if (ctx->ms) {
+            snprintf(buf, buf_sz, "%d", ctx->ms->mode_w);
+        } else {
+            snprintf(buf, buf_sz, "0");
+        }
+        return 0;
+    }
+    if (strcmp(token, "display.height") == 0) {
+        if (ctx->ms) {
+            snprintf(buf, buf_sz, "%d", ctx->ms->mode_h);
+        } else {
+            snprintf(buf, buf_sz, "0");
+        }
+        return 0;
+    }
+    if (strcmp(token, "display.refresh_hz") == 0) {
+        if (ctx->ms) {
+            snprintf(buf, buf_sz, "%d", ctx->ms->mode_hz);
+        } else {
+            snprintf(buf, buf_sz, "0");
+        }
+        return 0;
+    }
+    if (strcmp(token, "drm.video_plane_id") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->plane_id : 0);
+        return 0;
+    }
+    if (strcmp(token, "drm.osd_plane_id") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->osd_plane_id : 0);
+        return 0;
+    }
+    if (strcmp(token, "osd.refresh_ms") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->osd_refresh_ms : 0);
+        return 0;
+    }
+    if (strcmp(token, "udp.port") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->udp_port : 0);
+        return 0;
+    }
+    if (strcmp(token, "udp.vid_pt") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->vid_pt : 0);
+        return 0;
+    }
+    if (strcmp(token, "udp.aud_pt") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->aud_pt : 0);
+        return 0;
+    }
+    if (strcmp(token, "pipeline.latency_ms") == 0) {
+        snprintf(buf, buf_sz, "%d", cfg ? cfg->latency_ms : 0);
+        return 0;
+    }
+    if (strcmp(token, "pipeline.state") == 0) {
+        snprintf(buf, buf_sz, "%s", osd_pipeline_state_name(ctx->ps));
+        return 0;
+    }
+    if (strcmp(token, "pipeline.restart_count") == 0) {
+        snprintf(buf, buf_sz, "%d", ctx->restart_count);
+        return 0;
+    }
+    if (strcmp(token, "pipeline.audio_suffix") == 0) {
+        if (ctx->audio_disabled) {
+            snprintf(buf, buf_sz, " audio=fakesink");
+        } else {
+            buf[0] = '\0';
+        }
+        return 0;
+    }
+    if (strcmp(token, "pipeline.audio_status") == 0) {
+        snprintf(buf, buf_sz, "%s", ctx->audio_disabled ? "fakesink" : "normal");
+        return 0;
+    }
+
+    if (strcmp(token, "udp.stats.available") == 0) {
+        snprintf(buf, buf_sz, "%s", ctx->have_stats ? "yes" : "no");
+        return 0;
+    }
+
+    if (!ctx->have_stats) {
+        if (strncmp(token, "udp.", 4) == 0) {
+            snprintf(buf, buf_sz, "n/a");
+            return 0;
+        }
+    }
+
+    if (strcmp(token, "udp.video_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.video_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.audio_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.audio_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.total_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.total_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.ignored_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.ignored_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.duplicate_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.duplicate_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.lost_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.lost_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.reordered_packets") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.reordered_packets);
+        return 0;
+    }
+    if (strcmp(token, "udp.total_bytes") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.total_bytes);
+        return 0;
+    }
+    if (strcmp(token, "udp.video_bytes") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.video_bytes);
+        return 0;
+    }
+    if (strcmp(token, "udp.audio_bytes") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.audio_bytes);
+        return 0;
+    }
+    if (strcmp(token, "udp.bitrate.latest_mbps") == 0) {
+        snprintf(buf, buf_sz, "%.2f", ctx->stats.bitrate_mbps);
+        return 0;
+    }
+    if (strcmp(token, "udp.bitrate.avg_mbps") == 0) {
+        snprintf(buf, buf_sz, "%.2f", ctx->stats.bitrate_avg_mbps);
+        return 0;
+    }
+    if (strcmp(token, "udp.jitter.latest_ms") == 0) {
+        snprintf(buf, buf_sz, "%.2f", ctx->stats.jitter / 90.0);
+        return 0;
+    }
+    if (strcmp(token, "udp.jitter.avg_ms") == 0) {
+        snprintf(buf, buf_sz, "%.2f", ctx->stats.jitter_avg / 90.0);
+        return 0;
+    }
+    if (strcmp(token, "udp.pipeline.drop_total") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.pipeline_dropped_total);
+        return 0;
+    }
+    if (strcmp(token, "udp.pipeline.drop_too_late") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.pipeline_dropped_too_late);
+        return 0;
+    }
+    if (strcmp(token, "udp.pipeline.drop_on_latency") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.pipeline_dropped_on_latency);
+        return 0;
+    }
+    if (strcmp(token, "udp.pipeline.last_drop_reason") == 0) {
+        if (ctx->stats.pipeline_last_drop_reason[0]) {
+            snprintf(buf, buf_sz, "%s", ctx->stats.pipeline_last_drop_reason);
+        } else {
+            snprintf(buf, buf_sz, "n/a");
+        }
+        return 0;
+    }
+    if (strcmp(token, "udp.pipeline.last_drop_seqnum") == 0) {
+        snprintf(buf, buf_sz, "%u", ctx->stats.pipeline_last_drop_seqnum);
+        return 0;
+    }
+    if (strcmp(token, "udp.pipeline.last_drop_timestamp_ns") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.pipeline_last_drop_timestamp);
+        return 0;
+    }
+    if (strcmp(token, "udp.frames.count") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.frame_count);
+        return 0;
+    }
+    if (strcmp(token, "udp.frames.incomplete") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.incomplete_frames);
+        return 0;
+    }
+    if (strcmp(token, "udp.frames.last_bytes") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.last_frame_bytes);
+        return 0;
+    }
+    if (strcmp(token, "udp.frames.avg_bytes") == 0) {
+        snprintf(buf, buf_sz, "%.0f", ctx->stats.frame_size_avg);
+        return 0;
+    }
+    if (strcmp(token, "udp.expected_sequence") == 0) {
+        snprintf(buf, buf_sz, "%u", ctx->stats.expected_sequence);
+        return 0;
+    }
+    if (strcmp(token, "udp.last_video_timestamp") == 0) {
+        snprintf(buf, buf_sz, "%u", ctx->stats.last_video_timestamp);
+        return 0;
+    }
+
+    snprintf(buf, buf_sz, "{%s}", token);
+    return -1;
+}
+
+static int osd_metric_sample(const OsdRenderContext *ctx, const char *key, double *out_value) {
+    if (!key || !out_value) {
+        return 0;
+    }
+    if (!ctx->have_stats && strncmp(key, "udp.", 4) == 0) {
+        return 0;
+    }
+
+    if (strcmp(key, "udp.bitrate.latest_mbps") == 0) {
+        *out_value = ctx->stats.bitrate_mbps;
+        return 1;
+    }
+    if (strcmp(key, "udp.bitrate.avg_mbps") == 0) {
+        *out_value = ctx->stats.bitrate_avg_mbps;
+        return 1;
+    }
+    if (strcmp(key, "udp.jitter.latest_ms") == 0) {
+        *out_value = ctx->stats.jitter / 90.0;
+        return 1;
+    }
+    if (strcmp(key, "udp.jitter.avg_ms") == 0) {
+        *out_value = ctx->stats.jitter_avg / 90.0;
+        return 1;
+    }
+    if (strcmp(key, "udp.pipeline.drop_total") == 0) {
+        *out_value = (double)ctx->stats.pipeline_dropped_total;
+        return 1;
+    }
+    if (strcmp(key, "udp.pipeline.drop_on_latency") == 0) {
+        *out_value = (double)ctx->stats.pipeline_dropped_on_latency;
+        return 1;
+    }
+    if (strcmp(key, "udp.pipeline.drop_too_late") == 0) {
+        *out_value = (double)ctx->stats.pipeline_dropped_too_late;
+        return 1;
+    }
+    if (strcmp(key, "udp.frames.avg_bytes") == 0) {
+        *out_value = ctx->stats.frame_size_avg;
+        return 1;
+    }
+    if (strcmp(key, "udp.frames.count") == 0) {
+        *out_value = (double)ctx->stats.frame_count;
+        return 1;
+    }
+    if (strcmp(key, "udp.video_packets") == 0) {
+        *out_value = (double)ctx->stats.video_packets;
+        return 1;
+    }
+    if (strcmp(key, "udp.duplicate_packets") == 0) {
+        *out_value = (double)ctx->stats.duplicate_packets;
+        return 1;
+    }
+    if (strcmp(key, "udp.lost_packets") == 0) {
+        *out_value = (double)ctx->stats.lost_packets;
+        return 1;
+    }
+    if (strcmp(key, "udp.reordered_packets") == 0) {
+        *out_value = (double)ctx->stats.reordered_packets;
+        return 1;
+    }
+
+    if (strcmp(key, "pipeline.restart_count") == 0) {
+        *out_value = (double)ctx->restart_count;
+        return 1;
+    }
+    if (strcmp(key, "pipeline.latency_ms") == 0) {
+        *out_value = (double)(ctx->cfg ? ctx->cfg->latency_ms : 0);
+        return 1;
+    }
+
+    return 0;
+}
+
+static void osd_expand_template(const OsdRenderContext *ctx, const char *tmpl, char *out, size_t out_sz) {
+    if (!tmpl || !out || out_sz == 0) {
+        return;
+    }
+    size_t pos = 0;
+    const char *p = tmpl;
+    while (*p && pos + 1 < out_sz) {
+        if (*p == '{') {
+            const char *end = strchr(p, '}');
+            if (!end) {
+                out[pos++] = *p++;
+                continue;
+            }
+            size_t key_len = (size_t)(end - (p + 1));
+            char key[128];
+            if (key_len >= sizeof(key)) {
+                key_len = sizeof(key) - 1;
+            }
+            memcpy(key, p + 1, key_len);
+            key[key_len] = '\0';
+            char value[256];
+            if (osd_token_format(ctx, key, value, sizeof(value)) != 0) {
+                snprintf(value, sizeof(value), "{%s}", key);
+            }
+            size_t value_len = strnlen(value, sizeof(value));
+            if (value_len > out_sz - pos - 1) {
+                value_len = out_sz - pos - 1;
+            }
+            memcpy(out + pos, value, value_len);
+            pos += value_len;
+            p = end + 1;
+        } else {
+            out[pos++] = *p++;
+        }
+    }
+    out[pos] = '\0';
+}
+
+static void osd_format_metric_value(const char *metric_key, double value, char *buf, size_t buf_sz) {
+    if (!metric_key || !buf || buf_sz == 0) {
+        return;
+    }
+    if (strstr(metric_key, "mbps") || strstr(metric_key, "ms")) {
+        snprintf(buf, buf_sz, "%.2f", value);
+    } else if (strstr(metric_key, "avg") || strstr(metric_key, "ratio")) {
+        snprintf(buf, buf_sz, "%.2f", value);
+    } else {
+        snprintf(buf, buf_sz, "%.0f", value);
+    }
+}
+
 static void osd_clear_rect(OSD *o, const OSDRect *r) {
     if (!r || r->w <= 0 || r->h <= 0) {
         return;
@@ -276,7 +638,8 @@ static void osd_draw_rect(OSD *o, int x, int y, int w, int h, uint32_t argb) {
     osd_draw_vline(o, x + w - (o->scale > 0 ? o->scale : 1), y, h, argb);
 }
 
-static void osd_compute_anchor(const OSD *o, int rect_w, int rect_h, OSDWidgetPosition pos, int *out_x, int *out_y) {
+static void osd_compute_placement(const OSD *o, int rect_w, int rect_h, const OsdPlacement *placement,
+                                  int *out_x, int *out_y) {
     int margin = o->margin_px;
     int inner_w = o->w - 2 * margin;
     int inner_h = o->h - 2 * margin;
@@ -290,6 +653,7 @@ static void osd_compute_anchor(const OSD *o, int rect_w, int rect_h, OSDWidgetPo
     int x = margin;
     int y = margin;
 
+    OSDWidgetPosition pos = placement ? placement->anchor : OSD_POS_TOP_LEFT;
     switch (pos) {
     case OSD_POS_TOP_LEFT:
         x = margin;
@@ -351,134 +715,150 @@ static void osd_compute_anchor(const OSD *o, int rect_w, int rect_h, OSDWidgetPo
         y = 0;
     }
 
+    if (placement) {
+        x += placement->offset_x;
+        y += placement->offset_y;
+    }
+
     *out_x = x;
     *out_y = y;
 }
 
-static void osd_plot_reset(OSD *o, const AppCfg *cfg) {
-    o->plot_window_seconds = 60;
-    o->plot_position = OSD_POS_BOTTOM_LEFT;
-    o->plot_sum = 0.0;
-    o->plot_size = 0;
-    o->plot_cursor = 0;
-    o->plot_latest = 0.0;
-    o->plot_min = DBL_MAX;
-    o->plot_max = 0.0;
-    o->plot_avg = 0.0;
-    o->plot_scale_min = 0.0;
-    o->plot_scale_max = 1.0;
-    o->plot_step_px = 0.0;
-    o->plot_background_ready = 0;
-    o->plot_prev_valid = 0;
-    o->plot_prev_x = 0;
-    o->plot_prev_y = 0;
-    o->plot_rescale_countdown = 0;
-    memset(o->plot_samples, 0, sizeof(o->plot_samples));
-    o->plot_clear_on_next_draw = 0;
+static void osd_line_reset(OSD *o, const AppCfg *cfg, int idx) {
+    if (idx < 0 || idx >= o->layout.element_count) {
+        return;
+    }
+    OsdElementConfig *elem_cfg = &o->layout.elements[idx];
+    OsdElementType type = elem_cfg->type;
+    o->elements[idx].type = type;
+    if (type != OSD_WIDGET_LINE) {
+        return;
+    }
 
-    int margin = o->margin_px;
-    int desired_columns = cfg->osd_refresh_ms > 0
-                              ? (int)((o->plot_window_seconds * 1000 + cfg->osd_refresh_ms - 1) / cfg->osd_refresh_ms)
-                              : o->plot_window_seconds;
+    int scale = o->scale > 0 ? o->scale : 1;
+    OsdLineState *state = &o->elements[idx].data.line;
+    memset(state, 0, sizeof(*state));
+
+    int window_seconds = elem_cfg->data.line.window_seconds > 0 ? elem_cfg->data.line.window_seconds : 60;
+    int refresh_ms = cfg->osd_refresh_ms > 0 ? cfg->osd_refresh_ms : 500;
+    int desired_columns = (window_seconds * 1000 + refresh_ms - 1) / refresh_ms;
     if (desired_columns < 2) {
         desired_columns = 2;
     }
-
-    int capacity = desired_columns;
-    if (capacity > OSD_PLOT_MAX_SAMPLES) {
-        capacity = OSD_PLOT_MAX_SAMPLES;
+    state->capacity = desired_columns;
+    if (state->capacity > OSD_PLOT_MAX_SAMPLES) {
+        state->capacity = OSD_PLOT_MAX_SAMPLES;
     }
-    if (capacity < 2) {
-        capacity = 2;
+    if (state->capacity < 2) {
+        state->capacity = 2;
     }
 
-    o->plot_capacity = capacity;
-    int scale = o->scale > 0 ? o->scale : 1;
-    int target_plot_w = 360 * scale;
-    int available_w = o->w - 2 * margin;
-    int min_plot_w = 160 * scale;
-    if (available_w <= 0) {
-        target_plot_w = min_plot_w;
+    state->size = 0;
+    state->cursor = 0;
+    state->sum = 0.0;
+    state->latest = 0.0;
+    state->min_v = DBL_MAX;
+    state->max_v = 0.0;
+    state->avg = 0.0;
+    state->scale_min = 0.0;
+    state->scale_max = 1.0;
+    state->step_px = 0.0;
+    state->clear_on_next_draw = 0;
+    state->background_ready = 0;
+    state->prev_valid = 0;
+    state->rescale_countdown = 0;
+
+    int width = elem_cfg->data.line.width;
+    int height = elem_cfg->data.line.height;
+    if (width <= 0) {
+        width = 360;
+    }
+    if (height <= 0) {
+        height = 80;
+    }
+    width *= scale;
+    height *= scale;
+
+    int margin = o->margin_px;
+    if (width > o->w - 2 * margin) {
+        width = o->w - 2 * margin;
+    }
+    if (width < scale * 80) {
+        width = scale * 80;
+    }
+    if (width <= 0) {
+        width = scale * 80;
+    }
+
+    if (height > o->h - 2 * margin) {
+        height = o->h - 2 * margin;
+    }
+    if (height < scale * 40) {
+        height = scale * 40;
+    }
+    if (height <= 0) {
+        height = scale * 40;
+    }
+
+    state->width = width;
+    state->height = height;
+    osd_compute_placement(o, width, height, &elem_cfg->placement, &state->x, &state->y);
+    osd_store_rect(&state->plot_rect, 0, 0, 0, 0);
+    osd_store_rect(&state->label_rect, 0, 0, 0, 0);
+    osd_store_rect(&state->footer_rect, 0, 0, 0, 0);
+
+    if (state->capacity > 1 && state->width > 1) {
+        state->step_px = (double)(state->width - 1) / (double)(state->capacity - 1);
     } else {
-        if (target_plot_w > available_w) {
-            target_plot_w = available_w;
-        }
-        if (target_plot_w < min_plot_w) {
-            target_plot_w = available_w < min_plot_w ? available_w : min_plot_w;
-        }
-        if (target_plot_w <= 0) {
-            target_plot_w = available_w;
-        }
-    }
-    if (target_plot_w <= 0) {
-        target_plot_w = min_plot_w;
-    }
-    o->plot_w = target_plot_w;
-    int plot_target_h = 80 * scale;
-    if (plot_target_h > o->h - 2 * margin) {
-        plot_target_h = o->h - 2 * margin;
-    }
-    if (plot_target_h < 48 * scale) {
-        plot_target_h = 48 * scale;
-    }
-    o->plot_h = plot_target_h;
-    osd_compute_anchor(o, o->plot_w, o->plot_h, o->plot_position, &o->plot_x, &o->plot_y);
-    osd_store_rect(&o->plot_rect, 0, 0, 0, 0);
-    osd_store_rect(&o->plot_label_rect, 0, 0, 0, 0);
-    osd_store_rect(&o->plot_stats_rect, 0, 0, 0, 0);
-
-    if (o->plot_capacity > 1 && o->plot_w > 1) {
-        o->plot_step_px = (double)(o->plot_w - 1) / (double)(o->plot_capacity - 1);
-    } else {
-        o->plot_step_px = 0.0;
+        state->step_px = 0.0;
     }
 }
 
-static void osd_plot_push(OSD *o, double value) {
-    if (o->plot_capacity <= 0) {
+static void osd_line_push(OsdLineState *state, double value) {
+    if (!state || state->capacity <= 0) {
         return;
     }
-    if (o->plot_cursor >= o->plot_capacity) {
-        o->plot_cursor = 0;
+    if (state->cursor >= state->capacity) {
+        state->cursor = 0;
     }
-    if (o->plot_cursor == 0 && o->plot_size >= o->plot_capacity) {
-        o->plot_clear_on_next_draw = 1;
-        o->plot_background_ready = 0;
-        o->plot_prev_valid = 0;
-        o->plot_size = 0;
-        o->plot_sum = 0.0;
-        o->plot_min = DBL_MAX;
-        o->plot_max = 0.0;
-        o->plot_avg = 0.0;
-        o->plot_latest = 0.0;
+    if (state->cursor == 0 && state->size >= state->capacity) {
+        state->clear_on_next_draw = 1;
+        state->background_ready = 0;
+        state->prev_valid = 0;
+        state->size = 0;
+        state->sum = 0.0;
+        state->min_v = DBL_MAX;
+        state->max_v = 0.0;
+        state->avg = 0.0;
+        state->latest = 0.0;
     }
 
-    o->plot_samples[o->plot_cursor] = value;
-    o->plot_cursor++;
-    if (o->plot_size < o->plot_cursor) {
-        o->plot_size = o->plot_cursor;
+    state->samples[state->cursor] = value;
+    state->cursor++;
+    if (state->size < state->cursor) {
+        state->size = state->cursor;
     }
-    o->plot_sum += value;
-    if (o->plot_size == 1 || value < o->plot_min) {
-        o->plot_min = value;
+    state->sum += value;
+    if (state->size == 1 || value < state->min_v) {
+        state->min_v = value;
     }
-    if (value > o->plot_max) {
-        o->plot_max = value;
+    if (value > state->max_v) {
+        state->max_v = value;
     }
-    o->plot_avg = o->plot_size > 0 ? (o->plot_sum / (double)o->plot_size) : 0.0;
-    o->plot_latest = value;
+    state->avg = state->size > 0 ? (state->sum / (double)state->size) : 0.0;
+    state->latest = value;
 }
 
 #define OSD_PLOT_RESCALE_DELAY 12
 
-static void osd_plot_compute_scale(const OSD *o, double *out_min, double *out_max) {
+static void osd_line_compute_scale(const OsdLineState *state, double *out_min, double *out_max) {
     double min_v = 0.0;
     double max_v = 1.0;
-    if (o->plot_size > 0) {
-        if (o->plot_min != DBL_MAX) {
-            min_v = o->plot_min;
+    if (state->size > 0) {
+        if (state->min_v != DBL_MAX) {
+            min_v = state->min_v;
         }
-        max_v = o->plot_max;
+        max_v = state->max_v;
         if (max_v < 0.1) {
             max_v = 0.1;
         }
@@ -507,9 +887,9 @@ static void osd_plot_compute_scale(const OSD *o, double *out_min, double *out_ma
     *out_max = max_v;
 }
 
-static int osd_plot_value_to_y(const OSD *o, double value) {
-    double min_v = o->plot_scale_min;
-    double max_v = o->plot_scale_max;
+static int osd_line_value_to_y(const OsdLineState *state, double value) {
+    double min_v = state->scale_min;
+    double max_v = state->scale_max;
     if (max_v <= min_v) {
         max_v = min_v + 0.1;
     }
@@ -520,27 +900,29 @@ static int osd_plot_value_to_y(const OSD *o, double value) {
     if (norm > 1.0) {
         norm = 1.0;
     }
-    int plot_h = o->plot_h;
-    int base_y = o->plot_y;
+    int plot_h = state->height;
+    int base_y = state->y;
     return base_y + plot_h - 1 - (int)(norm * (plot_h - 1) + 0.5);
 }
 
-static void osd_plot_draw_background(OSD *o) {
-    uint32_t bg = 0x40202020u;
+static void osd_line_draw_background(OSD *o, int idx) {
+    OsdLineState *state = &o->elements[idx].data.line;
+    const OsdLineConfig *cfg = &o->layout.elements[idx].data.line;
+    uint32_t bg = cfg->bg ? cfg->bg : 0x40202020u;
     uint32_t border = 0x60FFFFFFu;
-    uint32_t axis = 0x60FFFFFFu;
-    uint32_t grid = 0x30909090u;
+    uint32_t axis = cfg->fg ? cfg->fg : 0x60FFFFFFu;
+    uint32_t grid = cfg->grid ? cfg->grid : 0x30909090u;
 
-    osd_clear_rect(o, &o->plot_rect);
+    osd_clear_rect(o, &state->plot_rect);
 
-    int base_x = o->plot_x;
-    int base_y = o->plot_y;
-    int plot_w = o->plot_w;
-    int plot_h = o->plot_h;
+    int base_x = state->x;
+    int base_y = state->y;
+    int plot_w = state->width;
+    int plot_h = state->height;
 
     osd_fill_rect(o, base_x, base_y, plot_w, plot_h, bg);
     osd_draw_rect(o, base_x, base_y, plot_w, plot_h, border);
-    osd_store_rect(&o->plot_rect, base_x, base_y, plot_w, plot_h);
+    osd_store_rect(&state->plot_rect, base_x, base_y, plot_w, plot_h);
 
     int grid_lines = 4;
     for (int i = 1; i < grid_lines; ++i) {
@@ -549,9 +931,8 @@ static void osd_plot_draw_background(OSD *o) {
     }
 
     int desired_secs = 10;
-    double px_per_sec = (o->plot_window_seconds > 0 && plot_w > 1)
-                            ? (double)(plot_w - 1) / (double)o->plot_window_seconds
-                            : 0.0;
+    int window_seconds = cfg->window_seconds > 0 ? cfg->window_seconds : 60;
+    double px_per_sec = (window_seconds > 0 && plot_w > 1) ? (double)(plot_w - 1) / (double)window_seconds : 0.0;
     if (px_per_sec > 0.0) {
         int step_px = (int)(px_per_sec * desired_secs + 0.5);
         int scale = o->scale > 0 ? o->scale : 1;
@@ -563,19 +944,20 @@ static void osd_plot_draw_background(OSD *o) {
         }
     }
 
-    osd_draw_hline(o, base_x, base_y + plot_h - (o->scale > 0 ? o->scale : 1), plot_w, axis);
+    int axis_thickness = o->scale > 0 ? o->scale : 1;
+    osd_draw_hline(o, base_x, base_y + plot_h - axis_thickness, plot_w, axis);
     osd_draw_vline(o, base_x, base_y, plot_h, axis);
 }
 
-static void osd_plot_draw_all(OSD *o) {
-    int limit = o->plot_size;
+static void osd_line_draw_all(OSD *o, int idx, uint32_t color) {
+    OsdLineState *state = &o->elements[idx].data.line;
+    int limit = state->size;
     if (limit <= 0) {
-        o->plot_prev_valid = 0;
+        state->prev_valid = 0;
         return;
     }
-    uint32_t plot_color = 0xB0FF4040u;
-    int base_x = o->plot_x;
-    double step = o->plot_step_px;
+    int base_x = state->x;
+    double step = state->step_px;
     if (step <= 0.0) {
         step = 0.0;
     }
@@ -584,71 +966,73 @@ static void osd_plot_draw_all(OSD *o) {
     int scale = o->scale > 0 ? o->scale : 1;
 
     for (int i = 0; i < limit; ++i) {
-        double value = o->plot_samples[i];
+        double value = state->samples[i];
         int x = base_x + (int)(i * step + 0.5);
-        if (x >= base_x + o->plot_w) {
-            x = base_x + o->plot_w - 1;
+        if (x >= base_x + state->width) {
+            x = base_x + state->width - 1;
         }
-        int y = osd_plot_value_to_y(o, value);
+        int y = osd_line_value_to_y(state, value);
         if (prev_x >= 0 && x >= prev_x) {
-            osd_draw_line(o, prev_x, prev_y, x, y, plot_color);
+            osd_draw_line(o, prev_x, prev_y, x, y, color);
         }
-        osd_fill_rect(o, x, y, scale, scale, plot_color);
+        osd_fill_rect(o, x, y, scale, scale, color);
         prev_x = x;
         prev_y = y;
     }
 
     if (prev_x >= 0 && prev_y >= 0) {
-        o->plot_prev_valid = 1;
-        o->plot_prev_x = prev_x;
-        o->plot_prev_y = prev_y;
+        state->prev_valid = 1;
+        state->prev_x = prev_x;
+        state->prev_y = prev_y;
     } else {
-        o->plot_prev_valid = 0;
+        state->prev_valid = 0;
     }
 }
 
-static void osd_plot_draw_latest(OSD *o) {
-    int limit = o->plot_size;
+static void osd_line_draw_latest(OSD *o, int idx, uint32_t color) {
+    OsdLineState *state = &o->elements[idx].data.line;
+    int limit = state->size;
     if (limit <= 0) {
-        o->plot_prev_valid = 0;
+        state->prev_valid = 0;
         return;
     }
     int index = limit - 1;
-    double value = o->plot_samples[index];
-    uint32_t plot_color = 0xB0FF4040u;
-    int base_x = o->plot_x;
-    double step = o->plot_step_px;
+    double value = state->samples[index];
+    int base_x = state->x;
+    double step = state->step_px;
     int x = base_x + (int)(index * step + 0.5);
-    if (x >= base_x + o->plot_w) {
-        x = base_x + o->plot_w - 1;
+    if (x >= base_x + state->width) {
+        x = base_x + state->width - 1;
     }
-    int y = osd_plot_value_to_y(o, value);
+    int y = osd_line_value_to_y(state, value);
     int scale = o->scale > 0 ? o->scale : 1;
 
-    if (o->plot_prev_valid) {
-        osd_draw_line(o, o->plot_prev_x, o->plot_prev_y, x, y, plot_color);
+    if (state->prev_valid) {
+        osd_draw_line(o, state->prev_x, state->prev_y, x, y, color);
     }
-    osd_fill_rect(o, x, y, scale, scale, plot_color);
-    o->plot_prev_valid = 1;
-    o->plot_prev_x = x;
-    o->plot_prev_y = y;
+    osd_fill_rect(o, x, y, scale, scale, color);
+    state->prev_valid = 1;
+    state->prev_x = x;
+    state->prev_y = y;
 }
 
-static void osd_plot_draw(OSD *o) {
-    if (o->plot_capacity <= 0) {
+static void osd_line_draw(OSD *o, int idx) {
+    OsdLineState *state = &o->elements[idx].data.line;
+    const OsdLineConfig *cfg = &o->layout.elements[idx].data.line;
+    if (state->capacity <= 0) {
         return;
     }
 
-    double scale_min = o->plot_scale_min;
-    double scale_max = o->plot_scale_max;
+    double scale_min = state->scale_min;
+    double scale_max = state->scale_max;
     double new_min = scale_min;
     double new_max = scale_max;
-    osd_plot_compute_scale(o, &new_min, &new_max);
+    osd_line_compute_scale(state, &new_min, &new_max);
 
-    int need_background = (!o->plot_background_ready || o->plot_clear_on_next_draw);
-    if (o->plot_size > 0) {
-        double actual_min = (o->plot_min != DBL_MAX) ? o->plot_min : new_min;
-        double actual_max = o->plot_max;
+    int need_background = (!state->background_ready || state->clear_on_next_draw);
+    if (state->size > 0) {
+        double actual_min = (state->min_v != DBL_MAX) ? state->min_v : new_min;
+        double actual_max = state->max_v;
         if (!need_background) {
             if (actual_min < scale_min || actual_max > scale_max) {
                 need_background = 1;
@@ -658,43 +1042,46 @@ static void osd_plot_draw(OSD *o) {
                 if (span > 0.0 && used >= 0.0) {
                     double utilization = (span > 0.0) ? (used / span) : 1.0;
                     if (utilization < 0.35) {
-                        if (o->plot_rescale_countdown > 0) {
-                            o->plot_rescale_countdown--;
+                        if (state->rescale_countdown > 0) {
+                            state->rescale_countdown--;
                         } else {
                             need_background = 1;
                         }
                     } else {
-                        o->plot_rescale_countdown = OSD_PLOT_RESCALE_DELAY;
+                        state->rescale_countdown = OSD_PLOT_RESCALE_DELAY;
                     }
                 }
             }
         }
     }
 
+    uint32_t fg = cfg->fg ? cfg->fg : 0xB0FF4040u;
+
     if (need_background) {
-        osd_plot_draw_background(o);
-        o->plot_scale_min = new_min;
-        o->plot_scale_max = new_max;
-        o->plot_background_ready = 1;
-        o->plot_clear_on_next_draw = 0;
-        o->plot_prev_valid = 0;
-        o->plot_rescale_countdown = OSD_PLOT_RESCALE_DELAY;
-        osd_plot_draw_all(o);
+        osd_line_draw_background(o, idx);
+        state->scale_min = new_min;
+        state->scale_max = new_max;
+        state->background_ready = 1;
+        state->clear_on_next_draw = 0;
+        state->prev_valid = 0;
+        state->rescale_countdown = OSD_PLOT_RESCALE_DELAY;
+        osd_line_draw_all(o, idx, fg);
         return;
     }
 
-    if (o->plot_size <= 0) {
-        o->plot_prev_valid = 0;
+    if (state->size <= 0) {
+        state->prev_valid = 0;
         return;
     }
 
-    osd_plot_draw_latest(o);
+    osd_line_draw_latest(o, idx, fg);
 }
 
-static void osd_plot_draw_label(OSD *o, const char *text) {
-    osd_clear_rect(o, &o->plot_label_rect);
+static void osd_line_draw_label(OSD *o, int idx, const char *text) {
+    OsdLineState *state = &o->elements[idx].data.line;
+    osd_clear_rect(o, &state->label_rect);
     if (text == NULL || text[0] == '\0') {
-        osd_store_rect(&o->plot_label_rect, 0, 0, 0, 0);
+        osd_store_rect(&state->label_rect, 0, 0, 0, 0);
         return;
     }
     int scale = o->scale > 0 ? o->scale : 1;
@@ -703,13 +1090,13 @@ static void osd_plot_draw_label(OSD *o, const char *text) {
     int text_w = (int)strlen(text) * (8 + 1) * scale;
     int box_w = text_w + 2 * pad;
     int box_h = line_height + 2 * pad;
-    int x = o->plot_x + pad;
-    int y = o->plot_y + pad;
-    if (x + box_w > o->plot_x + o->plot_w - pad) {
-        x = o->plot_x + o->plot_w - pad - box_w;
+    int x = state->x + pad;
+    int y = state->y + pad;
+    if (x + box_w > state->x + state->width - pad) {
+        x = state->x + state->width - pad - box_w;
     }
-    if (y + box_h > o->plot_y + o->plot_h - pad) {
-        y = o->plot_y + o->plot_h - pad - box_h;
+    if (y + box_h > state->y + state->height - pad) {
+        y = state->y + state->height - pad - box_h;
     }
     if (x < o->margin_px) {
         x = o->margin_px;
@@ -723,13 +1110,14 @@ static void osd_plot_draw_label(OSD *o, const char *text) {
     osd_fill_rect(o, x, y, box_w, box_h, bg);
     osd_draw_rect(o, x, y, box_w, box_h, border);
     osd_draw_text(o, x + pad, y + pad, text, text_color, o->scale);
-    osd_store_rect(&o->plot_label_rect, x, y, box_w, box_h);
+    osd_store_rect(&state->label_rect, x, y, box_w, box_h);
 }
 
-static void osd_plot_draw_footer(OSD *o, const char **lines, int line_count) {
-    osd_clear_rect(o, &o->plot_stats_rect);
+static void osd_line_draw_footer(OSD *o, int idx, const char **lines, int line_count) {
+    OsdLineState *state = &o->elements[idx].data.line;
+    osd_clear_rect(o, &state->footer_rect);
     if (lines == NULL || line_count <= 0) {
-        osd_store_rect(&o->plot_stats_rect, 0, 0, 0, 0);
+        osd_store_rect(&state->footer_rect, 0, 0, 0, 0);
         return;
     }
     int scale = o->scale > 0 ? o->scale : 1;
@@ -747,23 +1135,26 @@ static void osd_plot_draw_footer(OSD *o, const char **lines, int line_count) {
         }
     }
     if (max_line_w <= 0) {
-        osd_store_rect(&o->plot_stats_rect, 0, 0, 0, 0);
+        osd_store_rect(&state->footer_rect, 0, 0, 0, 0);
         return;
     }
     int box_w = max_line_w + 2 * pad;
     int box_h = line_count * line_advance + 2 * pad;
-    int x = o->plot_x;
-    int y = o->plot_y + o->plot_h + scale * 4;
-    if (y + box_h > o->h - o->margin_px) {
-        y = o->plot_y + o->plot_h - box_h - scale * 4;
-        if (y < o->margin_px) {
-            y = o->margin_px;
-        }
+    int x = state->x + state->width - box_w;
+    if (x < o->margin_px) {
+        x = o->margin_px;
     }
     if (x + box_w > o->w - o->margin_px) {
         x = o->w - o->margin_px - box_w;
         if (x < o->margin_px) {
             x = o->margin_px;
+        }
+    }
+    int y = state->y + state->height + scale * 4;
+    if (y + box_h > o->h - o->margin_px) {
+        y = state->y + state->height - box_h - scale * 4;
+        if (y < o->margin_px) {
+            y = o->margin_px;
         }
     }
     uint32_t bg = 0x40202020u;
@@ -779,7 +1170,121 @@ static void osd_plot_draw_footer(OSD *o, const char **lines, int line_count) {
         osd_draw_text(o, x + pad, draw_y, lines[i], text_color, o->scale);
         draw_y += line_advance;
     }
-    osd_store_rect(&o->plot_stats_rect, x, y, box_w, box_h);
+    osd_store_rect(&state->footer_rect, x, y, box_w, box_h);
+}
+
+static void osd_render_text_element(OSD *o, int idx, const OsdRenderContext *ctx) {
+    OsdElementConfig *cfg = &o->layout.elements[idx];
+    OsdTextConfig *text_cfg = &cfg->data.text;
+    osd_clear_rect(o, &o->elements[idx].rect);
+
+    if (text_cfg->line_count <= 0) {
+        osd_store_rect(&o->elements[idx].rect, 0, 0, 0, 0);
+        return;
+    }
+
+    char lines[OSD_MAX_TEXT_LINES][OSD_TEXT_MAX_LINE_CHARS];
+    const char *line_ptrs[OSD_MAX_TEXT_LINES];
+    int actual_lines = 0;
+    for (int i = 0; i < text_cfg->line_count && i < OSD_MAX_TEXT_LINES; ++i) {
+        osd_expand_template(ctx, text_cfg->lines[i].raw, lines[actual_lines], sizeof(lines[actual_lines]));
+        line_ptrs[actual_lines] = lines[actual_lines];
+        actual_lines++;
+    }
+
+    if (actual_lines <= 0) {
+        osd_store_rect(&o->elements[idx].rect, 0, 0, 0, 0);
+        return;
+    }
+
+    int scale = o->scale > 0 ? o->scale : 1;
+    int padding = text_cfg->padding > 0 ? text_cfg->padding : 6;
+    int pad_px = padding * scale;
+    if (pad_px < 4) {
+        pad_px = 4;
+    }
+    int line_advance = (8 + 1) * scale;
+    int max_line_width = 0;
+    for (int i = 0; i < actual_lines; ++i) {
+        int len = (int)strlen(line_ptrs[i]);
+        int width = len * (8 + 1) * scale;
+        if (width > max_line_width) {
+            max_line_width = width;
+        }
+    }
+    int box_w = max_line_width + 2 * pad_px;
+    int box_h = actual_lines * line_advance + 2 * pad_px;
+
+    int draw_x = 0;
+    int draw_y = 0;
+    osd_compute_placement(o, box_w, box_h, &cfg->placement, &draw_x, &draw_y);
+
+    uint32_t fg = text_cfg->fg ? text_cfg->fg : 0xB0FFFFFFu;
+    uint32_t bg = text_cfg->bg ? text_cfg->bg : 0x40202020u;
+    uint32_t border = text_cfg->border ? text_cfg->border : 0x60FFFFFFu;
+
+    osd_fill_rect(o, draw_x, draw_y, box_w, box_h, bg);
+    osd_draw_rect(o, draw_x, draw_y, box_w, box_h, border);
+
+    int text_x = draw_x + pad_px;
+    int text_y = draw_y + pad_px;
+    for (int i = 0; i < actual_lines; ++i) {
+        osd_draw_text(o, text_x, text_y, line_ptrs[i], fg, o->scale);
+        text_y += line_advance;
+    }
+
+    osd_store_rect(&o->elements[idx].rect, draw_x, draw_y, box_w, box_h);
+    o->elements[idx].data.text.last_line_count = actual_lines;
+}
+
+static void osd_render_line_element(OSD *o, int idx, const OsdRenderContext *ctx) {
+    OsdElementConfig *elem_cfg = &o->layout.elements[idx];
+    OsdLineState *state = &o->elements[idx].data.line;
+    osd_clear_rect(o, &o->elements[idx].rect);
+
+    double value = 0.0;
+    int have_value = osd_metric_sample(ctx, elem_cfg->data.line.metric, &value);
+    if (have_value) {
+        osd_line_push(state, value);
+    }
+
+    osd_line_draw(o, idx);
+    osd_line_draw_label(o, idx, elem_cfg->data.line.label);
+
+    char footer_lines[3][128];
+    const char *footer_ptrs[3];
+    int footer_count = 0;
+
+    if (state->size > 0) {
+        char latest_buf[32];
+        char avg_buf[32];
+        double min_v = (state->min_v == DBL_MAX) ? 0.0 : state->min_v;
+        char min_buf[32];
+        char max_buf[32];
+        osd_format_metric_value(elem_cfg->data.line.metric, state->latest, latest_buf, sizeof(latest_buf));
+        osd_format_metric_value(elem_cfg->data.line.metric, state->avg, avg_buf, sizeof(avg_buf));
+        osd_format_metric_value(elem_cfg->data.line.metric, min_v, min_buf, sizeof(min_buf));
+        osd_format_metric_value(elem_cfg->data.line.metric, state->max_v, max_buf, sizeof(max_buf));
+
+        snprintf(footer_lines[footer_count], sizeof(footer_lines[footer_count]), "Latest %s  Avg %s", latest_buf, avg_buf);
+        footer_ptrs[footer_count++] = footer_lines[footer_count - 1];
+        if (footer_count < 3) {
+            snprintf(footer_lines[footer_count], sizeof(footer_lines[footer_count]), "Min %s  Max %s", min_buf, max_buf);
+            footer_ptrs[footer_count++] = footer_lines[footer_count - 1];
+        }
+        if (footer_count < 3) {
+            int window_seconds = elem_cfg->data.line.window_seconds > 0 ? elem_cfg->data.line.window_seconds : 60;
+            snprintf(footer_lines[footer_count], sizeof(footer_lines[footer_count]), "Window %ds", window_seconds);
+            footer_ptrs[footer_count++] = footer_lines[footer_count - 1];
+        }
+    } else {
+        const char *msg = ctx->have_stats && have_value ? "Collecting samples..." : "Metric unavailable";
+        snprintf(footer_lines[0], sizeof(footer_lines[0]), "%s", msg);
+        footer_ptrs[footer_count++] = footer_lines[0];
+    }
+
+    osd_line_draw_footer(o, idx, footer_ptrs, footer_count);
+    osd_store_rect(&o->elements[idx].rect, state->x, state->y, state->width, state->height);
 }
 
 typedef struct {
@@ -1159,8 +1664,20 @@ int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plan
         return -1;
     }
 
-    osd_plot_reset(o, cfg);
-    osd_store_rect(&o->text_rect, 0, 0, 0, 0);
+    o->layout = cfg->osd_layout;
+    if (o->layout.element_count > OSD_MAX_ELEMENTS) {
+        o->layout.element_count = OSD_MAX_ELEMENTS;
+    }
+    o->element_count = o->layout.element_count;
+    for (int i = 0; i < o->element_count; ++i) {
+        o->elements[i].type = o->layout.elements[i].type;
+        osd_store_rect(&o->elements[i].rect, 0, 0, 0, 0);
+        if (o->elements[i].type == OSD_WIDGET_LINE) {
+            osd_line_reset(o, cfg, i);
+        } else if (o->elements[i].type == OSD_WIDGET_TEXT) {
+            o->elements[i].data.text.last_line_count = 0;
+        }
+    }
 
     osd_clear(o, 0x00000000u);
     if (osd_commit_enable(fd, ms->crtc_id, o) != 0) {
@@ -1180,154 +1697,35 @@ void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const 
         return;
     }
 
-    int margin = o->margin_px;
-    int line_advance = (8 + 1) * o->scale;
-    uint32_t text_color = 0xB0FFFFFFu;
-    uint32_t text_bg = 0x40202020u;
-    uint32_t text_border = 0x60FFFFFFu;
-    int pad = 6 * o->scale;
-    if (pad < 4) {
-        pad = 4;
+    OsdRenderContext ctx = {
+        .cfg = cfg,
+        .ms = ms,
+        .ps = ps,
+        .audio_disabled = audio_disabled,
+        .restart_count = restart_count,
+        .have_stats = 0,
+    };
+    if (ps && pipeline_get_receiver_stats(ps, &ctx.stats) == 0) {
+        ctx.have_stats = 1;
     }
 
-    char text_lines[12][192];
-    const char *line_ptrs[12];
-    int line_count = 0;
-    char plot_lines[3][128];
-    const char *plot_line_ptrs[3];
-    int plot_line_count = 0;
-    int plot_line_cap = (int)(sizeof(plot_line_ptrs) / sizeof(plot_line_ptrs[0]));
-
-    snprintf(text_lines[line_count], sizeof(text_lines[line_count]), "HDMI %dx%d@%d plane=%d", ms->mode_w,
-             ms->mode_h, ms->mode_hz, cfg->plane_id);
-    line_ptrs[line_count] = text_lines[line_count];
-    line_count++;
-
-    snprintf(text_lines[line_count], sizeof(text_lines[line_count]), "UDP:%d PTv=%d PTa=%d lat=%dms", cfg->udp_port,
-             cfg->vid_pt, cfg->aud_pt, cfg->latency_ms);
-    line_ptrs[line_count] = text_lines[line_count];
-    line_count++;
-
-    snprintf(text_lines[line_count], sizeof(text_lines[line_count]), "Pipeline: %s restarts=%d%s",
-             ps->state == PIPELINE_RUNNING ? "RUN" : "STOP", restart_count, audio_disabled ? " audio=fakesink" : "");
-    line_ptrs[line_count] = text_lines[line_count];
-    line_count++;
-
-    UdpReceiverStats stats;
-    int have_stats = (pipeline_get_receiver_stats(ps, &stats) == 0);
-    if (have_stats) {
-        double jitter_ms = stats.jitter / 90.0;
-        double jitter_avg_ms = stats.jitter_avg / 90.0;
-        snprintf(text_lines[line_count], sizeof(text_lines[line_count]),
-                 "RTP vpkts=%llu net-loss=%llu reo=%llu dup=%llu jitter=%.2f/%.2fms br=%.2f/%.2fMbps",
-                 (unsigned long long)stats.video_packets, (unsigned long long)stats.lost_packets,
-                 (unsigned long long)stats.reordered_packets, (unsigned long long)stats.duplicate_packets, jitter_ms,
-                 jitter_avg_ms, stats.bitrate_mbps, stats.bitrate_avg_mbps);
-        line_ptrs[line_count] = text_lines[line_count];
-        line_count++;
-
-        const char *drop_reason = stats.pipeline_last_drop_reason[0] != '\0'
-                                      ? stats.pipeline_last_drop_reason
-                                      : "n/a";
-        snprintf(text_lines[line_count], sizeof(text_lines[line_count]),
-                 "Pipe drop=%llu late=%llu latency=%llu last=%s seq=%u",
-                 (unsigned long long)stats.pipeline_dropped_total,
-                 (unsigned long long)stats.pipeline_dropped_too_late,
-                 (unsigned long long)stats.pipeline_dropped_on_latency, drop_reason,
-                 stats.pipeline_last_drop_seqnum);
-        line_ptrs[line_count] = text_lines[line_count];
-        line_count++;
-
-        snprintf(text_lines[line_count], sizeof(text_lines[line_count]),
-                 "Frames=%llu incomplete=%llu last=%lluB avg=%.0fB seq=%u",
-                 (unsigned long long)stats.frame_count, (unsigned long long)stats.incomplete_frames,
-                 (unsigned long long)stats.last_frame_bytes, stats.frame_size_avg, stats.expected_sequence);
-        line_ptrs[line_count] = text_lines[line_count];
-        line_count++;
-
-        osd_plot_push(o, stats.bitrate_mbps);
-    } else {
-        snprintf(text_lines[line_count], sizeof(text_lines[line_count]), "UDP statistics unavailable");
-        line_ptrs[line_count] = text_lines[line_count];
-        line_count++;
-    }
-
-    if (o->plot_size > 0) {
-        if (plot_line_count < plot_line_cap) {
-            snprintf(plot_lines[plot_line_count], sizeof(plot_lines[plot_line_count]), "Latest %.2f Mbps  Avg %.2f",
-                     o->plot_latest, o->plot_avg);
-            plot_line_ptrs[plot_line_count] = plot_lines[plot_line_count];
-            plot_line_count++;
-        }
-        if (plot_line_count < plot_line_cap) {
-            double min_v = (o->plot_min == DBL_MAX) ? 0.0 : o->plot_min;
-            snprintf(plot_lines[plot_line_count], sizeof(plot_lines[plot_line_count]), "Min %.2f  Max %.2f",
-                     min_v, o->plot_max);
-            plot_line_ptrs[plot_line_count] = plot_lines[plot_line_count];
-            plot_line_count++;
-        }
-        if (plot_line_count < plot_line_cap) {
-            snprintf(plot_lines[plot_line_count], sizeof(plot_lines[plot_line_count]), "Window %ds", o->plot_window_seconds);
-            plot_line_ptrs[plot_line_count] = plot_lines[plot_line_count];
-            plot_line_count++;
-        }
-    } else {
-        if (plot_line_count < plot_line_cap) {
-            const char *waiting = have_stats ? "Collecting bitrate samples..." : "Bitrate stats unavailable";
-            snprintf(plot_lines[plot_line_count], sizeof(plot_lines[plot_line_count]), "%s", waiting);
-            plot_line_ptrs[plot_line_count] = plot_lines[plot_line_count];
-            plot_line_count++;
+    for (int i = 0; i < o->element_count; ++i) {
+        OsdElementType type = o->layout.elements[i].type;
+        o->elements[i].type = type;
+        switch (type) {
+        case OSD_WIDGET_TEXT:
+            osd_render_text_element(o, i, &ctx);
+            break;
+        case OSD_WIDGET_LINE:
+            osd_render_line_element(o, i, &ctx);
+            break;
+        case OSD_WIDGET_BAR:
+        default:
+            osd_clear_rect(o, &o->elements[i].rect);
+            osd_store_rect(&o->elements[i].rect, 0, 0, 0, 0);
+            break;
         }
     }
-
-    osd_clear_rect(o, &o->text_rect);
-
-    int text_box_x = margin;
-    int text_box_y = margin;
-    int max_line_width = 0;
-    for (int i = 0; i < line_count; ++i) {
-        int len = (int)strlen(line_ptrs[i]);
-        int width = len * (8 + 1) * o->scale;
-        if (width > max_line_width) {
-            max_line_width = width;
-        }
-    }
-    int text_box_w = max_line_width + 2 * pad;
-    int text_box_h = line_count * line_advance + 2 * pad;
-    if (text_box_w < 0) {
-        text_box_w = 0;
-    }
-    if (text_box_h < 0) {
-        text_box_h = 0;
-    }
-    if (text_box_x + text_box_w > o->w) {
-        text_box_w = o->w - text_box_x;
-        if (text_box_w < 0) {
-            text_box_w = 0;
-        }
-    }
-    if (text_box_y + text_box_h > o->h) {
-        text_box_h = o->h - text_box_y;
-        if (text_box_h < 0) {
-            text_box_h = 0;
-        }
-    }
-
-    if (text_box_w > 0 && text_box_h > 0) {
-        osd_fill_rect(o, text_box_x, text_box_y, text_box_w, text_box_h, text_bg);
-        osd_draw_rect(o, text_box_x, text_box_y, text_box_w, text_box_h, text_border);
-        int draw_x = text_box_x + pad;
-        int draw_y = text_box_y + pad;
-        for (int i = 0; i < line_count; ++i) {
-            osd_draw_text(o, draw_x, draw_y, line_ptrs[i], text_color, o->scale);
-            draw_y += line_advance;
-        }
-    }
-    osd_store_rect(&o->text_rect, text_box_x, text_box_y, text_box_w, text_box_h);
-
-    osd_plot_draw(o);
-    osd_plot_draw_label(o, "Mbit/s");
-    osd_plot_draw_footer(o, plot_line_ptrs, plot_line_count);
 
     osd_commit_touch(fd, o->crtc_id, o);
 }

--- a/src/osd.c
+++ b/src/osd.c
@@ -671,7 +671,7 @@ static void osd_compute_placement(const OSD *o, int rect_w, int rect_h, const Os
         x = margin;
         y = margin + (inner_h - rect_h) / 2;
         break;
-    case OSD_POS_MID_MID:
+    case OSD_POS_MID:
         x = margin + (inner_w - rect_w) / 2;
         y = margin + (inner_h - rect_h) / 2;
         break;
@@ -1267,20 +1267,24 @@ static void osd_render_line_element(OSD *o, int idx, const OsdRenderContext *ctx
         osd_format_metric_value(elem_cfg->data.line.metric, state->max_v, max_buf, sizeof(max_buf));
 
         snprintf(footer_lines[footer_count], sizeof(footer_lines[footer_count]), "Latest %s  Avg %s", latest_buf, avg_buf);
-        footer_ptrs[footer_count++] = footer_lines[footer_count - 1];
+        footer_ptrs[footer_count] = footer_lines[footer_count];
+        footer_count++;
         if (footer_count < 3) {
             snprintf(footer_lines[footer_count], sizeof(footer_lines[footer_count]), "Min %s  Max %s", min_buf, max_buf);
-            footer_ptrs[footer_count++] = footer_lines[footer_count - 1];
+            footer_ptrs[footer_count] = footer_lines[footer_count];
+            footer_count++;
         }
         if (footer_count < 3) {
             int window_seconds = elem_cfg->data.line.window_seconds > 0 ? elem_cfg->data.line.window_seconds : 60;
             snprintf(footer_lines[footer_count], sizeof(footer_lines[footer_count]), "Window %ds", window_seconds);
-            footer_ptrs[footer_count++] = footer_lines[footer_count - 1];
+            footer_ptrs[footer_count] = footer_lines[footer_count];
+            footer_count++;
         }
     } else {
         const char *msg = ctx->have_stats && have_value ? "Collecting samples..." : "Metric unavailable";
         snprintf(footer_lines[0], sizeof(footer_lines[0]), "%s", msg);
-        footer_ptrs[footer_count++] = footer_lines[0];
+        footer_ptrs[footer_count] = footer_lines[0];
+        footer_count++;
     }
 
     osd_line_draw_footer(o, idx, footer_ptrs, footer_count);

--- a/src/osd.c
+++ b/src/osd.c
@@ -1079,14 +1079,14 @@ static void osd_line_draw_background(OSD *o, int idx) {
     }
 
     int scale = o->scale > 0 ? o->scale : 1;
-    int step_px = (int)(state->step_px + 0.5);
-    if (step_px < scale) {
-        step_px = scale;
+    int marker_count = 4;
+    int marker_height = 5 * scale;
+    if (marker_height > plot_h) {
+        marker_height = plot_h;
     }
-    if (step_px > 0) {
-        for (int gx = step_px; gx < plot_w; gx += step_px) {
-            osd_draw_vline(o, base_x + gx, base_y, plot_h, grid);
-        }
+    for (int i = 1; i <= marker_count; ++i) {
+        int gx = base_x + (plot_w * i) / (marker_count + 1);
+        osd_draw_vline(o, gx, base_y + plot_h - marker_height, marker_height, grid);
     }
 
     int axis_thickness = o->scale > 0 ? o->scale : 1;

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -22,6 +22,7 @@ static void line_defaults(OsdLineConfig *cfg) {
     cfg->window_seconds = 60;
     cfg->metric[0] = '\0';
     cfg->label[0] = '\0';
+    cfg->show_info_box = 1;
     cfg->fg = 0xFFFFFFFFu;
     cfg->grid = 0x20FFFFFFu;
     cfg->bg = 0x20000000u;

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -1,0 +1,66 @@
+#include "osd_layout.h"
+
+#include <string.h>
+
+static void placement_defaults(OsdPlacement *p, OSDWidgetPosition anchor) {
+    p->anchor = anchor;
+    p->offset_x = 0;
+    p->offset_y = 0;
+}
+
+static void text_defaults(OsdTextConfig *cfg) {
+    cfg->line_count = 0;
+    cfg->padding = 6;
+    cfg->fg = 0xB0FFFFFFu;
+    cfg->bg = 0x40202020u;
+    cfg->border = 0x60FFFFFFu;
+}
+
+static void line_defaults(OsdLineConfig *cfg) {
+    cfg->width = 360;
+    cfg->height = 80;
+    cfg->window_seconds = 60;
+    cfg->metric[0] = '\0';
+    cfg->label[0] = '\0';
+    cfg->fg = 0xFFFFFFFFu;
+    cfg->grid = 0x20FFFFFFu;
+    cfg->bg = 0x20000000u;
+}
+
+void osd_layout_defaults(OsdLayout *layout) {
+    if (!layout) {
+        return;
+    }
+    memset(layout, 0, sizeof(*layout));
+
+    layout->element_count = 2;
+
+    OsdElementConfig *text = &layout->elements[0];
+    text->type = OSD_WIDGET_TEXT;
+    strncpy(text->name, "stats", sizeof(text->name) - 1);
+    placement_defaults(&text->placement, OSD_POS_TOP_LEFT);
+    text_defaults(&text->data.text);
+
+    const char *default_lines[] = {
+        "HDMI {display.mode} plane={drm.video_plane_id}",
+        "UDP:{udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms",
+        "Pipeline: {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}",
+        "RTP vpkts={udp.video_packets} net-loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets} jitter={udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms br={udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps",
+        "Pipe drop={udp.pipeline.drop_total} late={udp.pipeline.drop_too_late} latency={udp.pipeline.drop_on_latency} last={udp.pipeline.last_drop_reason} seq={udp.pipeline.last_drop_seqnum}",
+        "Frames={udp.frames.count} incomplete={udp.frames.incomplete} last={udp.frames.last_bytes}B avg={udp.frames.avg_bytes}B seq={udp.expected_sequence}"
+    };
+    for (size_t i = 0; i < sizeof(default_lines) / sizeof(default_lines[0]) && i < OSD_MAX_TEXT_LINES; ++i) {
+        strncpy(text->data.text.lines[text->data.text.line_count].raw, default_lines[i],
+                sizeof(text->data.text.lines[0].raw) - 1);
+        text->data.text.lines[text->data.text.line_count].raw[sizeof(text->data.text.lines[0].raw) - 1] = '\0';
+        text->data.text.line_count++;
+    }
+
+    OsdElementConfig *plot = &layout->elements[1];
+    plot->type = OSD_WIDGET_LINE;
+    strncpy(plot->name, "bitrate", sizeof(plot->name) - 1);
+    placement_defaults(&plot->placement, OSD_POS_BOTTOM_LEFT);
+    line_defaults(&plot->data.line);
+    strncpy(plot->data.line.metric, "udp.bitrate.latest_mbps", sizeof(plot->data.line.metric) - 1);
+    strncpy(plot->data.line.label, "Mbit/s", sizeof(plot->data.line.label) - 1);
+}

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -19,7 +19,7 @@ static void text_defaults(OsdTextConfig *cfg) {
 static void line_defaults(OsdLineConfig *cfg) {
     cfg->width = 360;
     cfg->height = 80;
-    cfg->window_seconds = 60;
+    cfg->sample_stride_px = 4;
     cfg->metric[0] = '\0';
     cfg->label[0] = '\0';
     cfg->show_info_box = 1;


### PR DESCRIPTION
## Summary
- add an INI parser to load core settings and a structured OSD layout
- refactor the OSD renderer around configurable text and line elements with token expansion and metric sampling
- document the available tokens/metrics and provide a comprehensive sample configuration file

## Testing
- make *(fails: libdrm headers are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dad3d557b0832bb3e035146e5c92ba