### PR TITLE
Split RTP streams per payload type

### DIFF
--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -18,6 +18,8 @@ typedef struct {
     GstElement *source;
     GstElement *demux;
     GstElement *video_sink;
+    GstElement *video_branch_entry;
+    GstElement *audio_branch_entry;
     GstPad *video_pad;
     GstPad *audio_pad;
     UdpReceiver *udp_receiver;

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -16,7 +16,7 @@ typedef struct {
     PipelineStateEnum state;
     GstElement *pipeline;
     GstElement *source;
-    GstElement *tee;
+    GstElement *demux;
     GstElement *video_sink;
     GstPad *video_pad;
     GstPad *audio_pad;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -131,7 +131,15 @@ static gboolean link_demux_branch(GstElement *demux, GstElement *branch, GstPad 
         return FALSE;
     }
 
-    GstPad *src_pad = gst_element_get_request_pad(demux, pad_name);
+    GstPadTemplate *pad_template =
+        gst_element_class_get_pad_template(GST_ELEMENT_GET_CLASS(demux), "src_%u");
+    if (pad_template == NULL) {
+        LOGE("Failed to get pad template for %s branch", name);
+        g_free(pad_name);
+        return FALSE;
+    }
+
+    GstPad *src_pad = gst_element_request_pad(demux, pad_template, pad_name, NULL);
     g_free(pad_name);
     if (src_pad == NULL) {
         LOGE("Failed to request demux pad for %s branch", name);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -125,7 +125,14 @@ static gboolean link_demux_branch(GstElement *demux, GstElement *branch, GstPad 
         LOGE("Invalid payload type for %s branch", name);
         return FALSE;
     }
-    GstPad *src_pad = gst_element_get_request_pad(demux, "src_%u");
+    gchar *pad_name = g_strdup_printf("src_%u", payload_type);
+    if (pad_name == NULL) {
+        LOGE("Failed to allocate pad name for %s branch", name);
+        return FALSE;
+    }
+
+    GstPad *src_pad = gst_element_get_request_pad(demux, pad_name);
+    g_free(pad_name);
     if (src_pad == NULL) {
         LOGE("Failed to request demux pad for %s branch", name);
         return FALSE;


### PR DESCRIPTION
## Summary
- replace the tee splitter with an rtp payload-type demuxer to route video and audio separately
- request payload-specific pads and keep explicit RTP caps before the jitter buffers to avoid payload mismatch
- update pipeline cleanup to release the new demux pads

## Testing
- make *(fails: missing libdrm headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0fdf8614832bb4a31eaa2934e0df