### PR TITLE
Disable ALSA clock when RTP audio is absent

### DIFF
--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -387,7 +387,7 @@ static gboolean build_audio_branch(PipelineState *ps, GstElement *pipeline, GstE
     gst_caps_unref(caps_rtp_cfg);
     gst_caps_unref(caps_raw_cfg);
     g_object_set(queue_sink, "leaky", 2, NULL);
-    g_object_set(alsa, "device", cfg->aud_dev, "sync", FALSE, NULL);
+    g_object_set(alsa, "device", cfg->aud_dev, "sync", FALSE, "provide-clock", FALSE, NULL);
 
     gst_bin_add_many(GST_BIN(pipeline), queue_start, caps_rtp, jitter, depay, decoder, aconv, ares, caps_raw,
                      queue_sink, alsa, NULL);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -575,6 +575,12 @@ int pipeline_start(const AppCfg *cfg, int audio_disabled, PipelineState *ps) {
 
     GstElement *pipeline = gst_pipeline_new("pixelpilot-pipeline");
     CHECK_ELEM(pipeline, "pipeline");
+
+    GstClock *clock = gst_system_clock_obtain();
+    gst_pipeline_use_clock(GST_PIPELINE(pipeline), clock);
+    gst_element_set_start_time(pipeline, GST_CLOCK_TIME_NONE);
+    gst_object_unref(clock);
+
     ps->pipeline = pipeline;
     ps->source = NULL;
     ps->demux = NULL;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -48,13 +48,13 @@ static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiv
     }
 
     g_object_set(appsrc_elem, "is-live", TRUE, "format", GST_FORMAT_TIME, "stream-type",
-                 GST_APP_STREAM_TYPE_STREAM, "max-bytes", (guint64)(4 * 1024 * 1024), NULL);
+                 GST_APP_STREAM_TYPE_STREAM, "max-bytes", (guint64)(4 * 1024 * 1024),
+                 "do-timestamp", TRUE, NULL);
 
     GstAppSrc *appsrc = GST_APP_SRC(appsrc_elem);
     gst_app_src_set_caps(appsrc, caps);
     gst_caps_unref(caps);
     caps = NULL;
-    gst_app_src_set_do_timestamp(appsrc, TRUE);
     gst_app_src_set_latency(appsrc, 0, 0);
     gst_app_src_set_max_bytes(appsrc, 4 * 1024 * 1024);
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -47,13 +47,14 @@ static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiv
         goto fail;
     }
 
-    g_object_set(appsrc_elem, "is-live", TRUE, "format", GST_FORMAT_BYTES, "stream-type",
+    g_object_set(appsrc_elem, "is-live", TRUE, "format", GST_FORMAT_TIME, "stream-type",
                  GST_APP_STREAM_TYPE_STREAM, "max-bytes", (guint64)(4 * 1024 * 1024), NULL);
 
     GstAppSrc *appsrc = GST_APP_SRC(appsrc_elem);
     gst_app_src_set_caps(appsrc, caps);
     gst_caps_unref(caps);
     caps = NULL;
+    gst_app_src_set_do_timestamp(appsrc, TRUE);
     gst_app_src_set_latency(appsrc, 0, 0);
     gst_app_src_set_max_bytes(appsrc, 4 * 1024 * 1024);
 


### PR DESCRIPTION
## Summary
- stop the ALSA sink from providing the pipeline clock so video keeps advancing when no audio packets arrive

## Testing
- make *(fails: missing libdrm headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc32ec07b4832ba30041b870d1a922