### PR TITLE
Integrate hardware decoder pipeline with Rockchip MPP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PKG_DRMCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags libdrm libudev)
 PKG_DRMLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs libdrm libudev)
 PKG_GSTCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0)
 PKG_GSTLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0)
+PKG_MPPCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags rockchip-mpp)
+PKG_MPPLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs rockchip-mpp)
 
 CFLAGS ?= -O2 -Wall
 CFLAGS += -Iinclude
@@ -17,6 +19,12 @@ ifneq ($(strip $(PKG_GSTCFLAGS)),)
 CFLAGS += $(PKG_GSTCFLAGS)
 endif
 
+ifneq ($(strip $(PKG_MPPCFLAGS)),)
+CFLAGS += $(PKG_MPPCFLAGS)
+else
+CFLAGS += -I/usr/include/rockchip
+endif
+
 ifneq ($(strip $(PKG_DRMLIBS)),)
 LDFLAGS += $(PKG_DRMLIBS)
 else
@@ -27,6 +35,12 @@ ifneq ($(strip $(PKG_GSTLIBS)),)
 LDFLAGS += $(PKG_GSTLIBS)
 else
 LDFLAGS += -lgstreamer-1.0 -lgstvideo-1.0 -lgstapp-1.0 -lgobject-2.0 -lglib-2.0
+endif
+
+ifneq ($(strip $(PKG_MPPLIBS)),)
+LDFLAGS += $(PKG_MPPLIBS)
+else
+LDFLAGS += -lrockchip_mpp
 endif
 
 LDFLAGS += -lpthread

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -5,6 +5,7 @@
 #include <gst/gst.h>
 
 #include "udp_receiver.h"
+#include "video_decoder.h"
 
 typedef enum {
     PIPELINE_STOPPED = 0,
@@ -24,6 +25,7 @@ typedef struct {
     GstPad *audio_pad;
     UdpReceiver *udp_receiver;
     GThread *bus_thread;
+    GThread *appsink_thread;
     GMutex lock;
     GCond cond;
     gboolean initialized;
@@ -33,11 +35,15 @@ typedef struct {
     int audio_disabled;
     const AppCfg *cfg;
     int bus_thread_cpu_slot;
+    gboolean appsink_thread_running;
+    VideoDecoder decoder;
+    gboolean decoder_initialized;
+    gboolean decoder_running;
 } PipelineState;
 
 #include "config.h"
 
-int pipeline_start(const AppCfg *cfg, int audio_disabled, PipelineState *ps);
+int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int audio_disabled, PipelineState *ps);
 void pipeline_stop(PipelineState *ps, int wait_ms_total);
 void pipeline_poll_child(PipelineState *ps);
 int pipeline_get_receiver_stats(const PipelineState *ps, UdpReceiverStats *stats);

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -36,7 +36,7 @@ typedef struct {
     const AppCfg *cfg;
     int bus_thread_cpu_slot;
     gboolean appsink_thread_running;
-    VideoDecoder decoder;
+    VideoDecoder *decoder;
     gboolean decoder_initialized;
     gboolean decoder_running;
 } PipelineState;

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -1,0 +1,24 @@
+#ifndef VIDEO_DECODER_H
+#define VIDEO_DECODER_H
+
+#include <glib.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "config.h"
+#include "drm_modeset.h"
+
+typedef struct VideoDecoder VideoDecoder;
+
+int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult *ms, int drm_fd);
+void video_decoder_deinit(VideoDecoder *vd);
+
+int video_decoder_start(VideoDecoder *vd);
+void video_decoder_stop(VideoDecoder *vd);
+
+int video_decoder_feed(VideoDecoder *vd, const guint8 *data, size_t size);
+void video_decoder_send_eos(VideoDecoder *vd);
+
+size_t video_decoder_max_packet_size(const VideoDecoder *vd);
+
+#endif // VIDEO_DECODER_H

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -10,6 +10,9 @@
 
 typedef struct VideoDecoder VideoDecoder;
 
+VideoDecoder *video_decoder_new(void);
+void video_decoder_free(VideoDecoder *vd);
+
 int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult *ms, int drm_fd);
 void video_decoder_deinit(VideoDecoder *vd);
 

