### PR TITLE
Add framesize bar graph to OSD sample config

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -46,7 +46,7 @@ refresh-ms = 100
 plane-id = 0
 ; Order of elements rendered each update
 ; The names reference [osd.element.NAME] sections below.
-elements = stats, bitrate_plot, jitter_plot
+elements = stats, framesize_plot, bitrate_plot, jitter_plot
 
 ; -----------------------------------------------------------------------------
 ; Element placement quick reference
@@ -106,6 +106,19 @@ grid = transparent-white
 ; - label is a free-form axis caption rendered along the Y axis.
 ; - info-box toggles the small badge with the latest sample (or a status
 ;   message while the stream warms up).
+
+[osd.element.framesize_plot]
+type = bar
+anchor = mid-left
+size = 360x90
+sample-spacing = 12
+bar-width = 8
+metric = udp.frames.last_bytes
+label = Frame Size (KB)
+info-box = true
+foreground = green
+background = transparent-grey
+grid = transparent-white
 
 [osd.element.jitter_plot]
 type = bar


### PR DESCRIPTION
## Summary
- add a mid-left frame size bar graph element to the sample OSD configuration
- include the new framesize element in the OSD render order with info-box support enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e23efcc370832ba8f45a0f5231af57