### PR TITLE
Add splash fallback for idle UDP streams

### DIFF
--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -12,6 +12,22 @@ port = 5600
 video-pt = 97
 audio-pt = 98
 
+[splash]
+; Provide an Annex-B H.265 file with repeated key frames for the idle slate.
+enable = false
+input = /opt/pixelpilot/splash/standby.h265
+fps = 30.0
+idle-timeout-ms = 2000
+default-sequence = intro
+
+[splash.sequence.intro]
+start = 0
+end = 179
+
+[splash.sequence.loop]
+start = 180
+end = 359
+
 [pipeline]
 latency-ms = 8
 custom-sink = receiver

--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,8 @@
 
 #include "osd_layout.h"
 
+#define SPLASH_MAX_SEQUENCES 32
+
 #ifndef CPU_SETSIZE
 #define CPU_SETSIZE ((int)(sizeof(cpu_set_t) * CHAR_BIT))
 #endif
@@ -14,6 +16,22 @@ typedef enum {
     CUSTOM_SINK_RECEIVER = 0,
     CUSTOM_SINK_UDPSRC,
 } CustomSinkMode;
+
+typedef struct {
+    char name[64];
+    int start_frame;
+    int end_frame;
+} SplashSequenceCfg;
+
+typedef struct {
+    int enable;
+    int idle_timeout_ms;
+    double fps;
+    char input_path[PATH_MAX];
+    char default_sequence[64];
+    int sequence_count;
+    SplashSequenceCfg sequences[SPLASH_MAX_SEQUENCES];
+} SplashCfg;
 
 typedef struct {
     char card_path[64];
@@ -46,6 +64,8 @@ typedef struct {
     int cpu_affinity_count;
 
     OsdLayout osd_layout;
+
+    SplashCfg splash;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -13,10 +13,13 @@ typedef enum {
     PIPELINE_STOPPING = 2
 } PipelineStateEnum;
 
+struct Splash;
+
 typedef struct {
     PipelineStateEnum state;
     GstElement *pipeline;
     GstElement *video_sink;
+    GstElement *input_selector;
     UdpReceiver *udp_receiver;
     GThread *bus_thread;
     GThread *appsink_thread;
@@ -33,6 +36,16 @@ typedef struct {
     VideoDecoder *decoder;
     gboolean decoder_initialized;
     gboolean decoder_running;
+    struct Splash *splash;
+    GThread *splash_loop_thread;
+    gboolean splash_loop_running;
+    GstPad *selector_udp_pad;
+    GstPad *selector_splash_pad;
+    gboolean splash_active;
+    gboolean splash_available;
+    guint splash_idle_timeout_ms;
+    guint64 pipeline_start_ns;
+    guint64 last_udp_activity_ns;
 } PipelineState;
 
 #include "config.h"

--- a/include/splashlib.h
+++ b/include/splashlib.h
@@ -1,0 +1,114 @@
+#ifndef SPLASHLIB_H
+#define SPLASHLIB_H
+
+#include <gst/gst.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque handle
+typedef struct Splash Splash;
+
+// Named sequence: inclusive frame indices [start..end]
+typedef struct {
+    const char *name;   // non-owning utf8 string
+    int start_frame;    // e.g., 0
+    int end_frame;      // e.g., 180
+} SplashSeq;
+
+// Output selection
+typedef enum {
+    SPLASH_OUTPUT_NONE   = 0,
+    SPLASH_OUTPUT_UDP    = 1 << 0,
+    SPLASH_OUTPUT_APPSRC = 1 << 1,
+} SplashOutputMode;
+
+// UDP endpoint
+typedef struct {
+    const char *host;  // e.g., "127.0.0.1"
+    int port;          // e.g., 5600
+} SplashEndpoint;
+
+// Configuration
+typedef struct {
+    const char *input_path;   // Annex-B H.265 elementary stream (AUD+VUI recommended)
+    double fps;               // e.g., 30.0
+    SplashOutputMode outputs; // Bitmask of SPLASH_OUTPUT_* values (defaults to UDP)
+    SplashEndpoint endpoint;  // UDP host+port
+} SplashConfig;
+
+// Event callback (optional)
+typedef enum {
+    SPLASH_EVT_STARTED,
+    SPLASH_EVT_STOPPED,
+    SPLASH_EVT_SWITCHED_AT_BOUNDARY,  // payload: from_idx -> to_idx
+    SPLASH_EVT_QUEUED_NEXT,           // payload: to_idx
+    SPLASH_EVT_CLEARED_QUEUE,
+    SPLASH_EVT_ERROR                  // payload: const char* message
+} SplashEventType;
+
+typedef void (*SplashEventCb)(SplashEventType type, int a, int b, const char *msg, void *user);
+
+// ---- Lifecycle ----
+Splash* splash_new(void);
+void    splash_free(Splash *s);
+
+// Configure named sequences (can be called any time; thread-safe)
+bool splash_set_sequences(Splash *s, const SplashSeq *seqs, int n_seqs);
+
+// Full (re)configuration of pipelines (safe to call while running)
+bool splash_apply_config(Splash *s, const SplashConfig *cfg);
+
+// Start/Run/Stop
+bool splash_start(Splash *s);
+void splash_run(Splash *s);    // blocks: runs internal GMainLoop
+void splash_quit(Splash *s);   // quits the loop (non-blocking)
+void splash_stop(Splash *s);   // stops pipelines
+
+// ---- Control / Queue API ----
+// Multi-queue model: current loops forever; queued entries take over at segment boundaries.
+// Returns false if any index/name is invalid or the queue would overflow.
+bool splash_enqueue_next_by_index(Splash *s, int idx);
+bool splash_enqueue_next_by_name(Splash *s, const char *name);
+bool splash_enqueue_next_many(Splash *s, const int *indices, int n_indices);
+
+// Convenience helper for the common "enqueue + choose repeat" workflow. The
+// repeat behavior controls what happens after the queued items finish:
+//   SPLASH_REPEAT_NONE  -> disable any custom repeat order.
+//   SPLASH_REPEAT_LAST  -> loop the last queued index indefinitely.
+//   SPLASH_REPEAT_FULL  -> loop the full queued order.
+// Returns false if queuing fails (invalid indices or queue full).
+typedef enum {
+    SPLASH_REPEAT_NONE = 0,
+    SPLASH_REPEAT_LAST,
+    SPLASH_REPEAT_FULL,
+} SplashRepeatMode;
+
+bool splash_enqueue_with_repeat(Splash *s,
+                                                                const int *indices,
+                                                                int n_indices,
+                                                                SplashRepeatMode repeat);
+
+void splash_clear_next(Splash *s);
+
+// Configure automatic looping order once the queue drains. Passing NULL or
+// n_indices<=0 disables any custom repeat behavior.
+void splash_set_repeat_order(Splash *s, const int *indices, int n_indices);
+
+// Query helpers (optional)
+int  splash_active_index(Splash *s);          // -1 if none
+int  splash_pending_index(Splash *s);         // -1 if none
+int  splash_find_index_by_name(Splash *s, const char *name);
+
+// Logging / events
+void splash_set_event_cb(Splash *s, SplashEventCb cb, void *user);
+
+// Accessors for optional outputs
+GstElement* splash_get_appsrc(Splash *s); // returns new ref or NULL when disabled
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -55,6 +55,7 @@ typedef struct {
     size_t history_count;
     size_t history_head;
     UdpReceiverPacketSample history[UDP_RECEIVER_HISTORY];
+    guint64 last_packet_ns;
 } UdpReceiverStats;
 
 typedef struct UdpReceiver UdpReceiver;
@@ -66,6 +67,7 @@ void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);
 void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats);
 void udp_receiver_set_stats_enabled(UdpReceiver *ur, gboolean enabled);
+guint64 udp_receiver_get_last_packet_time(UdpReceiver *ur);
 #ifdef __cplusplus
 }
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -105,6 +105,18 @@ void cfg_defaults(AppCfg *c) {
     memset(c->cpu_affinity_order, 0, sizeof(c->cpu_affinity_order));
 
     osd_layout_defaults(&c->osd_layout);
+
+    c->splash.enable = 0;
+    c->splash.idle_timeout_ms = 2000;
+    c->splash.fps = 30.0;
+    c->splash.input_path[0] = '\0';
+    c->splash.default_sequence[0] = '\0';
+    c->splash.sequence_count = 0;
+    for (int i = 0; i < SPLASH_MAX_SEQUENCES; ++i) {
+        c->splash.sequences[i].name[0] = '\0';
+        c->splash.sequences[i].start_frame = -1;
+        c->splash.sequences[i].end_frame = -1;
+    }
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -218,6 +218,108 @@ static int parse_bool(const char *value, int *out) {
     return -1;
 }
 
+static int parse_double(const char *value, double *out) {
+    if (value == NULL || out == NULL) {
+        return -1;
+    }
+    char *end = NULL;
+    double v = strtod(value, &end);
+    if (end == value || end == NULL) {
+        return -1;
+    }
+    *out = v;
+    return 0;
+}
+
+static SplashSequenceCfg *splash_find_sequence(SplashCfg *splash, const char *name) {
+    if (splash == NULL || name == NULL || *name == '\0') {
+        return NULL;
+    }
+    for (int i = 0; i < splash->sequence_count; ++i) {
+        if (strcmp(splash->sequences[i].name, name) == 0) {
+            return &splash->sequences[i];
+        }
+    }
+    return NULL;
+}
+
+static SplashSequenceCfg *splash_ensure_sequence(SplashCfg *splash, const char *name) {
+    if (splash == NULL || name == NULL || *name == '\0') {
+        return NULL;
+    }
+    SplashSequenceCfg *seq = splash_find_sequence(splash, name);
+    if (seq != NULL) {
+        return seq;
+    }
+    if (splash->sequence_count >= SPLASH_MAX_SEQUENCES) {
+        return NULL;
+    }
+    seq = &splash->sequences[splash->sequence_count++];
+    memset(seq, 0, sizeof(*seq));
+    ini_copy_string(seq->name, sizeof(seq->name), name);
+    seq->start_frame = -1;
+    seq->end_frame = -1;
+    return seq;
+}
+
+static int parse_splash_section(AppCfg *cfg, const char *key, const char *value) {
+    if (strcasecmp(key, "enable") == 0) {
+        int v = 0;
+        if (parse_bool(value, &v) != 0) {
+            return -1;
+        }
+        cfg->splash.enable = v;
+        return 0;
+    }
+    if (strcasecmp(key, "input") == 0 || strcasecmp(key, "input-path") == 0) {
+        ini_copy_string(cfg->splash.input_path, sizeof(cfg->splash.input_path), value);
+        return 0;
+    }
+    if (strcasecmp(key, "fps") == 0) {
+        double fps = 0.0;
+        if (parse_double(value, &fps) != 0) {
+            return -1;
+        }
+        cfg->splash.fps = fps;
+        return 0;
+    }
+    if (strcasecmp(key, "idle-timeout-ms") == 0) {
+        cfg->splash.idle_timeout_ms = atoi(value);
+        if (cfg->splash.idle_timeout_ms < 0) {
+            cfg->splash.idle_timeout_ms = 0;
+        }
+        return 0;
+    }
+    if (strcasecmp(key, "default-sequence") == 0) {
+        ini_copy_string(cfg->splash.default_sequence, sizeof(cfg->splash.default_sequence), value);
+        return 0;
+    }
+    return -1;
+}
+
+static int parse_splash_sequence(AppCfg *cfg, const char *section, const char *key, const char *value) {
+    const char *prefix = "splash.sequence.";
+    size_t prefix_len = strlen(prefix);
+    if (strncasecmp(section, prefix, prefix_len) != 0) {
+        return -1;
+    }
+    const char *name = section + prefix_len;
+    SplashSequenceCfg *seq = splash_ensure_sequence(&cfg->splash, name);
+    if (seq == NULL) {
+        LOGE("config: too many splash sequences defined (max %d)", SPLASH_MAX_SEQUENCES);
+        return -1;
+    }
+    if (strcasecmp(key, "start") == 0 || strcasecmp(key, "start-frame") == 0) {
+        seq->start_frame = atoi(value);
+        return 0;
+    }
+    if (strcasecmp(key, "end") == 0 || strcasecmp(key, "end-frame") == 0) {
+        seq->end_frame = atoi(value);
+        return 0;
+    }
+    return -1;
+}
+
 static int parse_named_color(const char *value, uint32_t *out) {
     static const struct {
         const char *name;
@@ -768,6 +870,19 @@ int cfg_load_file(const char *path, AppCfg *cfg) {
             value = value + 1;
         }
 
+        if (strncasecmp(current_section, "splash.sequence.", strlen("splash.sequence.")) == 0) {
+            if (parse_splash_sequence(cfg, current_section, key, value) != 0) {
+                LOGE("config:%d: failed to parse splash sequence setting %s", lineno, key);
+                fclose(fp);
+                return -1;
+            }
+            continue;
+        }
+        if (strcasecmp(current_section, "splash") == 0) {
+            if (parse_splash_section(cfg, key, value) == 0) {
+                continue;
+            }
+        }
         if (strncasecmp(current_section, "osd.element.", strlen("osd.element.")) == 0) {
             if (parse_osd_element(&builder, current_section, key, value) != 0) {
                 LOGE("config:%d: failed to parse osd element setting %s", lineno, key);
@@ -792,6 +907,21 @@ int cfg_load_file(const char *path, AppCfg *cfg) {
 
     if (builder_finalize(&builder, &cfg->osd_layout) != 0) {
         return -1;
+    }
+
+    if (cfg->splash.sequence_count > SPLASH_MAX_SEQUENCES) {
+        cfg->splash.sequence_count = SPLASH_MAX_SEQUENCES;
+    }
+    for (int i = 0; i < cfg->splash.sequence_count; ++i) {
+        SplashSequenceCfg *seq = &cfg->splash.sequences[i];
+        if (seq->start_frame < 0 || seq->end_frame < 0) {
+            LOGE("config: splash sequence '%s' missing start/end", seq->name);
+            return -1;
+        }
+        if (seq->end_frame < seq->start_frame) {
+            LOGE("config: splash sequence '%s' has end before start", seq->name);
+            return -1;
+        }
     }
 
     return 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -12,15 +12,23 @@
 #define MAX_INI_LINE 512
 
 static void ini_copy_string(char *dst, size_t dst_sz, const char *src) {
-    if (!dst || dst_sz == 0) {
+    if (dst == NULL || dst_sz == 0) {
         return;
     }
-    if (!src) {
+    if (src == NULL) {
         dst[0] = '\0';
         return;
     }
-    strncpy(dst, src, dst_sz - 1);
-    dst[dst_sz - 1] = '\0';
+
+    size_t copy_len = strlen(src);
+    if (copy_len >= dst_sz) {
+        copy_len = dst_sz - 1;
+    }
+
+    if (copy_len > 0) {
+        memcpy(dst, src, copy_len);
+    }
+    dst[copy_len] = '\0';
 }
 
 typedef struct {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -34,7 +34,7 @@ static void release_selector_pad(GstElement *selector, GstPad **pad_slot) {
     }
 
     GstPad *pad = *pad_slot;
-    if (selector != NULL && GST_PAD_IS_REQUEST(pad)) {
+    if (selector != NULL) {
         gst_element_release_request_pad(selector, pad);
     }
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -2,6 +2,7 @@
 
 #include "pipeline.h"
 #include "logging.h"
+#include "splashlib.h"
 
 #ifndef GST_USE_UNSTABLE_API
 #define GST_USE_UNSTABLE_API
@@ -26,6 +27,294 @@
             goto fail;                                                                              \
         }                                                                                           \
     } while (0)
+
+static guint64 monotonic_time_ns(void) {
+    return (guint64)g_get_monotonic_time() * 1000ull;
+}
+
+static gpointer splash_loop_thread_func(gpointer data) {
+    PipelineState *ps = (PipelineState *)data;
+    Splash *splash = NULL;
+
+    g_mutex_lock(&ps->lock);
+    ps->splash_loop_running = TRUE;
+    splash = ps->splash;
+    g_mutex_unlock(&ps->lock);
+
+    if (splash != NULL) {
+        splash_run(splash);
+    }
+
+    g_mutex_lock(&ps->lock);
+    ps->splash_loop_running = FALSE;
+    g_mutex_unlock(&ps->lock);
+    return NULL;
+}
+
+static gboolean pipeline_prepare_splash(PipelineState *ps,
+                                        const AppCfg *cfg,
+                                        GstElement *pipeline,
+                                        GstElement *selector) {
+    ps->splash_available = FALSE;
+    if (ps == NULL || cfg == NULL || pipeline == NULL || selector == NULL) {
+        return FALSE;
+    }
+
+    if (!cfg->splash.enable) {
+        return TRUE;
+    }
+    if (cfg->splash.sequence_count <= 0 || cfg->splash.input_path[0] == '\0') {
+        LOGW("Splash fallback enabled but missing input or sequences; disabling");
+        return TRUE;
+    }
+
+    Splash *splash = splash_new();
+    if (splash == NULL) {
+        LOGE("Failed to allocate splash player state");
+        return FALSE;
+    }
+    ps->splash = splash;
+
+    GstElement *splash_appsrc = NULL;
+    GstElement *splash_queue = NULL;
+
+    int seq_count = cfg->splash.sequence_count;
+    if (seq_count > SPLASH_MAX_SEQUENCES) {
+        seq_count = SPLASH_MAX_SEQUENCES;
+    }
+
+    SplashSeq seqs[SPLASH_MAX_SEQUENCES];
+    for (int i = 0; i < seq_count; ++i) {
+        seqs[i].name = cfg->splash.sequences[i].name;
+        seqs[i].start_frame = cfg->splash.sequences[i].start_frame;
+        seqs[i].end_frame = cfg->splash.sequences[i].end_frame;
+    }
+
+    if (!splash_set_sequences(splash, seqs, seq_count)) {
+        LOGE("Failed to load splash sequences");
+        goto fail;
+    }
+
+    double fps = cfg->splash.fps > 0.0 ? cfg->splash.fps : 30.0;
+    SplashConfig splash_cfg = {0};
+    splash_cfg.input_path = cfg->splash.input_path;
+    splash_cfg.fps = fps;
+    splash_cfg.outputs = SPLASH_OUTPUT_APPSRC;
+
+    if (!splash_apply_config(splash, &splash_cfg)) {
+        LOGE("Failed to configure splash playback");
+        goto fail;
+    }
+
+    splash_clear_next(splash);
+    int order[SPLASH_MAX_SEQUENCES];
+    int order_count = 0;
+    int start_index = 0;
+    if (cfg->splash.default_sequence[0] != '\0') {
+        int idx = splash_find_index_by_name(splash, cfg->splash.default_sequence);
+        if (idx >= 0) {
+            start_index = idx;
+        } else {
+            LOGW("Splash default-sequence '%s' not found; starting from first sequence", cfg->splash.default_sequence);
+        }
+    }
+    for (int i = 0; i < seq_count; ++i) {
+        int idx = (start_index + i) % seq_count;
+        order[order_count++] = idx;
+    }
+    if (order_count > 0) {
+        SplashRepeatMode repeat_mode = order_count > 1 ? SPLASH_REPEAT_FULL : SPLASH_REPEAT_LAST;
+        if (!splash_enqueue_with_repeat(splash, order, order_count, repeat_mode)) {
+            LOGW("Failed to configure splash repeat order; disabling repeat loop");
+            splash_set_repeat_order(splash, NULL, 0);
+        }
+    }
+
+    splash_appsrc = splash_get_appsrc(splash);
+    if (splash_appsrc == NULL) {
+        LOGE("Failed to obtain splash appsrc element");
+        goto fail;
+    }
+
+    splash_queue = gst_element_factory_make("queue", "splash_queue");
+    if (splash_queue == NULL) {
+        LOGE("Failed to create splash queue element");
+        gst_object_unref(splash_appsrc);
+        goto fail;
+    }
+
+    g_object_set(splash_queue, "leaky", 2, "max-size-buffers", 16, "max-size-bytes", (guint64)0,
+                 "max-size-time", (guint64)0, NULL);
+
+    gst_bin_add_many(GST_BIN(pipeline), splash_appsrc, splash_queue, NULL);
+    if (!gst_element_link_many(splash_appsrc, splash_queue, selector, NULL)) {
+        LOGE("Failed to link splash branch into selector");
+        gst_bin_remove(GST_BIN(pipeline), splash_queue);
+        gst_bin_remove(GST_BIN(pipeline), splash_appsrc);
+        splash_queue = NULL;
+        splash_appsrc = NULL;
+        goto fail;
+    }
+
+    GstPad *queue_src = gst_element_get_static_pad(splash_queue, "src");
+    if (queue_src != NULL) {
+        ps->selector_splash_pad = gst_pad_get_peer(queue_src);
+        gst_object_unref(queue_src);
+    }
+    if (ps->selector_splash_pad == NULL) {
+        LOGE("Failed to obtain selector pad for splash branch");
+        gst_bin_remove(GST_BIN(pipeline), splash_queue);
+        gst_bin_remove(GST_BIN(pipeline), splash_appsrc);
+        splash_queue = NULL;
+        splash_appsrc = NULL;
+        goto fail;
+    }
+
+    ps->splash_loop_thread = g_thread_new("splash-loop", splash_loop_thread_func, ps);
+    if (ps->splash_loop_thread == NULL) {
+        LOGE("Failed to start splash main loop thread");
+        goto fail_thread;
+    }
+
+    if (!splash_start(splash)) {
+        LOGE("Failed to start splash playback");
+        goto fail_thread;
+    }
+
+    ps->splash_available = TRUE;
+    ps->splash_active = FALSE;
+    LOGI("Splash fallback ready with %d sequence(s)", order_count);
+    return TRUE;
+
+fail_thread:
+    if (ps->splash_loop_thread != NULL) {
+        splash_quit(ps->splash);
+        g_thread_join(ps->splash_loop_thread);
+        ps->splash_loop_thread = NULL;
+        ps->splash_loop_running = FALSE;
+    }
+    if (ps->selector_splash_pad != NULL) {
+        gst_object_unref(ps->selector_splash_pad);
+        ps->selector_splash_pad = NULL;
+    }
+    if (splash_queue != NULL) {
+        if (GST_OBJECT_PARENT(splash_queue) == GST_OBJECT(pipeline)) {
+            gst_bin_remove(GST_BIN(pipeline), splash_queue);
+        } else {
+            gst_object_unref(splash_queue);
+        }
+        splash_queue = NULL;
+    }
+    if (splash_appsrc != NULL) {
+        if (GST_OBJECT_PARENT(splash_appsrc) == GST_OBJECT(pipeline)) {
+            gst_bin_remove(GST_BIN(pipeline), splash_appsrc);
+        } else {
+            gst_object_unref(splash_appsrc);
+        }
+        splash_appsrc = NULL;
+    }
+fail:
+    if (splash_queue != NULL) {
+        if (GST_OBJECT_PARENT(splash_queue) == GST_OBJECT(pipeline)) {
+            gst_bin_remove(GST_BIN(pipeline), splash_queue);
+        } else {
+            gst_object_unref(splash_queue);
+        }
+        splash_queue = NULL;
+    }
+    if (splash_appsrc != NULL) {
+        if (GST_OBJECT_PARENT(splash_appsrc) == GST_OBJECT(pipeline)) {
+            gst_bin_remove(GST_BIN(pipeline), splash_appsrc);
+        } else {
+            gst_object_unref(splash_appsrc);
+        }
+        splash_appsrc = NULL;
+    }
+    if (ps->splash != NULL) {
+        splash_stop(ps->splash);
+        splash_free(ps->splash);
+        ps->splash = NULL;
+    }
+    ps->splash_available = FALSE;
+    ps->splash_active = FALSE;
+    return FALSE;
+}
+
+static void pipeline_teardown_splash(PipelineState *ps) {
+    if (ps == NULL) {
+        return;
+    }
+    if (ps->splash != NULL) {
+        splash_stop(ps->splash);
+    }
+    if (ps->splash_loop_thread != NULL) {
+        splash_quit(ps->splash);
+        g_thread_join(ps->splash_loop_thread);
+        ps->splash_loop_thread = NULL;
+    }
+    if (ps->splash != NULL) {
+        splash_free(ps->splash);
+        ps->splash = NULL;
+    }
+    ps->splash_loop_running = FALSE;
+    if (ps->selector_udp_pad != NULL) {
+        gst_object_unref(ps->selector_udp_pad);
+        ps->selector_udp_pad = NULL;
+    }
+    if (ps->selector_splash_pad != NULL) {
+        gst_object_unref(ps->selector_splash_pad);
+        ps->selector_splash_pad = NULL;
+    }
+    ps->input_selector = NULL;
+    ps->splash_available = FALSE;
+    ps->splash_active = FALSE;
+}
+
+static void pipeline_update_splash(PipelineState *ps) {
+    if (ps == NULL) {
+        return;
+    }
+    if (!ps->splash_available || ps->udp_receiver == NULL) {
+        return;
+    }
+
+    guint idle_ms = ps->splash_idle_timeout_ms;
+    if (idle_ms == 0) {
+        return;
+    }
+
+    guint64 last_packet = udp_receiver_get_last_packet_time(ps->udp_receiver);
+    guint64 reference_ns = last_packet != 0 ? last_packet : ps->pipeline_start_ns;
+    if (reference_ns == 0) {
+        return;
+    }
+
+    guint64 now_ns = monotonic_time_ns();
+    guint64 diff_ms = now_ns > reference_ns ? (now_ns - reference_ns) / 1000000ull : 0;
+
+    g_mutex_lock(&ps->lock);
+    gboolean active = ps->splash_active;
+    ps->last_udp_activity_ns = last_packet;
+    g_mutex_unlock(&ps->lock);
+
+    if (!active && diff_ms >= idle_ms) {
+        g_mutex_lock(&ps->lock);
+        if (!ps->splash_active && ps->selector_splash_pad != NULL && ps->input_selector != NULL) {
+            LOGI("Activating splash fallback after %u ms without video", idle_ms);
+            g_object_set(ps->input_selector, "active-pad", ps->selector_splash_pad, NULL);
+            ps->splash_active = TRUE;
+        }
+        g_mutex_unlock(&ps->lock);
+    } else if (active && last_packet != 0 && diff_ms < idle_ms) {
+        g_mutex_lock(&ps->lock);
+        if (ps->splash_active && ps->selector_udp_pad != NULL && ps->input_selector != NULL) {
+            LOGI("Video stream detected; returning to UDP input");
+            g_object_set(ps->input_selector, "active-pad", ps->selector_udp_pad, NULL);
+            ps->splash_active = FALSE;
+        }
+        g_mutex_unlock(&ps->lock);
+    }
+}
 
 static void ensure_gst_initialized(const AppCfg *cfg) {
     static gsize inited = 0;
@@ -103,6 +392,8 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     GstElement *pipeline = NULL;
     GstElement *appsrc = NULL;
     GstElement *depay = NULL;
+    GstElement *udp_queue = NULL;
+    GstElement *selector = NULL;
     GstElement *parser = NULL;
     GstElement *capsfilter = NULL;
     GstElement *appsink = NULL;
@@ -118,6 +409,18 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     GstElement *audio_sink = NULL;
     GstCaps *audio_caps = NULL;
 
+    if (ps->selector_udp_pad != NULL) {
+        gst_object_unref(ps->selector_udp_pad);
+        ps->selector_udp_pad = NULL;
+    }
+    if (ps->selector_splash_pad != NULL) {
+        gst_object_unref(ps->selector_splash_pad);
+        ps->selector_splash_pad = NULL;
+    }
+    ps->input_selector = NULL;
+    ps->splash_active = FALSE;
+    ps->splash_available = FALSE;
+
     pipeline = gst_pipeline_new("pixelpilot-receiver");
     CHECK_ELEM(pipeline, "pipeline");
 
@@ -128,8 +431,14 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
 
     depay = gst_element_factory_make("rtph265depay", "video_depay");
     CHECK_ELEM(depay, "rtph265depay");
+    udp_queue = gst_element_factory_make("queue", "udp_queue");
+    CHECK_ELEM(udp_queue, "queue");
+    selector = gst_element_factory_make("input-selector", "video_selector");
+    CHECK_ELEM(selector, "input-selector");
     parser = gst_element_factory_make("h265parse", "video_parser");
     CHECK_ELEM(parser, "h265parse");
+    capsfilter = gst_element_factory_make("capsfilter", "video_capsfilter");
+    CHECK_ELEM(capsfilter, "capsfilter");
     appsink = gst_element_factory_make("appsink", "out_appsink");
     CHECK_ELEM(appsink, "appsink");
 
@@ -145,9 +454,6 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
         LOGW("Failed to force h265parse alignment=au; downstream decoder may misbehave");
     }
 
-    capsfilter = gst_element_factory_make("capsfilter", "video_capsfilter");
-    CHECK_ELEM(capsfilter, "capsfilter");
-
     raw_caps = gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "byte-stream",
                                    "alignment", G_TYPE_STRING, "au", NULL);
     if (raw_caps == NULL) {
@@ -159,10 +465,40 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     gst_caps_unref(raw_caps);
     raw_caps = NULL;
 
-    gst_bin_add_many(GST_BIN(pipeline), appsrc, depay, parser, capsfilter, appsink, NULL);
-    if (!gst_element_link_many(appsrc, depay, parser, capsfilter, appsink, NULL)) {
+    g_object_set(udp_queue, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
+                 "max-size-buffers", 16, NULL);
+    g_object_set(selector, "sync-streams", FALSE, NULL);
+
+    gst_bin_add_many(GST_BIN(pipeline), appsrc, depay, udp_queue, selector, parser, capsfilter, appsink, NULL);
+    if (!gst_element_link_many(appsrc, depay, udp_queue, NULL)) {
+        LOGE("Failed to link UDP receiver passthrough source chain");
+        goto fail;
+    }
+    if (!gst_element_link(udp_queue, selector)) {
+        LOGE("Failed to link UDP queue into selector");
+        goto fail;
+    }
+    if (!gst_element_link_many(selector, parser, capsfilter, appsink, NULL)) {
         LOGE("Failed to link UDP receiver passthrough pipeline");
         goto fail;
+    }
+
+    GstPad *udp_src_pad = gst_element_get_static_pad(udp_queue, "src");
+    if (udp_src_pad != NULL) {
+        ps->selector_udp_pad = gst_pad_get_peer(udp_src_pad);
+        gst_object_unref(udp_src_pad);
+    }
+    if (ps->selector_udp_pad == NULL) {
+        LOGE("Failed to obtain selector pad for UDP branch");
+        goto fail;
+    }
+
+    if (!pipeline_prepare_splash(ps, cfg, pipeline, selector)) {
+        goto fail;
+    }
+
+    if (ps->selector_udp_pad != NULL) {
+        g_object_set(selector, "active-pad", ps->selector_udp_pad, NULL);
     }
 
     gboolean enable_audio = (!cfg->no_audio && cfg->aud_pt >= 0 && !audio_disabled);
@@ -186,8 +522,7 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
         CHECK_ELEM(audio_sink, "alsasink");
 
         g_object_set(audio_appsrc, "is-live", TRUE, "format", GST_FORMAT_TIME, "stream-type",
-                     GST_APP_STREAM_TYPE_STREAM, "do-timestamp", TRUE, "max-bytes", (guint64)(1024 * 1024),
-                     NULL);
+                     GST_APP_STREAM_TYPE_STREAM, "do-timestamp", TRUE, "max-bytes", (guint64)(1024 * 1024), NULL);
         gst_app_src_set_latency(GST_APP_SRC(audio_appsrc), 0, 0);
         gst_app_src_set_max_bytes(GST_APP_SRC(audio_appsrc), 1024 * 1024);
 
@@ -202,8 +537,7 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
         gst_caps_unref(audio_caps);
         audio_caps = NULL;
 
-        g_object_set(audio_queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     NULL);
+        g_object_set(audio_queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0, NULL);
         g_object_set(audio_queue_sink, "leaky", 2, NULL);
         g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE, NULL);
 
@@ -229,6 +563,7 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     ps->pipeline = pipeline;
     ps->video_sink = appsink;
     ps->udp_receiver = receiver;
+    ps->input_selector = selector;
     return TRUE;
 
 fail:
@@ -274,6 +609,12 @@ fail:
     if (parser != NULL && GST_OBJECT_PARENT(parser) == NULL) {
         gst_object_unref(parser);
     }
+    if (selector != NULL && GST_OBJECT_PARENT(selector) == NULL) {
+        gst_object_unref(selector);
+    }
+    if (udp_queue != NULL && GST_OBJECT_PARENT(udp_queue) == NULL) {
+        gst_object_unref(udp_queue);
+    }
     if (depay != NULL && GST_OBJECT_PARENT(depay) == NULL) {
         gst_object_unref(depay);
     }
@@ -286,8 +627,20 @@ fail:
     ps->pipeline = NULL;
     ps->video_sink = NULL;
     ps->udp_receiver = NULL;
+    ps->input_selector = NULL;
+    if (ps->selector_udp_pad != NULL) {
+        gst_object_unref(ps->selector_udp_pad);
+        ps->selector_udp_pad = NULL;
+    }
+    if (ps->selector_splash_pad != NULL) {
+        gst_object_unref(ps->selector_splash_pad);
+        ps->selector_splash_pad = NULL;
+    }
+    ps->splash_available = FALSE;
+    ps->splash_active = FALSE;
     return FALSE;
 }
+
 
 static gboolean setup_gst_udpsrc_pipeline(PipelineState *ps, const AppCfg *cfg) {
     if (ps == NULL || cfg == NULL) {
@@ -666,6 +1019,7 @@ static void cleanup_pipeline(PipelineState *ps) {
         udp_receiver_destroy(ps->udp_receiver);
         ps->udp_receiver = NULL;
     }
+    pipeline_teardown_splash(ps);
     ps->video_sink = NULL;
     if (ps->pipeline != NULL) {
         gst_object_unref(ps->pipeline);
@@ -707,6 +1061,15 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
     ps->cfg = cfg;
     ps->bus_thread_cpu_slot = 0;
 
+    if (cfg->splash.idle_timeout_ms > 0) {
+        ps->splash_idle_timeout_ms = (guint)cfg->splash.idle_timeout_ms;
+    } else {
+        ps->splash_idle_timeout_ms = 0;
+    }
+    ps->pipeline_start_ns = monotonic_time_ns();
+    ps->last_udp_activity_ns = 0;
+    ps->splash_active = FALSE;
+
     GstElement *pipeline = NULL;
     gboolean force_audio_disabled = FALSE;
 
@@ -743,6 +1106,8 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
             goto fail;
         }
     }
+
+    ps->pipeline_start_ns = monotonic_time_ns();
 
     if (drm_fd < 0) {
         LOGE("Invalid DRM file descriptor");
@@ -884,6 +1249,8 @@ void pipeline_poll_child(PipelineState *ps) {
             LOGI("Pipeline exited cleanly");
         }
     }
+
+    pipeline_update_splash(ps);
 }
 
 void pipeline_set_receiver_stats_enabled(PipelineState *ps, gboolean enabled) {

--- a/src/splashlib.c
+++ b/src/splashlib.c
@@ -1,0 +1,566 @@
+#include "splashlib.h"
+#include <gst/app/gstappsink.h>
+#include <gst/app/gstappsrc.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define MAX_SEQS 32
+#define MAX_QUEUE 256
+
+typedef struct {
+    char *name; // owned copy
+    int start_f;
+    int end_f;
+    gint64 seg_start_ns;
+    gint64 seg_stop_ns;
+} SeqDef;
+
+struct Splash {
+    // Core
+    GMainLoop *loop;
+    GMutex lock;
+
+    // Config
+    char *input_path;
+    double fps;
+    GstClockTime dur;
+    SplashOutputMode outputs;
+    char *host;
+    int   port;
+
+    // Sequences
+    SeqDef seqs[MAX_SEQS];
+    int nseq;
+
+    // Reader pipeline
+    GstElement *reader;
+    GstElement *appsink;
+
+    // Sender (UDP)
+    GstElement *sender_udp;
+    GstElement *appsrc_udp;
+
+    // Direct appsrc output
+    GstElement *appsrc_out;
+
+    // Timing
+    GstClockTime next_pts;
+
+    // Queue state
+    int active_idx;                 // current looping sequence index
+    int pending_queue[MAX_QUEUE];   // FIFO of queued sequence indices
+    int pending_count;              // number of valid entries in queue
+
+    // Automatic repeat order (optional)
+    int loop_order[MAX_QUEUE];
+    int loop_count;
+    guint64 queue_version;
+    guint64 loop_version;
+
+    // Events
+    SplashEventCb evt_cb;
+    void *evt_user;
+};
+
+// ---- small helpers ----
+static void free_str(char **p){ if(*p){ g_free(*p); *p=NULL; } }
+static void dup_cstr(char **dst, const char *src){ free_str(dst); if(src) *dst = g_strdup(src); }
+
+static void emit_evt(Splash *s, SplashEventType t, int a, int b, const char *m){
+    if (s->evt_cb) s->evt_cb(t, a, b, m, s->evt_user);
+}
+
+static gboolean do_segment_seek_locked(Splash *s, int which){
+    g_return_val_if_fail(s->reader!=NULL, FALSE);
+    if (which < 0 || which >= s->nseq) return FALSE;
+    return gst_element_seek(s->reader, 1.0, GST_FORMAT_TIME,
+            GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_SEGMENT | GST_SEEK_FLAG_ACCURATE,
+            GST_SEEK_TYPE_SET, s->seqs[which].seg_start_ns,
+            GST_SEEK_TYPE_SET, s->seqs[which].seg_stop_ns);
+}
+
+// ------------------------------------------------------------------
+// GStreamer callbacks
+// ------------------------------------------------------------------
+static gboolean on_reader_bus(GstBus *bus, GstMessage *m, gpointer user) {
+    (void)bus;
+    Splash *s = (Splash*)user;
+    switch (GST_MESSAGE_TYPE(m)) {
+        case GST_MESSAGE_SEGMENT_DONE:
+        case GST_MESSAGE_EOS: {
+            g_mutex_lock(&s->lock);
+            if (s->pending_count > 0) {
+                int from = s->active_idx;
+                int next = s->pending_queue[0];
+                if (s->pending_count > 1) {
+                    memmove(&s->pending_queue[0], &s->pending_queue[1],
+                                    (s->pending_count - 1) * sizeof(int));
+                }
+                s->pending_count--;
+                s->active_idx = next;
+                emit_evt(s, SPLASH_EVT_SWITCHED_AT_BOUNDARY, from, s->active_idx, NULL);
+            } else if (s->loop_count > 0 && s->loop_version == s->queue_version) {
+                int from = s->active_idx;
+                int next = s->loop_order[0];
+                if (next >= 0 && next < s->nseq) {
+                    s->active_idx = next;
+                    s->pending_count = 0;
+                    for (int i = 1; i < s->loop_count && i < MAX_QUEUE; ++i) {
+                        s->pending_queue[s->pending_count++] = s->loop_order[i];
+                    }
+                    if (from != s->active_idx) {
+                        emit_evt(s, SPLASH_EVT_SWITCHED_AT_BOUNDARY, from, s->active_idx, NULL);
+                    }
+                }
+            }
+            do_segment_seek_locked(s, s->active_idx);
+            g_mutex_unlock(&s->lock);
+            return TRUE;
+        }
+        case GST_MESSAGE_ERROR: {
+            GError *err=NULL; gchar *dbg=NULL;
+            gst_message_parse_error(m, &err, &dbg);
+            emit_evt(s, SPLASH_EVT_ERROR, 0, 0, err?err->message:NULL);
+            g_clear_error(&err); g_free(dbg);
+            if (s->loop) g_main_loop_quit(s->loop);
+            return FALSE;
+        }
+        default: return TRUE;
+    }
+}
+
+static GstFlowReturn on_new_sample(GstAppSink *sink, gpointer user) {
+    Splash *s = (Splash*)user;
+    GstSample *samp = gst_app_sink_pull_sample(sink);
+    if (!samp) return GST_FLOW_EOS;
+    GstBuffer *inbuf = gst_sample_get_buffer(samp);
+    if (!inbuf) {
+        gst_sample_unref(samp);
+        return GST_FLOW_ERROR;
+    }
+
+    GstClockTime pts;
+    GstClockTime dur;
+    g_mutex_lock(&s->lock);
+    pts = s->next_pts;
+    dur = s->dur;
+    s->next_pts += dur;
+    g_mutex_unlock(&s->lock);
+
+    GstFlowReturn overall = GST_FLOW_OK;
+    gboolean pushed = FALSE;
+
+    if ((s->outputs & SPLASH_OUTPUT_UDP) && s->appsrc_udp) {
+        GstBuffer *out = gst_buffer_copy_deep(inbuf);
+        GST_BUFFER_PTS(out)      = pts;
+        GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
+        GST_BUFFER_DURATION(out) = dur;
+        GstFlowReturn fr = gst_app_src_push_buffer(GST_APP_SRC(s->appsrc_udp), out);
+        overall = fr;
+        pushed = TRUE;
+    }
+
+    if ((s->outputs & SPLASH_OUTPUT_APPSRC) && s->appsrc_out) {
+        GstBuffer *out = gst_buffer_copy_deep(inbuf);
+        GST_BUFFER_PTS(out)      = pts;
+        GST_BUFFER_DTS(out)      = GST_CLOCK_TIME_NONE;
+        GST_BUFFER_DURATION(out) = dur;
+        GstFlowReturn fr = gst_app_src_push_buffer(GST_APP_SRC(s->appsrc_out), out);
+        if (!pushed || overall == GST_FLOW_OK) overall = fr;
+        pushed = TRUE;
+    }
+
+    gst_sample_unref(samp);
+    if (!pushed) return GST_FLOW_OK;
+    return overall;
+}
+
+// ------------------------------------------------------------------
+// RTSP media wiring
+// ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Pipeline lifecycle
+// ------------------------------------------------------------------
+static void destroy_pipelines_locked(Splash *s){
+    if (s->reader){
+        gst_element_set_state(s->reader, GST_STATE_NULL);
+        gst_object_unref(s->reader);
+        s->reader=NULL;
+    }
+    s->appsink = NULL;
+
+    if (s->sender_udp){
+        gst_element_set_state(s->sender_udp, GST_STATE_NULL);
+        gst_object_unref(s->sender_udp);
+        s->sender_udp=NULL;
+    }
+    s->appsrc_udp = NULL;
+
+    if (s->appsrc_out) {
+        gst_object_unref(s->appsrc_out);
+        s->appsrc_out = NULL;
+    }
+}
+
+static gboolean build_pipelines_locked(Splash *s, GError **err){
+    // Reader
+    gchar *rdesc = g_strdup_printf(
+        "filesrc location=\"%s\" ! "
+        "h265parse config-interval=1 ! "
+        "video/x-h265,stream-format=byte-stream,alignment=au,framerate=%d/1 ! "
+        "appsink name=srcsink emit-signals=true sync=false drop=false max-buffers=64",
+        s->input_path, (int)(s->fps+0.5));
+    s->reader = gst_parse_launch(rdesc, err); g_free(rdesc);
+    if (!s->reader) return FALSE;
+
+    s->appsink = gst_bin_get_by_name(GST_BIN(s->reader), "srcsink");
+    g_signal_connect(s->appsink, "new-sample", G_CALLBACK(on_new_sample), s);
+    GstBus *rbus = gst_element_get_bus(s->reader);
+    gst_bus_add_watch(rbus, (GstBusFunc)on_reader_bus, s);
+    gst_object_unref(rbus);
+
+    if (s->outputs & SPLASH_OUTPUT_UDP) {
+        gchar *sdesc = g_strdup_printf(
+            "appsrc name=src is-live=true format=time do-timestamp=false block=true "
+                "caps=video/x-h265,stream-format=byte-stream,alignment=au,framerate=%d/1 ! "
+            "h265parse config-interval=1 ! rtph265pay pt=97 mtu=1200 config-interval=1 ! "
+            "udpsink host=%s port=%d sync=true async=false",
+            (int)(s->fps+0.5), s->host, s->port);
+        s->sender_udp = gst_parse_launch(sdesc, err); g_free(sdesc);
+        if (!s->sender_udp) return FALSE;
+        s->appsrc_udp = gst_bin_get_by_name(GST_BIN(s->sender_udp), "src");
+    } else {
+        s->sender_udp = NULL;
+        s->appsrc_udp = NULL;
+    }
+
+    if (s->outputs & SPLASH_OUTPUT_APPSRC) {
+        s->appsrc_out = gst_element_factory_make("appsrc", "splash_out_appsrc");
+        if (!s->appsrc_out) {
+            if (err) {
+                g_set_error(err, GST_CORE_ERROR, GST_CORE_ERROR_FAILED,
+                                        "failed to create appsrc output element");
+            }
+            destroy_pipelines_locked(s);
+            return FALSE;
+        }
+        GstCaps *caps = gst_caps_new_simple("video/x-h265",
+            "stream-format", G_TYPE_STRING, "byte-stream",
+            "alignment", G_TYPE_STRING, "au",
+            "framerate", GST_TYPE_FRACTION, (int)(s->fps+0.5), 1,
+            NULL);
+        g_object_set(G_OBJECT(s->appsrc_out),
+            "is-live", TRUE,
+            "format", GST_FORMAT_TIME,
+            "do-timestamp", FALSE,
+            "block", TRUE,
+            "caps", caps,
+            NULL);
+        gst_caps_unref(caps);
+    } else {
+        s->appsrc_out = NULL;
+    }
+
+    return TRUE;
+}
+
+// ------------------------------------------------------------------
+// Public API
+// ------------------------------------------------------------------
+Splash* splash_new(void){
+    static gsize once = 0;
+    if (g_once_init_enter(&once)) {
+        int argc=0; char **argv=NULL;
+        gst_init(&argc, &argv);
+        g_once_init_leave(&once, 1);
+    }
+    Splash *s = g_new0(Splash, 1);
+    g_mutex_init(&s->lock);
+    s->loop = g_main_loop_new(NULL, FALSE);
+    s->fps = 30.0;
+    s->dur = (GstClockTime)(GST_SECOND/30.0 + 0.5);
+    s->outputs = SPLASH_OUTPUT_UDP;
+    s->host = g_strdup("127.0.0.1");
+    s->port = 5600;
+    s->active_idx = -1;
+    s->pending_count = 0;
+    s->loop_count = 0;
+    s->queue_version = 0;
+    s->loop_version = 0;
+    return s;
+}
+
+void splash_free(Splash *s){
+    if (!s) return;
+    splash_stop(s);
+    g_mutex_lock(&s->lock);
+    destroy_pipelines_locked(s);
+    for (int i=0;i<s->nseq;i++){
+        free_str(&s->seqs[i].name);
+    }
+    free_str(&s->input_path); free_str(&s->host);
+    g_mutex_unlock(&s->lock);
+    if (s->loop) g_main_loop_unref(s->loop);
+    g_mutex_clear(&s->lock);
+    g_free(s);
+}
+
+void splash_set_event_cb(Splash *s, SplashEventCb cb, void *user){
+    s->evt_cb = cb; s->evt_user = user;
+}
+
+bool splash_set_sequences(Splash *s, const SplashSeq *seqs, int n_seqs){
+    if (!s || !seqs || n_seqs<=0 || n_seqs>MAX_SEQS) return false;
+    g_mutex_lock(&s->lock);
+    // clear old
+    for (int i=0;i<s->nseq;i++){ free_str(&s->seqs[i].name); }
+    s->nseq = 0;
+
+    // copy new
+    for (int i=0;i<n_seqs;i++){
+        s->seqs[i].name = g_strdup(seqs[i].name ? seqs[i].name : "");
+        s->seqs[i].start_f = seqs[i].start_frame;
+        s->seqs[i].end_f   = seqs[i].end_frame;
+    }
+    s->nseq = n_seqs;
+
+    // recompute segment bounds
+    for (int i=0;i<s->nseq;i++){
+        s->seqs[i].seg_start_ns = (gint64)((double)s->seqs[i].start_f * GST_SECOND / s->fps);
+        s->seqs[i].seg_stop_ns  = (gint64)((double)(s->seqs[i].end_f + 1) * GST_SECOND / s->fps);
+    }
+
+    // If nothing active yet, pick 0
+    if (s->active_idx < 0 && s->nseq > 0) s->active_idx = 0;
+    // prune pending queue of invalid indices
+    int w = 0;
+    for (int r = 0; r < s->pending_count; ++r) {
+        int idx = s->pending_queue[r];
+        if (idx >= 0 && idx < s->nseq) {
+            if (w != r) s->pending_queue[w] = idx;
+            ++w;
+        }
+    }
+    s->pending_count = w;
+    s->loop_count = 0;
+    s->queue_version++;
+
+    g_mutex_unlock(&s->lock);
+    return true;
+}
+
+bool splash_apply_config(Splash *s, const SplashConfig *cfg){
+    if (!s || !cfg || !cfg->input_path || cfg->fps <= 0.1) return false;
+
+    g_mutex_lock(&s->lock);
+    // store config
+    dup_cstr(&s->input_path, cfg->input_path);
+    s->fps = cfg->fps;
+    s->dur = (GstClockTime)(GST_SECOND / s->fps + 0.5);
+    SplashOutputMode outputs = cfg->outputs;
+    if ((outputs & ~(SPLASH_OUTPUT_UDP | SPLASH_OUTPUT_APPSRC)) != 0) {
+        g_mutex_unlock(&s->lock);
+        return false;
+    }
+    if (outputs == SPLASH_OUTPUT_NONE) outputs = SPLASH_OUTPUT_UDP;
+    if ((outputs & SPLASH_OUTPUT_UDP) && (!cfg->endpoint.host || cfg->endpoint.port <= 0)) {
+        g_mutex_unlock(&s->lock);
+        return false;
+    }
+    s->outputs = outputs;
+    if (outputs & SPLASH_OUTPUT_UDP) {
+        dup_cstr(&s->host, cfg->endpoint.host ? cfg->endpoint.host : "127.0.0.1");
+        s->port = cfg->endpoint.port;
+    } else {
+        free_str(&s->host);
+        s->port = 0;
+    }
+
+    // recompute sequence segment times (fps may have changed)
+    for (int i=0;i<s->nseq;i++){
+        s->seqs[i].seg_start_ns = (gint64)((double)s->seqs[i].start_f * GST_SECOND / s->fps);
+        s->seqs[i].seg_stop_ns  = (gint64)((double)(s->seqs[i].end_f + 1) * GST_SECOND / s->fps);
+    }
+
+    // rebuild pipelines
+    destroy_pipelines_locked(s);
+    GError *err=NULL;
+    if (!build_pipelines_locked(s, &err)){
+        char buf[256]; buf[0]=0;
+        if (err && err->message) g_strlcpy(buf, err->message, sizeof(buf));
+        if (err) g_error_free(err);
+        g_mutex_unlock(&s->lock);
+        emit_evt(s, SPLASH_EVT_ERROR, 0, 0, buf[0]?buf: "pipeline build failed");
+        return false;
+    }
+    s->next_pts = 0;
+
+    g_mutex_unlock(&s->lock);
+    return true;
+}
+
+bool splash_start(Splash *s){
+    if (!s || !s->reader) return false;
+    g_mutex_lock(&s->lock);
+    if (s->sender_udp)
+        gst_element_set_state(s->sender_udp, GST_STATE_PLAYING);
+
+    gst_element_set_state(s->reader, GST_STATE_PLAYING);
+    if (s->active_idx < 0 && s->nseq>0) s->active_idx = 0;
+    do_segment_seek_locked(s, s->active_idx);
+    s->next_pts = 0;
+    g_mutex_unlock(&s->lock);
+    emit_evt(s, SPLASH_EVT_STARTED, 0, 0, NULL);
+    return true;
+}
+
+void splash_run(Splash *s){
+    if (!s || !s->loop) return;
+    g_main_loop_run(s->loop);
+}
+
+void splash_quit(Splash *s){
+    if (!s || !s->loop) return;
+    g_main_loop_quit(s->loop);
+}
+
+void splash_stop(Splash *s){
+    g_mutex_lock(&s->lock);
+    if (s->reader) gst_element_set_state(s->reader, GST_STATE_NULL);
+    if (s->sender_udp) gst_element_set_state(s->sender_udp, GST_STATE_NULL);
+    g_mutex_unlock(&s->lock);
+    emit_evt(s, SPLASH_EVT_STOPPED, 0, 0, NULL);
+}
+
+// ---- Queue control ----
+bool splash_enqueue_next_by_index(Splash *s, int idx){
+    return splash_enqueue_next_many(s, &idx, 1);
+}
+
+bool splash_enqueue_next_by_name(Splash *s, const char *name){
+    int idx = -1;
+    g_mutex_lock(&s->lock);
+    for (int i=0;i<s->nseq;i++){
+        if (g_strcmp0(s->seqs[i].name, name)==0) { idx = i; break; }
+    }
+    g_mutex_unlock(&s->lock);
+    if (idx<0) return false;
+    return splash_enqueue_next_by_index(s, idx);
+}
+
+void splash_clear_next(Splash *s){
+    g_mutex_lock(&s->lock);
+    s->pending_count = 0;
+    s->loop_count = 0;
+    s->queue_version++;
+    g_mutex_unlock(&s->lock);
+    emit_evt(s, SPLASH_EVT_CLEARED_QUEUE, 0, 0, NULL);
+}
+
+void splash_set_repeat_order(Splash *s, const int *indices, int n_indices){
+    if (!s) return;
+    g_mutex_lock(&s->lock);
+    if (!indices || n_indices <= 0) {
+        s->loop_count = 0;
+        s->loop_version = s->queue_version;
+        g_mutex_unlock(&s->lock);
+        return;
+    }
+    if (n_indices > MAX_QUEUE) n_indices = MAX_QUEUE;
+    gboolean valid = TRUE;
+    for (int i = 0; i < n_indices; ++i) {
+        if (indices[i] < 0 || indices[i] >= s->nseq) {
+            valid = FALSE;
+            break;
+        }
+    }
+    if (valid) {
+        s->loop_count = n_indices;
+        for (int i = 0; i < n_indices; ++i) {
+            s->loop_order[i] = indices[i];
+        }
+    } else {
+        s->loop_count = 0;
+    }
+    s->loop_version = s->queue_version;
+    g_mutex_unlock(&s->lock);
+}
+
+int splash_active_index(Splash *s){
+    g_mutex_lock(&s->lock);
+    int v = s->active_idx;
+    g_mutex_unlock(&s->lock);
+    return v;
+}
+
+int splash_pending_index(Splash *s){
+    g_mutex_lock(&s->lock);
+    int v = (s->pending_count > 0) ? s->pending_queue[0] : -1;
+    g_mutex_unlock(&s->lock);
+    return v;
+}
+
+bool splash_enqueue_next_many(Splash *s, const int *indices, int n_indices){
+    if (!s || !indices || n_indices <= 0) return false;
+    g_mutex_lock(&s->lock);
+    if (s->nseq <= 0 || s->pending_count + n_indices > MAX_QUEUE) {
+        g_mutex_unlock(&s->lock);
+        return false;
+    }
+    for (int i = 0; i < n_indices; ++i) {
+        if (indices[i] < 0 || indices[i] >= s->nseq) {
+            g_mutex_unlock(&s->lock);
+            return false;
+        }
+    }
+    for (int i = 0; i < n_indices; ++i) {
+        s->pending_queue[s->pending_count++] = indices[i];
+    }
+    s->queue_version++;
+    int to_emit[MAX_QUEUE];
+    int emit_count = n_indices;
+    for (int i = 0; i < emit_count; ++i) to_emit[i] = indices[i];
+    g_mutex_unlock(&s->lock);
+    for (int i = 0; i < emit_count; ++i) {
+        emit_evt(s, SPLASH_EVT_QUEUED_NEXT, to_emit[i], 0, NULL);
+    }
+    return true;
+}
+
+bool splash_enqueue_with_repeat(Splash *s,
+                                                                const int *indices,
+                                                                int n_indices,
+                                                                SplashRepeatMode repeat){
+    if (!s || !indices || n_indices <= 0) return false;
+    if (!splash_enqueue_next_many(s, indices, n_indices)) return false;
+
+    if (repeat == SPLASH_REPEAT_FULL) {
+        splash_set_repeat_order(s, indices, n_indices);
+    } else if (repeat == SPLASH_REPEAT_LAST) {
+        int last = indices[n_indices - 1];
+        splash_set_repeat_order(s, &last, 1);
+    } else {
+        splash_set_repeat_order(s, NULL, 0);
+    }
+
+    return true;
+}
+
+int splash_find_index_by_name(Splash *s, const char *name){
+    int idx=-1;
+    g_mutex_lock(&s->lock);
+    for (int i=0;i<s->nseq;i++){
+        if (g_strcmp0(s->seqs[i].name, name)==0) { idx = i; break; }
+    }
+    g_mutex_unlock(&s->lock);
+    return idx;
+}
+
+GstElement* splash_get_appsrc(Splash *s){
+    if (!s) return NULL;
+    g_mutex_lock(&s->lock);
+    GstElement *out = (s->outputs & SPLASH_OUTPUT_APPSRC) ? s->appsrc_out : NULL;
+    if (out) gst_object_ref(out);
+    g_mutex_unlock(&s->lock);
+    return out;
+}


### PR DESCRIPTION
## Summary
- integrate the splashscreen_rk appsrc helper so a local H.265 loop can feed the pipeline when RTP video is idle
- extend the configuration parser with [splash] sections and document/sample the new settings
- monitor the UDP receiver for recent traffic and automatically switch between the live stream and the splash source

## Testing
- make *(fails: missing xf86drm.h in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ba90f260832bb4a4408721e6d4cf