--- a/src/drm_fb.c
+++ b/src/drm_fb.c
@@ -8,8 +8,24 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 
+#if defined(__has_include)
+#if __has_include(<libdrm/drm.h>)
 #include <libdrm/drm.h>
-#include <drm_fourcc.h>
+#else
+#include <drm/drm.h>
+#endif
+#else
+#include <libdrm/drm.h>
+#endif
+#if defined(__has_include)
+#if __has_include(<libdrm/drm_fourcc.h>)
+#include <libdrm/drm_fourcc.h>
+#else
+#include <drm/drm_fourcc.h>
+#endif
+#else
+#include <drm/drm_fourcc.h>
+#endif
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 

--- a/src/drm_modeset.c
+++ b/src/drm_modeset.c
@@ -8,8 +8,21 @@
 #include <string.h>
 #include <unistd.h>
 
+#if defined(__has_include)
+#if __has_include(<libdrm/drm.h>)
+#include <libdrm/drm.h>
+#else
+#include <drm/drm.h>
+#endif
+#if __has_include(<libdrm/drm_fourcc.h>)
+#include <libdrm/drm_fourcc.h>
+#else
+#include <drm/drm_fourcc.h>
+#endif
+#else
 #include <libdrm/drm.h>
 #include <libdrm/drm_fourcc.h>
+#endif
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
             } else {
                 pipeline_set_receiver_stats_enabled(&ps, FALSE);
             }
