### PR TITLE
Ensure fallback switching occurs when filtered packets are dropped

### DIFF
--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -480,11 +480,6 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
 
     gst_buffer_unmap(gstbuf, map);
 
-    if (drop_packet) {
-        gst_buffer_unref(gstbuf);
-        return TRUE;
-    }
-
     if (switching_from_fallback != NULL && *switching_from_fallback && ur->using_fallback) {
         LOGI("UDP receiver: switching back to primary port %d", ur->udp_port);
         push_stream_reset_events(ur);
@@ -495,6 +490,11 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
         mark_discont = TRUE;
         ur->using_fallback = FALSE;
         *switching_from_fallback = FALSE;
+    }
+
+    if (drop_packet) {
+        gst_buffer_unref(gstbuf);
+        return TRUE;
     }
 
     if (mark_discont) {


### PR DESCRIPTION
## Summary
- run the fallback-to-primary reset logic before early-returning for dropped packets in `udp_receiver`
- prevent batches that only contain filtered packets (e.g. when audio is disabled) from leaving the receiver stuck in fallback mode

## Testing
- make *(fails: missing xf86drm.h on the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e235974648832bbe3c4dd4c189758c