### PR TITLE
Ignore audio SSRC when tracking RTP stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,38 @@ Any `line =` entry inside a `[osd.element.*]` section can reference `{token}` pl
 Line plots accept metrics such as `udp.bitrate.latest_mbps`, `udp.jitter.avg_ms`, or counter-style values like
 `udp.lost_packets` and automatically handle scaling and rendering based on the INI-provided geometry.
 
+### INI key reference
+
+The table below summarises every INI option that the loader understands. Values map 1:1 to command-line switches and fall back
+to the defaults listed in `src/config.c` when omitted.
+
+| Section / key | Description |
+| --- | --- |
+| `[drm].card` | DRM card node to open (default `/dev/dri/card0`). |
+| `[drm].connector` | Preferred connector name (e.g. `HDMI-A-1`). Leave blank to auto-pick the first connected head. |
+| `[drm].video-plane-id` | Numeric plane ID used for the decoded video plane. |
+| `[drm].use-udev` | `true` to enable the hotplug listener that reapplies modes when connectors change. |
+| `[drm].osd-plane-id` | Optional explicit plane for the OSD overlay (0 keeps the auto-selection). |
+| `[udp].port` | UDP port that the RTP stream arrives on. |
+| `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
+| `[pipeline].latency-ms` | Network jitter buffer target in milliseconds. This feeds the appsrc `latency` property as well as the OSD token `{pipeline.latency_ms}`. |
+| `[pipeline].custom-sink` | `receiver` to use the custom UDP receiver, or `udpsrc` for the bare GStreamer `udpsrc` pipeline. |
+| `[audio].device` | ALSA device string handed to the sink (e.g. `plughw:CARD=rockchiphdmi0,DEV=0`). |
+| `[audio].disable` | `true` drops the audio branch entirely (equivalent to `--no-audio`). |
+| `[audio].optional` | `true` allows auto-fallback to a fakesink when the audio path fails; `false` keeps retrying the real sink. |
+| `[restarts].limit` | Maximum automatic restarts allowed within the configured window. |
+| `[restarts].window-ms` | Rolling window (milliseconds) for counting automatic restarts. |
+| `[gst].log` | `true` forces `GST_DEBUG=3` unless already set in the environment. |
+| `[cpu].affinity` | Comma-separated CPU IDs used to pin the main process and helper threads. |
+| `[osd].enable` | Enable the OSD overlay plane. |
+| `[osd].refresh-ms` | Interval between OSD refreshes. |
+| `[osd].plane-id` | Optional override for the OSD plane (mirrors `[drm].osd-plane-id`). |
+| `[osd].elements` | Comma-separated list describing the render order of `[osd.element.NAME]` blocks. |
+| `[osd.element.NAME].type` | Widget style (`text`, `line`, or `bar`). Each type unlocks additional keys listed in the sample file. |
+| `[osd.element.NAME].anchor` / `offset` / `size` / color keys | Control placement and styling for OSD widgets. See inline comments in the sample file for full semantics. |
+| `[osd.element.NAME].line` | For text widgets, each `line =` entry appends a formatted row supporting `{token}` placeholders. |
+| `[osd.element.NAME].metric` | For line/bar widgets, selects the metric token (e.g. `udp.bitrate.latest_mbps`) sampled each refresh. |
+
 ## CPU affinity control
 
 Use `--cpu-list` to provide a comma-separated list of CPU IDs that the process and its busy worker threads should run on. The main process mask is restricted to the specified CPUs and the UDP receiver and GStreamer bus threads are pinned in a round-robin fashion to spread the work across cores.
@@ -31,21 +63,6 @@ Example:
 
 This constrains the process to CPUs 2 and 3 while placing the UDP receiver thread on CPU 2 and the GStreamer bus thread on CPU 3.
 
-## Video buffering controls
-
-When debugging decoder underruns or validating new transmitters it can be useful to temporarily increase buffering or disable
-latency-based drops in the video path. The following options expose the queue sizing and jitter buffer policy that are normally
-hard-coded for low-latency flight use:
-
-* `--video-queue-leaky MODE` sets the `leaky` mode on the pre-, post-, and sink-side video queues. The default `2` (downstream)
-  favors minimal latency by discarding the oldest buffers when the downstream stage stalls. Set `0` to disable dropping so the
-  pipeline accumulates backlog for analysis.
-* `--video-queue-pre-buffers N`, `--video-queue-post-buffers N`, and `--video-queue-sink-buffers N` adjust the queue depths for
-  each stage (defaults: 96/8/8). Raising these values increases tolerance for jitter at the cost of additional latency and
-  memory use.
-Keep the defaults for normal flying where latency is paramount. Switch to non-leaky queues and higher buffer counts only for
-short-term debugging sessions, as doing so can quickly introduce additional end-to-end delay.
-
 ## Bypassing the custom UDP receiver
 
 The default pipeline feeds RTP packets into an `appsrc` element backed by the project-specific UDP receiver. This provides
@@ -56,3 +73,39 @@ will then create a bare `udpsrc` element and UEP/receiver statistics are disable
 Use this mode when integrating with external tooling or experimenting with alternative buffering strategies where the
 application-level receiver is unnecessary. Revert with `--custom-sink receiver` (or remove the INI override) to restore the
 default behaviour and regain access to the telemetry counters.
+
+## UDP receiver statistics
+
+The custom receiver keeps a rolling telemetry snapshot that is exposed through the OSD token table and the `udp.*` metric
+namespace. Statistics are computed only while the feature is enabled (for example when the OSD requests them); toggling stats on
+resets the counters and history buffer so each session starts with a clean slate.
+
+Once the RTP payload types have been separated, only the video stream (payload type matching `[udp].video-pt`) feeds the
+aggregate counters. Audio packets still increment `udp.audio_packets` so you can confirm the sender is active, but they no longer
+impact bitrate, jitter, history samples, or frame statistics. Audio from the same SSRC nudges the internal sequence tracker forward
+when it is only a small step ahead of the video stream so that interleaved payload type 98 traffic does not look like loss; audio
+arriving on a different SSRC (or with a large sequence gap) is ignored entirely for the sequence heuristic.
+
+| Counter | Description |
+| --- | --- |
+| `udp.total_packets` | Video RTP packets forwarded to the decoder (payload type matching `[udp].video-pt`). |
+| `udp.video_packets` / `udp.audio_packets` | Video packets mirror the total; audio counts tick when `[udp].audio-pt` is observed, even if the audio branch is disabled. |
+| `udp.ignored_packets` | Packets whose payload type did not match either configured stream. |
+| `udp.duplicate_packets` | Packets that re-used the most recent sequence number. |
+| `udp.lost_packets` | The cumulative count of missing sequence numbers detected while walking the video stream. |
+| `udp.reordered_packets` | Packets that arrived with a sequence number lower than expected (but not a duplicate). |
+| `udp.total_bytes` / `udp.video_bytes` / `udp.audio_bytes` | Video byte counters mirror the packet stats; audio bytes reflect `[udp].audio-pt` traffic only. |
+| `udp.bitrate.latest_mbps` | Instantaneous video bitrate computed over a sliding 200 ms window. |
+| `udp.bitrate.avg_mbps` | Exponentially weighted moving average of the instantaneous video bitrate. |
+| `udp.jitter.latest_ms` | RFC 3550 style inter-arrival jitter derived from the video timestamps. |
+| `udp.jitter.avg_ms` | EWMA of the video jitter metric to smooth short-term spikes. |
+| `udp.frame.count` | Number of completed video frames detected via RTP marker bits. |
+| `udp.frame.incomplete` | Frames that ended with missing video packets. |
+| `udp.frame.last_kib` | Size of the most recent completed video frame (KiB). |
+| `udp.frame.avg_kib` | EWMA of recent video frame sizes (KiB). |
+| `udp.sequence.expected` | The next video sequence number the receiver is waiting for. |
+| `udp.timestamp.last_video` | RTP timestamp from the most recent video packet. |
+
+The history buffer exposed through `udp.history.*` tokens retains the 512 most recent packet samples, including packet size,
+payload type, arrival timestamp, and flags for loss, reordering, duplication, and frame boundaries. This makes it possible to
+build custom diagnostics or render per-packet overlays directly from the INI configuration.

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -6,7 +6,6 @@
 card = /dev/dri/card0
 connector = HDMI-A-1
 video-plane-id = 76
-blank-primary = false
 use-udev = true
 osd-plane-id = 0
 
@@ -17,12 +16,7 @@ audio-pt = 98
 
 [pipeline]
 latency-ms = 16
-video-queue-leaky = 2
-video-queue-pre-buffers = 128
-video-queue-post-buffers = 8
-video-queue-sink-buffers = 8
 custom-sink = receiver
-max-lateness-ns = 20000000
 
 [audio]
 device = plughw:CARD=rockchiphdmi0,DEV=0

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -4,7 +4,6 @@
 card = /dev/dri/card0
 connector = HDMI-A-1
 video-plane-id = 76
-blank-primary = false
 use-udev = true
 osd-plane-id = 0
 

--- a/include/config.h
+++ b/include/config.h
@@ -20,20 +20,12 @@ typedef struct {
     char connector_name[32];
     char config_path[PATH_MAX];
     int plane_id;
-    int blank_primary;
     int use_udev;
 
     int udp_port;
     int vid_pt;
     int aud_pt;
     int latency_ms;
-    int kmssink_sync;
-    int kmssink_qos;
-    int max_lateness_ns;
-    int video_queue_leaky;
-    int video_queue_pre_buffers;
-    int video_queue_post_buffers;
-    int video_queue_sink_buffers;
     CustomSinkMode custom_sink;
     char aud_dev[128];
 

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -16,13 +16,7 @@ typedef enum {
 typedef struct {
     PipelineStateEnum state;
     GstElement *pipeline;
-    GstElement *source;
-    GstElement *rtpbin;
     GstElement *video_sink;
-    GstElement *video_branch_entry;
-    GstElement *audio_branch_entry;
-    GstPad *video_pad;
-    GstPad *audio_pad;
     UdpReceiver *udp_receiver;
     GThread *bus_thread;
     GThread *appsink_thread;

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -59,7 +59,8 @@ typedef struct {
 
 typedef struct UdpReceiver UdpReceiver;
 
-UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *appsrc);
+UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc);
+void udp_receiver_set_audio_appsrc(UdpReceiver *ur, GstAppSrc *audio_appsrc);
 int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -593,14 +593,6 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->plane_id = atoi(value);
             return 0;
         }
-        if (strcasecmp(key, "blank-primary") == 0) {
-            int v = 0;
-            if (parse_bool(value, &v) != 0) {
-                return -1;
-            }
-            cfg->blank_primary = v;
-            return 0;
-        }
         if (strcasecmp(key, "osd-plane-id") == 0) {
             cfg->osd_plane_id = atoi(value);
             return 0;
@@ -635,22 +627,6 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->latency_ms = atoi(value);
             return 0;
         }
-        if (strcasecmp(key, "video-queue-leaky") == 0) {
-            cfg->video_queue_leaky = atoi(value);
-            return 0;
-        }
-        if (strcasecmp(key, "video-queue-pre-buffers") == 0) {
-            cfg->video_queue_pre_buffers = atoi(value);
-            return 0;
-        }
-        if (strcasecmp(key, "video-queue-post-buffers") == 0) {
-            cfg->video_queue_post_buffers = atoi(value);
-            return 0;
-        }
-        if (strcasecmp(key, "video-queue-sink-buffers") == 0) {
-            cfg->video_queue_sink_buffers = atoi(value);
-            return 0;
-        }
         if (strcasecmp(key, "custom-sink") == 0) {
             CustomSinkMode mode;
             if (cfg_parse_custom_sink_mode(value, &mode) != 0) {
@@ -667,10 +643,6 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             }
             LOGW("INI key pipeline.use-gst-udpsrc is deprecated; use pipeline.custom-sink instead");
             cfg->custom_sink = v ? CUSTOM_SINK_UDPSRC : CUSTOM_SINK_RECEIVER;
-            return 0;
-        }
-        if (strcasecmp(key, "max-lateness-ns") == 0) {
-            cfg->max_lateness_ns = atoi(value);
             return 0;
         }
         return -1;

--- a/src/drm_modeset.c
+++ b/src/drm_modeset.c
@@ -82,60 +82,6 @@ static int better_mode(const drmModeModeInfo *a, const drmModeModeInfo *b) {
     return a->clock > b->clock;
 }
 
-static int find_primary_plane_for_crtc(int fd, drmModeRes *res, uint32_t crtc_id) {
-    int crtc_index = -1;
-    for (int i = 0; i < res->count_crtcs; ++i) {
-        if ((uint32_t)res->crtcs[i] == crtc_id) {
-            crtc_index = i;
-            break;
-        }
-    }
-    if (crtc_index < 0) {
-        return -1;
-    }
-
-    drmModePlaneRes *prs = drmModeGetPlaneResources(fd);
-    if (!prs) {
-        return -1;
-    }
-
-    int primary_id = -1;
-    for (uint32_t i = 0; i < prs->count_planes; ++i) {
-        drmModePlane *p = drmModeGetPlane(fd, prs->planes[i]);
-        if (!p) {
-            continue;
-        }
-        if ((p->possible_crtcs & (1U << crtc_index)) == 0) {
-            drmModeFreePlane(p);
-            continue;
-        }
-
-        uint32_t type_prop = 0;
-        if (drm_get_prop_id(fd, p->plane_id, DRM_MODE_OBJECT_PLANE, "type", &type_prop) == 0) {
-            drmModeObjectProperties *props =
-                drmModeObjectGetProperties(fd, p->plane_id, DRM_MODE_OBJECT_PLANE);
-            if (props) {
-                for (uint32_t k = 0; k < props->count_props; ++k) {
-                    if (props->props[k] == type_prop) {
-                        uint64_t val = props->prop_values[k];
-                        if (val == DRM_PLANE_TYPE_PRIMARY) {
-                            primary_id = (int)p->plane_id;
-                        }
-                        break;
-                    }
-                }
-                drmModeFreeObjectProperties(props);
-            }
-        }
-        drmModeFreePlane(p);
-        if (primary_id > 0) {
-            break;
-        }
-    }
-    drmModeFreePlaneResources(prs);
-    return primary_id;
-}
-
 int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResult *out) {
     if (drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1) != 0) {
         LOGW("Failed to enable UNIVERSAL_PLANES");
@@ -302,15 +248,6 @@ int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResu
             v_z = zmax - 1;
         }
         drmModeAtomicAddProperty(req, cfg->plane_id, plane_zpos_id, v_z);
-    }
-
-    int primary_plane_id = cfg->blank_primary ? find_primary_plane_for_crtc(fd, res, crtc->crtc_id) : -1;
-    if (primary_plane_id > 0) {
-        uint32_t prim_fb_id = 0, prim_crtc_id = 0;
-        drm_get_prop_id(fd, (uint32_t)primary_plane_id, DRM_MODE_OBJECT_PLANE, "FB_ID", &prim_fb_id);
-        drm_get_prop_id(fd, (uint32_t)primary_plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_ID", &prim_crtc_id);
-        drmModeAtomicAddProperty(req, (uint32_t)primary_plane_id, prim_fb_id, 0);
-        drmModeAtomicAddProperty(req, (uint32_t)primary_plane_id, prim_crtc_id, 0);
     }
 
     int flags = DRM_MODE_ATOMIC_ALLOW_MODESET;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -48,10 +48,12 @@
 #define BITRATE_EWMA_ALPHA 0.1
 #define UDP_RECEIVER_MAX_PACKET 4096
 #define UDP_RECEIVER_BATCH 8
+#define UDP_AUDIO_SEQ_MAX_ADVANCE 8192
 
 typedef struct {
     guint16 sequence;
     guint32 timestamp;
+    guint32 ssrc;
     guint8 payload_type;
     guint8 marker;
     guint8 has_padding;
@@ -63,7 +65,8 @@ typedef struct {
 } RtpParseResult;
 
 struct UdpReceiver {
-    GstAppSrc *appsrc;
+    GstAppSrc *video_appsrc;
+    GstAppSrc *audio_appsrc;
     GThread *thread;
     GMutex lock;
     gboolean running;
@@ -74,7 +77,8 @@ struct UdpReceiver {
     int vid_pt;
     int aud_pt;
     int sockfd;
-    gboolean discont_pending;
+    gboolean video_discont_pending;
+    gboolean audio_discont_pending;
 
     GstBufferPool *pool;
     gsize buffer_size;
@@ -100,6 +104,9 @@ struct UdpReceiver {
 
     const AppCfg *cfg;
     int cpu_slot;
+
+    guint32 video_ssrc;
+    gboolean have_video_ssrc;
 };
 
 static gboolean parse_rtp(const guint8 *data, gsize len, RtpParseResult *out) {
@@ -149,6 +156,7 @@ static gboolean parse_rtp(const guint8 *data, gsize len, RtpParseResult *out) {
 
     out->sequence = ((guint16)data[2] << 8) | data[3];
     out->timestamp = ((guint32)data[4] << 24) | ((guint32)data[5] << 16) | ((guint32)data[6] << 8) | data[7];
+    out->ssrc = ((guint32)data[8] << 24) | ((guint32)data[9] << 16) | ((guint32)data[10] << 8) | data[11];
     out->payload_type = payload_type;
     out->marker = marker ? 1 : 0;
     out->has_padding = padding ? 1 : 0;
@@ -170,6 +178,32 @@ static inline gint16 seq_delta(guint16 a, guint16 b) {
 
 static inline guint64 get_time_ns(void) {
     return (guint64)g_get_monotonic_time() * 1000ull;
+}
+
+static inline void advance_expected_sequence(struct UdpReceiver *ur, const RtpParseResult *parsed) {
+    if (!ur->have_video_ssrc || parsed == NULL) {
+        return;
+    }
+
+    if (parsed->ssrc != ur->video_ssrc) {
+        return;
+    }
+
+    guint16 sequence = parsed->sequence;
+    if (!ur->seq_initialized) {
+        ur->seq_initialized = TRUE;
+        ur->expected_seq = seq_next(sequence);
+        ur->stats.expected_sequence = ur->expected_seq;
+        return;
+    }
+
+    gint16 delta = seq_delta(sequence, ur->expected_seq);
+    if (delta < 0 || delta > UDP_AUDIO_SEQ_MAX_ADVANCE) {
+        return;
+    }
+
+    ur->expected_seq = seq_next(sequence);
+    ur->stats.expected_sequence = ur->expected_seq;
 }
 
 static inline void neon_copy_bytes(guint8 *dst, const guint8 *src, size_t size) {
@@ -235,6 +269,8 @@ static void reset_stats_locked(struct UdpReceiver *ur) {
     ur->last_transit = 0.0;
     ur->bitrate_window_start_ns = 0;
     ur->bitrate_window_bytes = 0;
+    ur->video_ssrc = 0;
+    ur->have_video_ssrc = FALSE;
     memset(&ur->stats, 0, sizeof(ur->stats));
     memset(ur->history, 0, sizeof(ur->history));
 }
@@ -310,6 +346,34 @@ static void process_rtp(struct UdpReceiver *ur,
 
     gboolean is_video = (parsed->payload_type == ur->vid_pt);
     gboolean is_audio = (parsed->payload_type == ur->aud_pt);
+    if (is_audio) {
+        ur->stats.audio_packets++;
+        ur->stats.audio_bytes += len;
+        advance_expected_sequence(ur, parsed);
+        return;
+    }
+
+    if (!is_video) {
+        ur->stats.ignored_packets++;
+        return;
+    }
+
+    if (!ur->have_video_ssrc || ur->video_ssrc != parsed->ssrc) {
+        ur->video_ssrc = parsed->ssrc;
+        ur->have_video_ssrc = TRUE;
+        ur->seq_initialized = FALSE;
+        ur->have_last_seq = FALSE;
+        ur->frame_active = FALSE;
+        ur->frame_bytes = 0;
+        ur->frame_missing = FALSE;
+        ur->transit_initialized = FALSE;
+    }
+
+    ur->stats.total_packets++;
+    ur->stats.total_bytes += len;
+    ur->stats.video_packets++;
+    ur->stats.video_bytes += len;
+    ur->stats.last_video_timestamp = parsed->timestamp;
 
     UdpReceiverPacketSample sample = {0};
     sample.sequence = parsed->sequence;
@@ -319,78 +383,64 @@ static void process_rtp(struct UdpReceiver *ur,
     sample.size = (guint32)len;
     sample.arrival_ns = arrival_ns;
 
-    ur->stats.total_packets++;
-    ur->stats.total_bytes += len;
-
-    if (is_video) {
-        ur->stats.video_packets++;
-        ur->stats.video_bytes += len;
-        ur->stats.last_video_timestamp = parsed->timestamp;
-
-        if (!ur->frame_active || ur->frame_timestamp != parsed->timestamp) {
-            if (ur->frame_active) {
-                finalize_frame(ur);
-            }
-            ur->frame_active = TRUE;
-            ur->frame_timestamp = parsed->timestamp;
-            ur->frame_bytes = len;
-            ur->frame_missing = FALSE;
-        } else {
-            ur->frame_bytes += len;
+    if (!ur->frame_active || ur->frame_timestamp != parsed->timestamp) {
+        if (ur->frame_active) {
+            finalize_frame(ur);
         }
-
-        if (!ur->seq_initialized) {
-            ur->seq_initialized = TRUE;
-            ur->expected_seq = seq_next(parsed->sequence);
-            ur->stats.expected_sequence = ur->expected_seq;
-        } else {
-            gint16 delta = seq_delta(parsed->sequence, ur->expected_seq);
-            if (delta == 0) {
-                ur->expected_seq = seq_next(parsed->sequence);
-            } else if (delta > 0) {
-                ur->stats.lost_packets += delta;
-                ur->expected_seq = seq_next(parsed->sequence);
-                ur->frame_missing = TRUE;
-                sample.flags |= UDP_SAMPLE_FLAG_LOSS;
-            } else { // delta < 0
-                ur->stats.reordered_packets++;
-                sample.flags |= UDP_SAMPLE_FLAG_REORDER;
-            }
-            ur->stats.expected_sequence = ur->expected_seq;
-        }
-
-        if (ur->have_last_seq && parsed->sequence == ur->last_seq) {
-            ur->stats.duplicate_packets++;
-            sample.flags |= UDP_SAMPLE_FLAG_DUPLICATE;
-        }
-        ur->last_seq = parsed->sequence;
-        ur->have_last_seq = TRUE;
-
-        double arrival_rtp = (double)arrival_ns / 1e9 * 90000.0;
-        double transit = arrival_rtp - (double)parsed->timestamp;
-        if (!ur->transit_initialized) {
-            ur->transit_initialized = TRUE;
-            ur->last_transit = transit;
-            ur->stats.jitter = 0.0;
-            ur->stats.jitter_avg = 0.0;
-        } else {
-            double d = transit - ur->last_transit;
-            ur->last_transit = transit;
-            ur->stats.jitter += (fabs(d) - ur->stats.jitter) / 16.0;
-            if (ur->stats.jitter_avg == 0.0) {
-                ur->stats.jitter_avg = ur->stats.jitter;
-            } else {
-                ur->stats.jitter_avg += (ur->stats.jitter - ur->stats.jitter_avg) * JITTER_EWMA_ALPHA;
-            }
-        }
-    } else if (is_audio) {
-        ur->stats.audio_packets++;
-        ur->stats.audio_bytes += len;
+        ur->frame_active = TRUE;
+        ur->frame_timestamp = parsed->timestamp;
+        ur->frame_bytes = len;
+        ur->frame_missing = FALSE;
     } else {
-        ur->stats.ignored_packets++;
+        ur->frame_bytes += len;
     }
 
-    if (parsed->marker && is_video) {
+    if (!ur->seq_initialized) {
+        ur->seq_initialized = TRUE;
+        ur->expected_seq = seq_next(parsed->sequence);
+        ur->stats.expected_sequence = ur->expected_seq;
+    } else {
+        gint16 delta = seq_delta(parsed->sequence, ur->expected_seq);
+        if (delta == 0) {
+            ur->expected_seq = seq_next(parsed->sequence);
+        } else if (delta > 0) {
+            ur->stats.lost_packets += delta;
+            ur->expected_seq = seq_next(parsed->sequence);
+            ur->frame_missing = TRUE;
+            sample.flags |= UDP_SAMPLE_FLAG_LOSS;
+        } else { // delta < 0
+            ur->stats.reordered_packets++;
+            sample.flags |= UDP_SAMPLE_FLAG_REORDER;
+        }
+        ur->stats.expected_sequence = ur->expected_seq;
+    }
+
+    if (ur->have_last_seq && parsed->sequence == ur->last_seq) {
+        ur->stats.duplicate_packets++;
+        sample.flags |= UDP_SAMPLE_FLAG_DUPLICATE;
+    }
+    ur->last_seq = parsed->sequence;
+    ur->have_last_seq = TRUE;
+
+    double arrival_rtp = (double)arrival_ns / 1e9 * 90000.0;
+    double transit = arrival_rtp - (double)parsed->timestamp;
+    if (!ur->transit_initialized) {
+        ur->transit_initialized = TRUE;
+        ur->last_transit = transit;
+        ur->stats.jitter = 0.0;
+        ur->stats.jitter_avg = 0.0;
+    } else {
+        double d = transit - ur->last_transit;
+        ur->last_transit = transit;
+        ur->stats.jitter += (fabs(d) - ur->stats.jitter) / 16.0;
+        if (ur->stats.jitter_avg == 0.0) {
+            ur->stats.jitter_avg = ur->stats.jitter;
+        } else {
+            ur->stats.jitter_avg += (ur->stats.jitter - ur->stats.jitter_avg) * JITTER_EWMA_ALPHA;
+        }
+    }
+
+    if (parsed->marker) {
         sample.flags |= UDP_SAMPLE_FLAG_FRAME_END;
         finalize_frame(ur);
     }
@@ -411,10 +461,16 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
 
     gst_buffer_set_size(gstbuf, (gsize)bytes_read);
 
+    guint64 arrival_ns = get_time_ns();
     gboolean drop_packet = FALSE;
+    gboolean mark_discont = FALSE;
+    gboolean target_is_audio = FALSE;
+    GstAppSrc *target_appsrc = NULL;
     RtpParseResult preview;
     gboolean have_preview = FALSE;
-    gboolean preview_initialized = FALSE;
+
+    g_mutex_lock(&ur->lock);
+
     gboolean filter_non_video = FALSE;
     if (ur->cfg != NULL && ur->cfg->no_audio) {
         filter_non_video = TRUE;
@@ -422,32 +478,47 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
     if (ur->aud_pt < 0) {
         filter_non_video = TRUE;
     }
-    if (filter_non_video) {
+
+    gboolean need_preview = filter_non_video || ur->audio_appsrc != NULL || ur->stats_enabled;
+    if (need_preview) {
         have_preview = parse_rtp(map->data, (gsize)bytes_read, &preview);
-        preview_initialized = TRUE;
     }
 
-    guint64 arrival_ns = get_time_ns();
-    gboolean mark_discont = FALSE;
-    g_mutex_lock(&ur->lock);
-    if (ur->discont_pending) {
-        mark_discont = TRUE;
-        ur->discont_pending = FALSE;
+    gboolean is_video = have_preview && preview.payload_type == ur->vid_pt;
+    gboolean is_audio = have_preview && preview.payload_type == ur->aud_pt;
+
+    const RtpParseResult *parsed = have_preview ? &preview : NULL;
+    if (ur->stats_enabled) {
+        process_rtp(ur, map->data, (gsize)bytes_read, arrival_ns, parsed);
     }
-    if (!preview_initialized && ur->stats_enabled) {
-        have_preview = parse_rtp(map->data, (gsize)bytes_read, &preview);
-        preview_initialized = TRUE;
-    }
-    if (filter_non_video && have_preview && preview.payload_type != ur->vid_pt) {
+
+    if (filter_non_video && have_preview && !is_video) {
+        drop_packet = TRUE;
+    } else if (is_audio && ur->audio_appsrc == NULL) {
         drop_packet = TRUE;
     } else {
-        process_rtp(ur, map->data, (gsize)bytes_read, arrival_ns, have_preview ? &preview : NULL);
+        if (is_audio && ur->audio_appsrc != NULL) {
+            target_appsrc = ur->audio_appsrc;
+            target_is_audio = TRUE;
+            if (ur->audio_discont_pending) {
+                mark_discont = TRUE;
+                ur->audio_discont_pending = FALSE;
+            }
+        } else {
+            target_appsrc = ur->video_appsrc;
+            target_is_audio = FALSE;
+            if (ur->video_discont_pending) {
+                mark_discont = TRUE;
+                ur->video_discont_pending = FALSE;
+            }
+        }
     }
+
     g_mutex_unlock(&ur->lock);
 
     gst_buffer_unmap(gstbuf, map);
 
-    if (drop_packet) {
+    if (drop_packet || target_appsrc == NULL) {
         gst_buffer_unref(gstbuf);
         return TRUE;
     }
@@ -457,9 +528,11 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
         GST_BUFFER_FLAG_SET(gstbuf, GST_BUFFER_FLAG_RESYNC);
     }
 
-    GstFlowReturn flow = gst_app_src_push_buffer(ur->appsrc, gstbuf);
+    GstFlowReturn flow = gst_app_src_push_buffer(target_appsrc, gstbuf);
     if (flow != GST_FLOW_OK) {
-        LOGV("UDP receiver: push_buffer returned %s", gst_flow_get_name(flow));
+        LOGV("UDP receiver: push_buffer (%s) returned %s",
+             target_is_audio ? "audio" : "video",
+             gst_flow_get_name(flow));
         if (flow == GST_FLOW_FLUSHING) {
             g_usleep(1000);
         }
@@ -655,8 +728,8 @@ static gpointer receiver_thread(gpointer data) {
     return NULL;
 }
 
-UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *appsrc) {
-    if (appsrc == NULL) {
+UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc) {
+    if (video_appsrc == NULL) {
         return NULL;
     }
     struct UdpReceiver *ur = g_new0(struct UdpReceiver, 1);
@@ -667,13 +740,34 @@ UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc
     ur->vid_pt = vid_pt;
     ur->aud_pt = aud_pt;
     ur->sockfd = -1;
-    ur->discont_pending = TRUE;
+    ur->video_discont_pending = TRUE;
+    ur->audio_discont_pending = TRUE;
     g_mutex_init(&ur->lock);
-    ur->appsrc = GST_APP_SRC(gst_object_ref(appsrc));
+    ur->video_appsrc = GST_APP_SRC(gst_object_ref(video_appsrc));
+    ur->audio_appsrc = NULL;
     ur->stats_enabled = FALSE;
     ur->pool = NULL;
     ur->buffer_size = 0;
     return ur;
+}
+
+void udp_receiver_set_audio_appsrc(UdpReceiver *ur, GstAppSrc *audio_appsrc) {
+    if (ur == NULL) {
+        return;
+    }
+
+    g_mutex_lock(&ur->lock);
+    if (ur->audio_appsrc != NULL) {
+        gst_object_unref(ur->audio_appsrc);
+        ur->audio_appsrc = NULL;
+    }
+    if (audio_appsrc != NULL) {
+        ur->audio_appsrc = GST_APP_SRC(gst_object_ref(audio_appsrc));
+        ur->audio_discont_pending = TRUE;
+    } else {
+        ur->audio_discont_pending = TRUE;
+    }
+    g_mutex_unlock(&ur->lock);
 }
 
 static int setup_socket_for_port(int port, int *out_fd, const char *label) {
@@ -732,7 +826,8 @@ int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot) {
         return 0;
     }
     reset_stats_locked(ur);
-    ur->discont_pending = TRUE;
+    ur->video_discont_pending = TRUE;
+    ur->audio_discont_pending = TRUE;
     ur->cfg = cfg;
     ur->cpu_slot = cpu_slot;
     g_mutex_unlock(&ur->lock);
@@ -797,13 +892,20 @@ void udp_receiver_stop(UdpReceiver *ur) {
         ur->sockfd = -1;
     }
 
-    gst_app_src_end_of_stream(ur->appsrc);
+    if (ur->video_appsrc != NULL) {
+        gst_app_src_end_of_stream(ur->video_appsrc);
+    }
+    if (ur->audio_appsrc != NULL) {
+        gst_app_src_end_of_stream(ur->audio_appsrc);
+    }
 
     buffer_pool_stop(ur);
 
     g_mutex_lock(&ur->lock);
     ur->running = FALSE;
     ur->stop_requested = FALSE;
+    ur->video_discont_pending = TRUE;
+    ur->audio_discont_pending = TRUE;
     g_mutex_unlock(&ur->lock);
 }
 
@@ -812,9 +914,13 @@ void udp_receiver_destroy(UdpReceiver *ur) {
         return;
     }
     udp_receiver_stop(ur);
-    if (ur->appsrc != NULL) {
-        gst_object_unref(ur->appsrc);
-        ur->appsrc = NULL;
+    if (ur->video_appsrc != NULL) {
+        gst_object_unref(ur->video_appsrc);
+        ur->video_appsrc = NULL;
+    }
+    if (ur->audio_appsrc != NULL) {
+        gst_object_unref(ur->audio_appsrc);
+        ur->audio_appsrc = NULL;
     }
     buffer_pool_stop(ur);
     g_mutex_clear(&ur->lock);

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdint.h>
 #include <sys/ioctl.h>
 #include <time.h>
 #include <unistd.h>
@@ -505,8 +506,13 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
 
     set_mpp_decoding_parameters(vd);
 
+#if defined(MPP_SET_OUTPUT_TIMEOUT)
+    int64_t timeout = -1;
+    vd->mpi->control(vd->ctx, MPP_SET_OUTPUT_TIMEOUT, &timeout);
+#else
     int block = MPP_POLL_BLOCK;
     vd->mpi->control(vd->ctx, MPP_SET_OUTPUT_BLOCK, &block);
+#endif
 
     g_mutex_init(&vd->lock);
     g_cond_init(&vd->cond);


### PR DESCRIPTION
## Summary
- track the SSRC of the active video stream and ignore audio packets from other SSRCs when adjusting the expected sequence
- bound the audio-driven sequence advance so only small forward steps update the video counters and reset the tracker on SSRC changes
- document the sequence-tracking guardrails for audio/video interleaving in the UDP receiver README section

## Testing
- make *(fails: missing xf86drm.h headers in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e287e9f69c832b9110ed8c12d1250e