### PR TITLE
Add splash screen video fallback for idle pipeline

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -43,6 +43,9 @@ typedef struct {
 
     int gst_log;
 
+    int splash_enable;
+    char splash_path[PATH_MAX];
+
     int cpu_affinity_present;
     cpu_set_t cpu_affinity_mask;
     int cpu_affinity_order[CPU_SETSIZE];

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -27,6 +27,9 @@ typedef struct {
     GstElement *splash_decode;
     GstElement *splash_convert;
     GstElement *splash_queue;
+    gboolean sink_sync_active;
+    gboolean have_video_ssrc;
+    guint32 video_ssrc;
     GstPad *video_pad;
     GstPad *audio_pad;
     UdpReceiver *udp_receiver;

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -20,6 +20,13 @@ typedef struct {
     GstElement *video_sink;
     GstElement *video_branch_entry;
     GstElement *audio_branch_entry;
+    GstElement *video_selector;
+    GstPad *selector_network_pad;
+    GstPad *selector_splash_pad;
+    GstElement *splash_bin;
+    GstElement *splash_decode;
+    GstElement *splash_convert;
+    GstElement *splash_queue;
     GstPad *video_pad;
     GstPad *audio_pad;
     UdpReceiver *udp_receiver;
@@ -31,6 +38,7 @@ typedef struct {
     gboolean stop_requested;
     gboolean encountered_error;
     int audio_disabled;
+    gboolean splash_enabled;
     const AppCfg *cfg;
     int bus_thread_cpu_slot;
 } PipelineState;

--- a/src/config.c
+++ b/src/config.c
@@ -37,6 +37,8 @@ static void usage(const char *prog) {
             "  --osd-plane-id N             (force OSD plane id; default auto)\n"
             "  --osd-refresh-ms N           (default: 500)\n"
             "  --gst-log                    (set GST_DEBUG=3 if not set)\n"
+            "  --splash PATH                (enable splash screen playback from PATH)\n"
+            "  --no-splash                  (disable splash screen playback)\n"
             "  --cpu-list LIST              (comma-separated CPU IDs for affinity)\n"
             "  --verbose\n",
             prog);
@@ -74,6 +76,9 @@ void cfg_defaults(AppCfg *c) {
     c->osd_refresh_ms = 500;
 
     c->gst_log = 0;
+
+    c->splash_enable = 0;
+    c->splash_path[0] = '\0';
 
     c->cpu_affinity_present = 0;
     CPU_ZERO(&c->cpu_affinity_mask);
@@ -233,6 +238,14 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->osd_refresh_ms = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--gst-log")) {
             cfg->gst_log = 1;
+        } else if (!strcmp(argv[i], "--splash") && i + 1 < argc) {
+            cfg->splash_enable = 1;
+            cli_copy_string(cfg->splash_path, sizeof(cfg->splash_path), argv[++i]);
+        } else if (!strcmp(argv[i], "--splash-path") && i + 1 < argc) {
+            cli_copy_string(cfg->splash_path, sizeof(cfg->splash_path), argv[++i]);
+        } else if (!strcmp(argv[i], "--no-splash")) {
+            cfg->splash_enable = 0;
+            cfg->splash_path[0] = '\0';
         } else if (!strcmp(argv[i], "--cpu-list") && i + 1 < argc) {
             if (cfg_parse_cpu_list(argv[++i], cfg) != 0) {
                 return -1;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -729,6 +729,33 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "splash") == 0) {
+        if (strcasecmp(key, "enable") == 0 || strcasecmp(key, "splashscreen") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->splash_enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "path") == 0 || strcasecmp(key, "file") == 0 || strcasecmp(key, "video") == 0) {
+            ini_copy_string(cfg->splash_path, sizeof(cfg->splash_path), value);
+            return 0;
+        }
+        return -1;
+    }
+    if ((section == NULL || *section == '\0') && strcasecmp(key, "splashscreen") == 0) {
+        int v = 0;
+        if (parse_bool(value, &v) != 0) {
+            return -1;
+        }
+        cfg->splash_enable = v;
+        return 0;
+    }
+    if ((section == NULL || *section == '\0') && (strcasecmp(key, "splash-path") == 0 || strcasecmp(key, "splash") == 0)) {
+        ini_copy_string(cfg->splash_path, sizeof(cfg->splash_path), value);
+        return 0;
+    }
     if (strcasecmp(section, "cpu") == 0) {
         if (strcasecmp(key, "affinity") == 0) {
             return cfg_parse_cpu_list(value, cfg);


### PR DESCRIPTION
## Summary
- add configuration fields and CLI/INI parsing to enable a splash screen video
- extend the pipeline with an input-selector splash branch that loops a local file when no stream is present
- ensure selector switching and EOS handling keep the splash video running without interrupting live playback

## Testing
- make *(fails in container: missing libdrm/drm.h)*

------
https://chatgpt.com/codex/tasks/task_e_68dec4bb237c832bbb3fae6775880daf