### PR TITLE
Optimize OSD plane commit path

### DIFF
--- a/include/osd.h
+++ b/include/osd.h
@@ -81,6 +81,7 @@ typedef struct {
 typedef struct OSD {
     int enabled;
     int active;
+    int plane_attached;
     uint32_t requested_plane_id;
     uint32_t plane_id;
     struct DumbFB fb;


### PR DESCRIPTION
## Summary
- track whether the OSD plane is attached so refresh commits only update the framebuffer ID when possible
- issue non-blocking atomic commits for OSD refreshes and retry with a blocking commit when the driver rejects the fast path
- clear the attachment flag on failures so the next refresh forces a full plane reattach and log the error for easier diagnosis

## Testing
- make *(fails: missing libdrm headers in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e112df34ec832b9ebe796c93a6bb15