### PR TITLE
Default to 4-way parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 CC ?= gcc
+
+# Default to using 4 parallel jobs unless the caller already requested a
+# specific level of parallelism (e.g. via `make -j8`).
+ifeq ($(filter -j%,$(MAKEFLAGS)),)
+MAKEFLAGS += -j4
+endif
 PKG_CONFIG ?= pkg-config
 PKG_DRMCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags libdrm libudev)
 PKG_DRMLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs libdrm libudev)


### PR DESCRIPTION
## Summary
- default the Makefile to using four parallel jobs when no other -j flag is supplied

## Testing
- not run (external dependencies required)


------
https://chatgpt.com/codex/tasks/task_e_68e2492f9a88832ba5afee3611a7f456