### PR TITLE
Optimize packet copy using ARM NEON when available

### DIFF
--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -13,7 +13,7 @@
 #include <gst/gst.h>
 #include <rockchip/rk_mpi.h>
 
-#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(PIXELPILOT_HAS_NEON)
 #include <arm_neon.h>
 #endif
 
@@ -95,7 +95,7 @@ static inline guint64 get_time_ms(void) {
 }
 
 static inline void copy_packet_data(guint8 *dst, const guint8 *src, size_t size) {
-#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(PIXELPILOT_HAS_NEON)
     /*
      * Use NEON vector loads/stores to move packets in 64-byte bursts when
      * running on ARM targets with NEON support. For remaining tail bytes we


### PR DESCRIPTION
## Summary
- add an optional NEON-accelerated packet copy helper for ARM builds
- route packet feeding through the helper while preserving the memcpy fallback

## Testing
- make *(fails: missing xf86drm.h on the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68e2302ac2a0832bb5e1d337d1652be8