### PR TITLE
Add spinner asset unpacking to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,27 @@ SRC := $(wildcard src/*.c)
 OBJ := $(SRC:.c=.o)
 TARGET := pixelpilot_mini_rk
 
-all: $(TARGET)
+SPINNER_ZIP ?= spinner_h256.zip
+SPINNER_DIR ?= spinner_h256
+
+all: $(TARGET) unpack_spinner
 
 $(TARGET): $(OBJ)
 	$(CC) $(OBJ) -o $@ $(LDFLAGS)
+
+unpack_spinner: $(TARGET)
+	@if [ -f $(SPINNER_ZIP) ]; then \
+		echo "Unpacking $(SPINNER_ZIP) into $(CURDIR)"; \
+		unzip -o $(SPINNER_ZIP) -d $(CURDIR); \
+	else \
+		echo "spinner archive '$(SPINNER_ZIP)' not found; skipping unpack."; \
+	fi
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJ) $(TARGET)
+	rm -rf $(SPINNER_DIR)
 
-.PHONY: all clean
+.PHONY: all clean unpack_spinner


### PR DESCRIPTION
## Summary
- add configurable spinner asset variables to the Makefile
- unpack the spinner archive alongside the binary whenever the build runs
- remove the extracted spinner directory as part of `make clean`

## Testing
- `make clean`
- `make` *(fails: missing libdrm/drm.h header in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e133d158b4832baa2ce15257c2ca11