### PR TITLE
Use pixman for OSD rendering with cached glyphs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PKG_GSTCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags gstreamer-1.0 g
 PKG_GSTLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0)
 PKG_MPPCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags rockchip-mpp)
 PKG_MPPLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs rockchip-mpp)
+PKG_PIXCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags pixman-1)
+PKG_PIXLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs pixman-1)
 
 CFLAGS ?= -O2 -Wall
 CFLAGS += -Iinclude
@@ -62,6 +64,12 @@ else
 CFLAGS += -I/usr/include/rockchip
 endif
 
+ifneq ($(strip $(PKG_PIXCFLAGS)),)
+CFLAGS += $(PKG_PIXCFLAGS)
+else
+CFLAGS += -I/usr/include/pixman-1
+endif
+
 ifneq ($(strip $(PKG_DRMLIBS)),)
 LDFLAGS += $(PKG_DRMLIBS)
 else
@@ -78,6 +86,12 @@ ifneq ($(strip $(PKG_MPPLIBS)),)
 LDFLAGS += $(PKG_MPPLIBS)
 else
 LDFLAGS += -lrockchip_mpp
+endif
+
+ifneq ($(strip $(PKG_PIXLIBS)),)
+LDFLAGS += $(PKG_PIXLIBS)
+else
+LDFLAGS += -lpixman-1
 endif
 
 LDFLAGS += -lpthread

--- a/include/osd.h
+++ b/include/osd.h
@@ -9,7 +9,10 @@
 #include "osd_layout.h"
 #include "pipeline.h"
 
+#include <pixman.h>
+
 #define OSD_PLOT_MAX_SAMPLES 1024
+#define OSD_MAX_GLYPH_SCALES 8
 
 typedef struct {
     int x;
@@ -78,12 +81,18 @@ typedef struct {
     OSDRect footer_rect;
 } OsdBarState;
 
+typedef struct {
+    int scale;
+    pixman_image_t *glyphs[128];
+} OsdGlyphCacheEntry;
+
 typedef struct OSD {
     int enabled;
     int active;
     uint32_t requested_plane_id;
     uint32_t plane_id;
     struct DumbFB fb;
+    pixman_image_t *pixman_fb;
     int w;
     int h;
     int scale;
@@ -115,6 +124,9 @@ typedef struct OSD {
             OsdBarState bar;
         } data;
     } elements[OSD_MAX_ELEMENTS];
+
+    OsdGlyphCacheEntry glyph_cache[OSD_MAX_GLYPH_SCALES];
+    int glyph_cache_count;
 } OSD;
 
 void osd_init(OSD *osd);


### PR DESCRIPTION
## Summary
- add pixman build flags so the project can link against the new renderer helpers
- store a pixman framebuffer and reusable glyph cache in the OSD state
- render rectangles and text with pixman composites instead of per-pixel loops, while cleaning up pixman resources during teardown

## Testing
- make *(fails: missing xf86drm.h headers in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e245b67f10832bbb3a9ae3d6433bb3