### PR TITLE
Add RTSP splash fallback option

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -20,6 +20,10 @@ typedef struct {
 
     int udp_port;
     int udp_fallback_port;
+    int splash_rtsp_enable;
+    char splash_rtsp_url[256];
+    int splash_rtsp_latency_ms;
+    char splash_rtsp_protocols[32];
     int vid_pt;
     int aud_pt;
     int latency_ms;

--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,8 @@
 
 #include "osd_layout.h"
 
+#define DEFAULT_SPLASH_RTSP_URL "rtsp://127.0.0.1:8554/splash"
+
 #ifndef CPU_SETSIZE
 #define CPU_SETSIZE ((int)(sizeof(cpu_set_t) * CHAR_BIT))
 #endif

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -59,7 +59,7 @@ typedef struct {
 
 typedef struct UdpReceiver UdpReceiver;
 
-UdpReceiver *udp_receiver_create(int udp_port, int fallback_port, int vid_pt, int aud_pt, GstAppSrc *appsrc);
+UdpReceiver *udp_receiver_create(const AppCfg *cfg, GstAppSrc *appsrc);
 int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);

--- a/src/config.c
+++ b/src/config.c
@@ -20,6 +20,11 @@ static void usage(const char *prog) {
             "  --config PATH                (load settings from ini file)\n"
             "  --udp-port N                 (default: 5600)\n"
             "  --udp-fallback-port N        (default: 5601)\n"
+            "  --splash-rtsp                (enable RTSP splash fallback)\n"
+            "  --no-splash-rtsp             (disable RTSP splash fallback)\n"
+            "  --splash-rtsp-url URL        (RTSP URL for splash fallback)\n"
+            "  --splash-rtsp-latency N      (latency ms for RTSP splash; default: 100)\n"
+            "  --splash-rtsp-protocols STR  (RTSP protocols: udp|tcp|any; default: udp)\n"
             "  --vid-pt N                   (default: 97 H265)\n"
             "  --aud-pt N                   (default: 98 Opus)\n"
             "  --latency-ms N               (default: 8)\n"
@@ -53,6 +58,10 @@ void cfg_defaults(AppCfg *c) {
 
     c->udp_port = 5600;
     c->udp_fallback_port = 5601;
+    c->splash_rtsp_enable = 0;
+    c->splash_rtsp_url[0] = '\0';
+    c->splash_rtsp_latency_ms = 100;
+    strcpy(c->splash_rtsp_protocols, "udp");
     c->vid_pt = 97;
     c->aud_pt = 98;
     c->latency_ms = 8;
@@ -201,6 +210,16 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->udp_port = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--udp-fallback-port") && i + 1 < argc) {
             cfg->udp_fallback_port = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--splash-rtsp")) {
+            cfg->splash_rtsp_enable = 1;
+        } else if (!strcmp(argv[i], "--no-splash-rtsp")) {
+            cfg->splash_rtsp_enable = 0;
+        } else if (!strcmp(argv[i], "--splash-rtsp-url") && i + 1 < argc) {
+            cli_copy_string(cfg->splash_rtsp_url, sizeof(cfg->splash_rtsp_url), argv[++i]);
+        } else if (!strcmp(argv[i], "--splash-rtsp-latency") && i + 1 < argc) {
+            cfg->splash_rtsp_latency_ms = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--splash-rtsp-protocols") && i + 1 < argc) {
+            cli_copy_string(cfg->splash_rtsp_protocols, sizeof(cfg->splash_rtsp_protocols), argv[++i]);
         } else if (!strcmp(argv[i], "--vid-pt") && i + 1 < argc) {
             cfg->vid_pt = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--aud-pt") && i + 1 < argc) {

--- a/src/config.c
+++ b/src/config.c
@@ -22,7 +22,7 @@ static void usage(const char *prog) {
             "  --udp-fallback-port N        (default: 5601)\n"
             "  --splash-rtsp                (enable RTSP splash fallback)\n"
             "  --no-splash-rtsp             (disable RTSP splash fallback)\n"
-            "  --splash-rtsp-url URL        (RTSP URL for splash fallback)\n"
+            "  --splash-rtsp-url URL        (RTSP URL for splash fallback; default: %s)\n"
             "  --splash-rtsp-latency N      (latency ms for RTSP splash; default: 100)\n"
             "  --splash-rtsp-protocols STR  (RTSP protocols: udp|tcp|any; default: udp)\n"
             "  --vid-pt N                   (default: 97 H265)\n"
@@ -45,7 +45,7 @@ static void usage(const char *prog) {
             "  --gst-log                    (set GST_DEBUG=3 if not set)\n"
             "  --cpu-list LIST              (comma-separated CPU IDs for affinity)\n"
             "  --verbose\n",
-            prog);
+            prog, DEFAULT_SPLASH_RTSP_URL);
 }
 
 void cfg_defaults(AppCfg *c) {
@@ -59,7 +59,7 @@ void cfg_defaults(AppCfg *c) {
     c->udp_port = 5600;
     c->udp_fallback_port = 5601;
     c->splash_rtsp_enable = 0;
-    c->splash_rtsp_url[0] = '\0';
+    strcpy(c->splash_rtsp_url, DEFAULT_SPLASH_RTSP_URL);
     c->splash_rtsp_latency_ms = 100;
     strcpy(c->splash_rtsp_protocols, "udp");
     c->vid_pt = 97;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -624,12 +624,48 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->udp_fallback_port = atoi(value);
             return 0;
         }
+        if (strcasecmp(key, "splash-rtsp") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->splash_rtsp_enable = v;
+            return 0;
+        }
         if (strcasecmp(key, "video-pt") == 0) {
             cfg->vid_pt = atoi(value);
             return 0;
         }
         if (strcasecmp(key, "audio-pt") == 0) {
             cfg->aud_pt = atoi(value);
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "splash") == 0) {
+        if (strcasecmp(key, "rtsp-enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->splash_rtsp_enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "rtsp-url") == 0) {
+            ini_copy_string(cfg->splash_rtsp_url, sizeof(cfg->splash_rtsp_url), value);
+            return 0;
+        }
+        if (strcasecmp(key, "rtsp-latency-ms") == 0) {
+            cfg->splash_rtsp_latency_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "rtsp-protocols") == 0) {
+            ini_copy_string(cfg->splash_rtsp_protocols, sizeof(cfg->splash_rtsp_protocols), value);
+            return 0;
+        }
+        if (strcasecmp(key, "url") == 0) {
+            ini_copy_string(cfg->splash_rtsp_url, sizeof(cfg->splash_rtsp_url), value);
+            cfg->splash_rtsp_enable = 1;
             return 0;
         }
         return -1;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -85,7 +85,7 @@ static GstElement *create_udp_app_source(const AppCfg *cfg, UdpReceiver **receiv
     gst_app_src_set_latency(appsrc, 0, 0);
     gst_app_src_set_max_bytes(appsrc, 4 * 1024 * 1024);
 
-    receiver = udp_receiver_create(cfg->udp_port, cfg->udp_fallback_port, cfg->vid_pt, cfg->aud_pt, appsrc);
+    receiver = udp_receiver_create(cfg, appsrc);
     if (receiver == NULL) {
         LOGE("Failed to create UDP receiver");
         goto fail;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -975,10 +975,13 @@ UdpReceiver *udp_receiver_create(const AppCfg *cfg, GstAppSrc *appsrc) {
     ur->rtsp_pad = NULL;
     ur->rtsp_pad_linked = FALSE;
 
-    if (cfg->splash_rtsp_enable && cfg->splash_rtsp_url[0] != '\0') {
+    if (cfg->splash_rtsp_enable) {
+        const char *rtsp_url = cfg->splash_rtsp_url[0] != '\0'
+                                   ? cfg->splash_rtsp_url
+                                   : DEFAULT_SPLASH_RTSP_URL;
         ur->fallback_mode = FALLBACK_RTSP;
         ur->fallback_enabled = TRUE;
-        g_strlcpy(ur->rtsp_location, cfg->splash_rtsp_url, sizeof(ur->rtsp_location));
+        g_strlcpy(ur->rtsp_location, rtsp_url, sizeof(ur->rtsp_location));
     } else if (cfg->udp_fallback_port > 0 && cfg->udp_fallback_port != cfg->udp_port) {
         ur->fallback_mode = FALLBACK_UDP_PORT;
         ur->fallback_enabled = TRUE;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -24,6 +24,7 @@
 
 #include <gst/app/gstappsrc.h>
 #include <gst/app/gstappsink.h>
+#include <gst/rtsp/gstrtspdefs.h>
 #include <gst/rtsp/gstrtsptransport.h>
 #include <gst/gstbuffer.h>
 #include <gst/gstbufferpool.h>
@@ -343,7 +344,8 @@ static gboolean rtsp_pipeline_start(struct UdpReceiver *ur, guint64 now_ns) {
     }
 
     g_object_set(src, "location", ur->rtsp_location, "latency", ur->rtsp_latency_ms, "protocols",
-                 ur->rtsp_protocols, NULL);
+                 ur->rtsp_protocols, "do-rtsp-keep-alive", TRUE, "keep-alive",
+                 GST_RTSP_KEEP_ALIVE_OPTIONS, NULL);
     g_object_set(queue, "leaky", 2, "max-size-buffers", 16, "max-size-bytes", (guint64)0,
                  "max-size-time", (guint64)0, NULL);
     g_object_set(sink, "emit-signals", FALSE, "sync", FALSE, "max-buffers", 8, "drop", TRUE, NULL);

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -25,10 +25,11 @@
 #include <gst/app/gstappsrc.h>
 #include <gst/app/gstappsink.h>
 #include <gst/rtsp/gstrtspdefs.h>
-#include <gst/rtsp/gstrtpsrc.h>
 #include <gst/rtsp/gstrtsptransport.h>
 #include <gst/gstbuffer.h>
 #include <gst/gstbufferpool.h>
+
+typedef struct _GstRTSPSrc GstRTSPSrc;
 
 #define RTP_MIN_HEADER 12
 #define FRAME_EWMA_ALPHA 0.1


### PR DESCRIPTION
## Summary
- add RTSP splash fallback configuration options to the app configuration struct, CLI parsing, and INI loader
- update the pipeline to pass the full configuration into the UDP receiver factory
- extend the UDP receiver to handle RTSP splash fallback connections with retry logic and clean shutdown

## Testing
- make *(fails: missing libdrm/drm.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e09c5137c4832bbc4a3a82d1a5987c