### PR TITLE
Add configurable custom sink selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ short-term debugging sessions, as doing so can quickly introduce additional end-
 
 The default pipeline feeds RTP packets into an `appsrc` element backed by the project-specific UDP receiver. This provides
 extended telemetry (bitrate, jitter, packet counters, etc.) that powers the OSD widgets and log output. When you do not need
-those metrics, enable GStreamer's native source with `--gst-udpsrc` (or `pipeline.use-gst-udpsrc = true` in the INI file). The
-pipeline will then create a bare `udpsrc` element and UEP/receiver statistics are disabled entirely.
+those metrics, switch the sink with `--custom-sink udpsrc` (or `pipeline.custom-sink = udpsrc` in the INI file). The pipeline
+will then create a bare `udpsrc` element and UEP/receiver statistics are disabled entirely.
 
 Use this mode when integrating with external tooling or experimenting with alternative buffering strategies where the
-application-level receiver is unnecessary. Revert with `--no-gst-udpsrc` or by clearing the INI key to restore the default
-behaviour and regain access to the telemetry counters.
+application-level receiver is unnecessary. Revert with `--custom-sink receiver` (or remove the INI override) to restore the
+default behaviour and regain access to the telemetry counters.

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -21,7 +21,7 @@ video-queue-leaky = 2
 video-queue-pre-buffers = 128
 video-queue-post-buffers = 8
 video-queue-sink-buffers = 8
-use-gst-udpsrc = false
+custom-sink = receiver
 max-lateness-ns = 20000000
 
 [audio]

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -15,7 +15,7 @@ audio-pt = 98
 
 [pipeline]
 latency-ms = 8
-use-gst-udpsrc = false
+custom-sink = receiver
 
 [audio]
 device = plughw:CARD=rockchiphdmi0,DEV=0

--- a/include/config.h
+++ b/include/config.h
@@ -10,6 +10,11 @@
 #define CPU_SETSIZE ((int)(sizeof(cpu_set_t) * CHAR_BIT))
 #endif
 
+typedef enum {
+    CUSTOM_SINK_RECEIVER = 0,
+    CUSTOM_SINK_UDPSRC,
+} CustomSinkMode;
+
 typedef struct {
     char card_path[64];
     char connector_name[32];
@@ -30,7 +35,7 @@ typedef struct {
     int video_queue_pre_buffers;
     int video_queue_post_buffers;
     int video_queue_sink_buffers;
-    int use_gst_udpsrc;
+    CustomSinkMode custom_sink;
     char aud_dev[128];
 
     int no_audio;
@@ -59,5 +64,7 @@ int cfg_parse_cpu_list(const char *list, AppCfg *cfg);
 int cfg_has_cpu_affinity(const AppCfg *cfg);
 void cfg_get_process_affinity(const AppCfg *cfg, cpu_set_t *set_out);
 int cfg_get_thread_affinity(const AppCfg *cfg, int slot, cpu_set_t *set_out);
+int cfg_parse_custom_sink_mode(const char *value, CustomSinkMode *mode_out);
+const char *cfg_custom_sink_mode_name(CustomSinkMode mode);
 
 #endif // CONFIG_H

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -655,12 +655,22 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->video_queue_sink_buffers = atoi(value);
             return 0;
         }
+        if (strcasecmp(key, "custom-sink") == 0) {
+            CustomSinkMode mode;
+            if (cfg_parse_custom_sink_mode(value, &mode) != 0) {
+                LOGE("Invalid custom-sink mode '%s' in INI", value);
+                return -1;
+            }
+            cfg->custom_sink = mode;
+            return 0;
+        }
         if (strcasecmp(key, "use-gst-udpsrc") == 0) {
             int v = 0;
             if (parse_bool(value, &v) != 0) {
                 return -1;
             }
-            cfg->use_gst_udpsrc = v;
+            LOGW("INI key pipeline.use-gst-udpsrc is deprecated; use pipeline.custom-sink instead");
+            cfg->custom_sink = v ? CUSTOM_SINK_UDPSRC : CUSTOM_SINK_RECEIVER;
             return 0;
         }
         if (strcasecmp(key, "max-lateness-ns") == 0) {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -125,7 +125,7 @@ fail:
 }
 
 static GstElement *create_udp_source(const AppCfg *cfg, gboolean video_only, UdpReceiver **receiver_out) {
-    if (cfg->use_gst_udpsrc) {
+    if (cfg->custom_sink == CUSTOM_SINK_UDPSRC) {
         if (receiver_out != NULL) {
             *receiver_out = NULL;
         }
@@ -836,8 +836,8 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
     GstElement *pipeline = NULL;
     gboolean force_audio_disabled = FALSE;
 
-    if (cfg->use_gst_udpsrc) {
-        LOGI("Using GStreamer udpsrc; UDP receiver stats disabled");
+    if (cfg->custom_sink == CUSTOM_SINK_UDPSRC) {
+        LOGI("Custom sink mode 'udpsrc' selected; UDP receiver stats disabled");
         if (!setup_gst_udpsrc_pipeline(ps, cfg)) {
             goto fail;
         }


### PR DESCRIPTION
## Summary
- replace the old --gst-udpsrc flag with a generic --custom-sink selector
- add shared parsing helpers for the custom sink mode and propagate it through the pipeline
- update README and sample INI files to document the new option while keeping backward-compatible fallbacks

## Testing
- `make` *(fails: missing xf86drm.h in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e220d7fb4c832b94145be96536c481