-            if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
+            if (pipeline_start(&cfg, &ms, fd, audio_disabled, &ps) != 0) {
                 LOGE("Failed to start pipeline");
                 pipeline_set_receiver_stats_enabled(&ps, FALSE);
             } else {
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
                             if (ps.state != PIPELINE_STOPPED) {
                                 pipeline_stop(&ps, 700);
                             }
-                            if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
+                            if (pipeline_start(&cfg, &ms, fd, audio_disabled, &ps) != 0) {
                                 LOGE("Failed to start pipeline after hotplug");
                                 pipeline_set_receiver_stats_enabled(&ps, FALSE);
                             } else {
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
                 LOGW("Audio device likely busy; switching audio branch to fakesink to avoid restart loop.");
             }
             LOGW("Pipeline not running; restarting%s...", audio_disabled ? " (audio=fakesink)" : "");
-            if (pipeline_start(&cfg, audio_disabled, &ps) != 0) {
+            if (pipeline_start(&cfg, &ms, fd, audio_disabled, &ps) != 0) {
                 LOGE("Restart failed");
                 pipeline_set_receiver_stats_enabled(&ps, FALSE);
             } else {

--- a/src/osd.c
+++ b/src/osd.c
@@ -11,7 +11,15 @@
 #include <float.h>
 #include <ctype.h>
 
+#if defined(__has_include)
+#if __has_include(<libdrm/drm_fourcc.h>)
 #include <libdrm/drm_fourcc.h>
+#else
+#include <drm/drm_fourcc.h>
+#endif
+#else
+#include <libdrm/drm_fourcc.h>
+#endif
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -357,7 +357,7 @@ static GParamSpec *find_property_with_aliases(GObjectClass *klass, const char *p
 
     for (guint i = 0; i < n_props; ++i) {
         const char *name = props[i]->name;
-        const char *nick = props[i]->nick;
+        const char *nick = g_param_spec_get_nick(props[i]);
         if ((name != NULL && (enum_matches_string(name, property) || enum_matches_string(property, name))) ||
             (nick != NULL && (enum_matches_string(nick, property) || enum_matches_string(property, nick)))) {
             pspec = props[i];

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -134,6 +134,8 @@ static GstElement *create_udp_source(const AppCfg *cfg, gboolean video_only, Udp
     return create_udp_app_source(cfg, video_only, receiver_out);
 }
 
+static gboolean set_enum_property_by_nick(GObject *object, const char *property, const char *nick);
+
 static gboolean setup_gst_udpsrc_pipeline(PipelineState *ps, const AppCfg *cfg) {
     if (ps == NULL || cfg == NULL) {
         return FALSE;
@@ -477,13 +479,11 @@ static gboolean set_enum_property_by_nick(GObject *object, const char *property,
     }
 
     gboolean success = FALSE;
-    const GEnumValue *target_value = NULL;
     for (gint i = 0; i < enum_class->n_values; ++i) {
         const GEnumValue *value = &enum_class->values[i];
         if ((value->value_name != NULL && enum_matches_string(value->value_name, nick)) ||
             (value->value_nick != NULL && enum_matches_string(value->value_nick, nick))) {
             g_object_set(object, canon_property, value->value, NULL);
-            target_value = value;
             success = TRUE;
             break;
         }

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -1,0 +1,577 @@
+#include "video_decoder.h"
+
+#include "drm_props.h"
+#include "logging.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <gst/gst.h>
+#include <rockchip/rk_mpi.h>
+
+#include <drm_fourcc.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#define DECODER_READ_BUF_SIZE (1024 * 1024)
+#define DECODER_MAX_FRAMES 24
+
+struct FrameSlot {
+    int prime_fd;
+    uint32_t fb_id;
+    uint32_t handle;
+};
+
+struct VideoDecoder {
+    gboolean initialized;
+    gboolean running;
+    gboolean frame_thread_running;
+    gboolean display_thread_running;
+    gboolean eos_received;
+    gboolean lock_initialized;
+    gboolean cond_initialized;
+
+    int drm_fd;
+    uint32_t plane_id;
+    uint32_t crtc_id;
+    int mode_w;
+    int mode_h;
+    uint32_t src_w;
+    uint32_t src_h;
+
+    uint32_t prop_fb_id;
+    uint32_t prop_crtc_id;
+    uint32_t prop_crtc_x;
+    uint32_t prop_crtc_y;
+    uint32_t prop_crtc_w;
+    uint32_t prop_crtc_h;
+    uint32_t prop_src_x;
+    uint32_t prop_src_y;
+    uint32_t prop_src_w;
+    uint32_t prop_src_h;
+
+    MppCtx ctx;
+    MppApi *mpi;
+    MppBufferGroup frm_grp;
+    struct FrameSlot frame_map[DECODER_MAX_FRAMES];
+
+    guint8 *packet_buf;
+    size_t packet_buf_size;
+    MppPacket packet;
+
+    GMutex lock;
+    GCond cond;
+    uint32_t pending_fb;
+    uint64_t pending_pts;
+
+    GThread *frame_thread;
+    GThread *display_thread;
+};
+
+static inline guint64 get_time_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (guint64)ts.tv_sec * 1000ull + ts.tv_nsec / 1000000ull;
+}
+
+static void reset_frame_map(VideoDecoder *vd) {
+    for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
+        vd->frame_map[i].prime_fd = -1;
+        vd->frame_map[i].fb_id = 0;
+        vd->frame_map[i].handle = 0;
+    }
+}
+
+static void release_frame_group(VideoDecoder *vd) {
+    if (vd->frm_grp == NULL) {
+        return;
+    }
+    for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
+        if (vd->frame_map[i].fb_id) {
+            drmModeRmFB(vd->drm_fd, vd->frame_map[i].fb_id);
+            vd->frame_map[i].fb_id = 0;
+        }
+        if (vd->frame_map[i].prime_fd >= 0) {
+            close(vd->frame_map[i].prime_fd);
+            vd->frame_map[i].prime_fd = -1;
+        }
+        if (vd->frame_map[i].handle) {
+            struct drm_mode_destroy_dumb dmd = {.handle = vd->frame_map[i].handle};
+            ioctl(vd->drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dmd);
+            vd->frame_map[i].handle = 0;
+        }
+    }
+    mpp_buffer_group_clear(vd->frm_grp);
+    mpp_buffer_group_put(vd->frm_grp);
+    vd->frm_grp = NULL;
+    vd->src_w = 0;
+    vd->src_h = 0;
+}
+
+static void set_control_verbose(MppApi *mpi, MppCtx ctx, MpiCmd control, RK_U32 enable) {
+    RK_U32 res = mpi->control(ctx, control, &enable);
+    if (res) {
+        LOGW("MPP: control %d -> %u failed (%u)", control, enable, res);
+    }
+}
+
+static void set_mpp_decoding_parameters(VideoDecoder *vd) {
+    MppDecCfg cfg = NULL;
+    if (mpp_dec_cfg_init(&cfg) != MPP_OK) {
+        LOGW("MPP: mpp_dec_cfg_init failed");
+        return;
+    }
+
+    if (vd->mpi->control(vd->ctx, MPP_DEC_GET_CFG, cfg) != MPP_OK) {
+        LOGW("MPP: GET_CFG failed");
+        mpp_dec_cfg_deinit(cfg);
+        return;
+    }
+
+    if (mpp_dec_cfg_set_u32(cfg, "base:split_parse", 1) != MPP_OK) {
+        LOGW("MPP: failed to enable split_parse");
+    }
+
+    if (vd->mpi->control(vd->ctx, MPP_DEC_SET_CFG, cfg) != MPP_OK) {
+        LOGW("MPP: SET_CFG failed");
+    }
+
+    mpp_dec_cfg_deinit(cfg);
+
+    set_control_verbose(vd->mpi, vd->ctx, MPP_DEC_SET_DISABLE_ERROR, 0xffff);
+    set_control_verbose(vd->mpi, vd->ctx, MPP_DEC_SET_IMMEDIATE_OUT, 0xffff);
+    set_control_verbose(vd->mpi, vd->ctx, MPP_DEC_SET_ENABLE_FAST_PLAY, 0xffff);
+    set_control_verbose(vd->mpi, vd->ctx, MPP_DEC_SET_PARSER_SPLIT_MODE, 0);
+}
+
+static int commit_plane(VideoDecoder *vd, uint32_t fb_id, uint32_t src_w, uint32_t src_h) {
+    drmModeAtomicReq *req = drmModeAtomicAlloc();
+    if (!req) {
+        return -1;
+    }
+
+    if (src_w == 0) {
+        src_w = vd->src_w ? vd->src_w : (uint32_t)vd->mode_w;
+    } else {
+        vd->src_w = src_w;
+    }
+    if (src_h == 0) {
+        src_h = vd->src_h ? vd->src_h : (uint32_t)vd->mode_h;
+    } else {
+        vd->src_h = src_h;
+    }
+
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_fb_id, fb_id);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_crtc_id, vd->crtc_id);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_crtc_x, 0);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_crtc_y, 0);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_crtc_w, vd->mode_w);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_crtc_h, vd->mode_h);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_src_x, 0);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_src_y, 0);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_src_w, (uint64_t)src_w << 16);
+    drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_src_h, (uint64_t)src_h << 16);
+
+    int ret = drmModeAtomicCommit(vd->drm_fd, req, DRM_MODE_ATOMIC_NONBLOCK, NULL);
+    if (ret != 0) {
+        LOGW("Atomic commit failed: %s", g_strerror(errno));
+    }
+    drmModeAtomicFree(req);
+    return ret;
+}
+
+static int setup_external_buffers(VideoDecoder *vd, MppFrame frame) {
+    RK_U32 width = mpp_frame_get_width(frame);
+    RK_U32 height = mpp_frame_get_height(frame);
+    RK_U32 hor_stride = mpp_frame_get_hor_stride(frame);
+    RK_U32 ver_stride = mpp_frame_get_ver_stride(frame);
+    MppFrameFormat fmt = mpp_frame_get_fmt(frame);
+
+    if (fmt != MPP_FMT_YUV420SP && fmt != MPP_FMT_YUV420SP_10BIT) {
+        LOGE("MPP: unexpected format %d", fmt);
+        return -1;
+    }
+
+    release_frame_group(vd);
+
+    if (mpp_buffer_group_get_external(&vd->frm_grp, MPP_BUFFER_TYPE_DRM) != MPP_OK) {
+        LOGE("MPP: failed to get external buffer group");
+        return -1;
+    }
+
+    reset_frame_map(vd);
+
+    for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
+        struct drm_mode_create_dumb dmcd;
+        memset(&dmcd, 0, sizeof(dmcd));
+        dmcd.bpp = (fmt == MPP_FMT_YUV420SP) ? 8 : 10;
+        dmcd.width = hor_stride;
+        dmcd.height = ver_stride * 2;
+
+        int ret;
+        do {
+            ret = ioctl(vd->drm_fd, DRM_IOCTL_MODE_CREATE_DUMB, &dmcd);
+        } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+        if (ret != 0) {
+            LOGW("DRM_IOCTL_MODE_CREATE_DUMB failed: %s", g_strerror(errno));
+            continue;
+        }
+        vd->frame_map[i].handle = dmcd.handle;
+
+        struct drm_prime_handle dph;
+        memset(&dph, 0, sizeof(dph));
+        dph.handle = dmcd.handle;
+        dph.fd = -1;
+        do {
+            ret = ioctl(vd->drm_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &dph);
+        } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+        if (ret != 0) {
+            LOGW("PRIME_HANDLE_TO_FD failed: %s", g_strerror(errno));
+            continue;
+        }
+
+        MppBufferInfo info;
+        memset(&info, 0, sizeof(info));
+        info.type = MPP_BUFFER_TYPE_DRM;
+        info.size = dmcd.width * dmcd.height;
+        info.fd = dph.fd;
+        ret = mpp_buffer_commit(vd->frm_grp, &info);
+        if (ret != MPP_OK) {
+            LOGW("MPP: buffer_commit failed (%d)", ret);
+            close(dph.fd);
+            continue;
+        }
+        vd->frame_map[i].prime_fd = info.fd;
+        if (dph.fd != info.fd) {
+            close(dph.fd);
+        }
+
+        uint32_t handles[4] = {0};
+        uint32_t pitches[4] = {0};
+        uint32_t offsets[4] = {0};
+        handles[0] = vd->frame_map[i].handle;
+        handles[1] = vd->frame_map[i].handle;
+        pitches[0] = hor_stride;
+        pitches[1] = hor_stride;
+        offsets[0] = 0;
+        offsets[1] = pitches[0] * ver_stride;
+
+        ret = drmModeAddFB2(vd->drm_fd, width, height, DRM_FORMAT_NV12, handles, pitches, offsets,
+                            &vd->frame_map[i].fb_id, 0);
+        if (ret != 0) {
+            LOGW("drmModeAddFB2 failed: %s", g_strerror(errno));
+            continue;
+        }
+    }
+
+    vd->mpi->control(vd->ctx, MPP_DEC_SET_EXT_BUF_GROUP, vd->frm_grp);
+    vd->mpi->control(vd->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
+
+    vd->src_w = width;
+    vd->src_h = height;
+    commit_plane(vd, vd->frame_map[0].fb_id, width, height);
+    return 0;
+}
+
+static gpointer frame_thread_func(gpointer data) {
+    VideoDecoder *vd = (VideoDecoder *)data;
+    vd->frame_thread_running = TRUE;
+    while (TRUE) {
+        if (!vd->running) {
+            break;
+        }
+        MppFrame frame = NULL;
+        MPP_RET ret = vd->mpi->decode_get_frame(vd->ctx, &frame);
+        if (ret != MPP_OK || frame == NULL) {
+            g_usleep(1000);
+            continue;
+        }
+
+        if (mpp_frame_get_info_change(frame)) {
+            setup_external_buffers(vd, frame);
+        } else {
+            MppBuffer buffer = mpp_frame_get_buffer(frame);
+            if (buffer != NULL) {
+                MppBufferInfo info;
+                memset(&info, 0, sizeof(info));
+                if (mpp_buffer_info_get(buffer, &info) == MPP_OK) {
+                    for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
+                        if (vd->frame_map[i].prime_fd == info.fd) {
+                            g_mutex_lock(&vd->lock);
+                            vd->pending_fb = vd->frame_map[i].fb_id;
+                            vd->pending_pts = mpp_frame_get_pts(frame);
+                            g_cond_signal(&vd->cond);
+                            g_mutex_unlock(&vd->lock);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        vd->eos_received = mpp_frame_get_eos(frame) ? TRUE : FALSE;
+        mpp_frame_deinit(&frame);
+        if (vd->eos_received) {
+            break;
+        }
+    }
+
+    g_mutex_lock(&vd->lock);
+    vd->running = FALSE;
+    g_cond_broadcast(&vd->cond);
+    g_mutex_unlock(&vd->lock);
+    vd->frame_thread_running = FALSE;
+    return NULL;
+}
+
+static gpointer display_thread_func(gpointer data) {
+    VideoDecoder *vd = (VideoDecoder *)data;
+    vd->display_thread_running = TRUE;
+    while (TRUE) {
+        g_mutex_lock(&vd->lock);
+        while (vd->running && vd->pending_fb == 0) {
+            g_cond_wait(&vd->cond, &vd->lock);
+        }
+        uint32_t fb = vd->pending_fb;
+        vd->pending_fb = 0;
+        gboolean still_running = vd->running;
+        g_mutex_unlock(&vd->lock);
+
+        if (!still_running && fb == 0) {
+            break;
+        }
+        if (fb != 0) {
+            commit_plane(vd, fb, 0, 0);
+        }
+        if (!still_running) {
+            break;
+        }
+    }
+    vd->display_thread_running = FALSE;
+    return NULL;
+}
+
+size_t video_decoder_max_packet_size(const VideoDecoder *vd) {
+    if (vd == NULL || vd->packet_buf_size == 0) {
+        return DECODER_READ_BUF_SIZE;
+    }
+    return vd->packet_buf_size;
+}
+
+int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult *ms, int drm_fd) {
+    if (vd == NULL || cfg == NULL || ms == NULL) {
+        return -1;
+    }
+
+    memset(vd, 0, sizeof(*vd));
+    vd->drm_fd = -1;
+    vd->plane_id = (uint32_t)cfg->plane_id;
+    vd->crtc_id = ms->crtc_id;
+    vd->mode_w = ms->mode_w;
+    vd->mode_h = ms->mode_h;
+    vd->packet_buf_size = DECODER_READ_BUF_SIZE;
+    vd->packet_buf = g_malloc0(vd->packet_buf_size);
+    if (vd->packet_buf == NULL) {
+        LOGE("Video decoder: failed to allocate packet buffer");
+        return -1;
+    }
+
+    int dup_fd = fcntl(drm_fd, F_DUPFD_CLOEXEC, 0);
+    if (dup_fd < 0) {
+        LOGE("Video decoder: failed to dup DRM fd: %s", g_strerror(errno));
+        g_free(vd->packet_buf);
+        vd->packet_buf = NULL;
+        return -1;
+    }
+    vd->drm_fd = dup_fd;
+
+    if (drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "FB_ID", &vd->prop_fb_id) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_ID", &vd->prop_crtc_id) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_X", &vd->prop_crtc_x) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_Y", &vd->prop_crtc_y) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_W", &vd->prop_crtc_w) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_H", &vd->prop_crtc_h) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "SRC_X", &vd->prop_src_x) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "SRC_Y", &vd->prop_src_y) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "SRC_W", &vd->prop_src_w) != 0 ||
+        drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "SRC_H", &vd->prop_src_h) != 0) {
+        LOGE("Video decoder: failed to query plane properties");
+        video_decoder_deinit(vd);
+        return -1;
+    }
+
+    if (mpp_create(&vd->ctx, &vd->mpi) != MPP_OK) {
+        LOGE("Video decoder: mpp_create failed");
+        video_decoder_deinit(vd);
+        return -1;
+    }
+
+    if (mpp_packet_init(&vd->packet, vd->packet_buf, vd->packet_buf_size) != MPP_OK) {
+        LOGE("Video decoder: mpp_packet_init failed");
+        video_decoder_deinit(vd);
+        return -1;
+    }
+
+    MppCodingType coding = MPP_VIDEO_CodingHEVC;
+    if (mpp_init(vd->ctx, MPP_CTX_DEC, coding) != MPP_OK) {
+        LOGE("Video decoder: mpp_init failed");
+        video_decoder_deinit(vd);
+        return -1;
+    }
+
+    set_mpp_decoding_parameters(vd);
+
+    int block = MPP_POLL_BLOCK;
+    vd->mpi->control(vd->ctx, MPP_SET_OUTPUT_BLOCK, &block);
+
+    g_mutex_init(&vd->lock);
+    g_cond_init(&vd->cond);
+    vd->lock_initialized = TRUE;
+    vd->cond_initialized = TRUE;
+    vd->pending_fb = 0;
+    vd->pending_pts = 0;
+    vd->frm_grp = NULL;
+    reset_frame_map(vd);
+
+    vd->initialized = TRUE;
+    return 0;
+}
+
+void video_decoder_deinit(VideoDecoder *vd) {
+    if (vd == NULL) {
+        return;
+    }
+
+    video_decoder_stop(vd);
+
+    if (vd->packet) {
+        mpp_packet_deinit(&vd->packet);
+        vd->packet = NULL;
+    }
+
+    if (vd->mpi && vd->ctx) {
+        vd->mpi->reset(vd->ctx);
+        mpp_destroy(vd->ctx);
+    }
+    vd->ctx = NULL;
+    vd->mpi = NULL;
+
+    release_frame_group(vd);
+
+    if (vd->packet_buf) {
+        g_free(vd->packet_buf);
+        vd->packet_buf = NULL;
+    }
+
+    if (vd->drm_fd >= 0) {
+        close(vd->drm_fd);
+        vd->drm_fd = -1;
+    }
+
+    if (vd->lock_initialized) {
+        g_mutex_clear(&vd->lock);
+        vd->lock_initialized = FALSE;
+    }
+    if (vd->cond_initialized) {
+        g_cond_clear(&vd->cond);
+        vd->cond_initialized = FALSE;
+    }
+    vd->initialized = FALSE;
+}
+
+int video_decoder_start(VideoDecoder *vd) {
+    if (vd == NULL || !vd->initialized) {
+        return -1;
+    }
+    if (vd->running) {
+        return 0;
+    }
+
+    vd->running = TRUE;
+    vd->eos_received = FALSE;
+
+    vd->frame_thread = g_thread_new("mpp-frame", frame_thread_func, vd);
+    if (vd->frame_thread == NULL) {
+        vd->running = FALSE;
+        return -1;
+    }
+    vd->display_thread = g_thread_new("mpp-display", display_thread_func, vd);
+    if (vd->display_thread == NULL) {
+        vd->running = FALSE;
+        g_thread_join(vd->frame_thread);
+        vd->frame_thread = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+void video_decoder_stop(VideoDecoder *vd) {
+    if (vd == NULL) {
+        return;
+    }
+
+    g_mutex_lock(&vd->lock);
+    vd->running = FALSE;
+    g_cond_broadcast(&vd->cond);
+    g_mutex_unlock(&vd->lock);
+
+    if (vd->frame_thread) {
+        g_thread_join(vd->frame_thread);
+        vd->frame_thread = NULL;
+    }
+    if (vd->display_thread) {
+        g_thread_join(vd->display_thread);
+        vd->display_thread = NULL;
+    }
+}
+
+int video_decoder_feed(VideoDecoder *vd, const guint8 *data, size_t size) {
+    if (vd == NULL || !vd->running) {
+        return -1;
+    }
+    if (size == 0 || size > vd->packet_buf_size) {
+        return -1;
+    }
+
+    memcpy(vd->packet_buf, data, size);
+    mpp_packet_set_length(vd->packet, 0);
+    mpp_packet_set_size(vd->packet, vd->packet_buf_size);
+    mpp_packet_set_data(vd->packet, vd->packet_buf);
+    mpp_packet_set_pos(vd->packet, vd->packet_buf);
+    mpp_packet_set_length(vd->packet, size);
+    mpp_packet_set_pts(vd->packet, (RK_S64)get_time_ms());
+
+    while (vd->running) {
+        MPP_RET ret = vd->mpi->decode_put_packet(vd->ctx, vd->packet);
+        if (ret == MPP_OK) {
+            return 0;
+        }
+        g_usleep(2000);
+    }
+    return -1;
+}
+
+void video_decoder_send_eos(VideoDecoder *vd) {
+    if (vd == NULL || vd->packet == NULL) {
+        return;
+    }
+
+    mpp_packet_set_length(vd->packet, 0);
+    mpp_packet_set_size(vd->packet, vd->packet_buf_size);
+    mpp_packet_set_data(vd->packet, vd->packet_buf);
+    mpp_packet_set_pos(vd->packet, vd->packet_buf);
+    mpp_packet_set_eos(vd->packet);
+
+    while (vd->mpi && vd->ctx) {
+        MPP_RET ret = vd->mpi->decode_put_packet(vd->ctx, vd->packet);
+        if (ret == MPP_OK) {
+            break;
+        }
+        g_usleep(2000);
+    }
+}
+


### PR DESCRIPTION
## Summary
- route the RTP video branch into an appsink and feed frames through a new Rockchip MPP/DRM decoder that performs atomic plane updates
- add a reusable video_decoder module and expose it through the pipeline API
- update build flags and DRM includes to pick up Rockchip MPP and libdrm headers when available

## Testing
- make *(fails: xf86drm.h not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1898a4170832b9ee1068f3b5c3a4f