### PR TITLE
Fix audio-disabled pipeline by routing demux audio pads to fakesink

### DIFF
--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -338,17 +338,13 @@ fail:
 
 static gboolean build_audio_branch(PipelineState *ps, GstElement *pipeline, GstElement *demux, const AppCfg *cfg,
                                    int audio_disabled) {
-    if (cfg->no_audio) {
-        ps->audio_branch_entry = NULL;
-        ps->audio_pad = NULL;
-        return TRUE;
-    }
+    gboolean disable_audio_branch = cfg->no_audio || audio_disabled;
 
     GstElement *queue_start = gst_element_factory_make("queue", "audio_queue_start");
     CHECK_ELEM(queue_start, "queue");
     g_object_set(queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0, NULL);
 
-    if (audio_disabled) {
+    if (disable_audio_branch) {
         GstElement *fakesink = gst_element_factory_make("fakesink", "audio_fakesink");
         CHECK_ELEM(fakesink, "fakesink");
         g_object_set(fakesink, "sync", FALSE, NULL);


### PR DESCRIPTION
## Summary
- build the audio queue/fakesink branch whenever audio is disabled so RTP pads can still link
- treat the --no-audio flag the same as runtime audio disablement when deciding whether to create the fakesink branch

## Testing
- make *(fails: missing libdrm headers in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2c24e9c4832b8e5c96d3e12e3143