### PR TITLE
Add Matroska recording pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[audio].disable` | `true` drops the audio branch entirely (equivalent to `--no-audio`). |
 | `[audio].optional` | `true` allows auto-fallback to a fakesink when the audio path fails; `false` keeps retrying the real sink. |
 | `[record].enable` | `true` starts writing the incoming stream to a Matroska file. |
-| `[record].path` | Output path for the Matroska recording. Setting this implicitly enables recording. |
+| `[record].path` | Base output path for the Matroska recording. A timestamp suffix is added on start so each run creates a unique file. |
 | `[record].audio` | `true` muxes the Opus stream when the custom UDP receiver is active; otherwise the file is video-only. |
 | `[restarts].limit` | Maximum automatic restarts allowed within the configured window. |
 | `[restarts].window-ms` | Rolling window (milliseconds) for counting automatic restarts. |
@@ -96,6 +96,8 @@ extra copies. Audio is appended directly from the UDP receiver when the Opus RTP
   the video. Audio capture requires the custom UDP receiver mode; the bare `udpsrc` pipeline only records video.
 
 When `[record].path` is provided the recorder starts automatically on launch and stops when the main pipeline shuts down. The
+recorder appends a `-YYYYMMDD-HHMMSS` timestamp (before the file extension when present) so each session produces a fresh file
+without overwriting earlier captures.
 output file is finalised cleanly on EOS or when `pipeline_stop` is invoked.
 
 ## UDP receiver statistics

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -36,7 +36,8 @@ disable = false
 optional = true
 
 [record]
-; Enable the Matroska recorder and choose the output location
+; Enable the Matroska recorder and choose the output location.
+; A timestamp suffix is appended automatically so earlier runs are preserved.
 enable = false
 path = /tmp/pixelpilot-recording.mkv
 audio = true

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -35,6 +35,12 @@ device = plughw:CARD=rockchiphdmi0,DEV=0
 disable = false
 optional = true
 
+[record]
+; Enable the Matroska recorder and choose the output location
+enable = false
+path = /tmp/pixelpilot-recording.mkv
+audio = true
+
 [restarts]
 limit = 3
 window-ms = 2000

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -37,6 +37,11 @@ device = plughw:CARD=rockchiphdmi0,DEV=0
 disable = false
 optional = true
 
+[record]
+enable = false
+path = /tmp/pixelpilot-recording.mkv
+audio = true
+
 [osd]
 enable = true
 refresh-ms = 500

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -38,6 +38,7 @@ disable = false
 optional = true
 
 [record]
+; Output files receive an automatic -YYYYMMDD-HHMMSS suffix.
 enable = false
 path = /tmp/pixelpilot-recording.mkv
 audio = true

--- a/include/config.h
+++ b/include/config.h
@@ -34,6 +34,12 @@ typedef struct {
 } SplashCfg;
 
 typedef struct {
+    int enable;
+    int audio;
+    char output_path[PATH_MAX];
+} RecordCfg;
+
+typedef struct {
     char card_path[64];
     char connector_name[32];
     char config_path[PATH_MAX];
@@ -66,6 +72,7 @@ typedef struct {
     OsdLayout osd_layout;
 
     SplashCfg splash;
+    RecordCfg record;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -49,6 +49,9 @@ typedef struct {
     guint64 last_udp_activity_ns;
     struct Recorder *recorder;
     gboolean recorder_running;
+    gboolean recorder_enabled;
+    gboolean recorder_restart_pending;
+    guint64 recorder_restart_last_ns;
 } PipelineState;
 
 #include "config.h"

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -53,6 +53,7 @@ typedef struct {
     gboolean recorder_restart_pending;
     guint64 recorder_restart_last_ns;
     gboolean recorder_skip_initial_caps;
+    GstCaps *recorder_last_video_caps;
 } PipelineState;
 
 #include "config.h"

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -14,6 +14,7 @@ typedef enum {
 } PipelineStateEnum;
 
 struct Splash;
+struct Recorder;
 
 typedef struct {
     PipelineStateEnum state;
@@ -46,6 +47,8 @@ typedef struct {
     guint splash_idle_timeout_ms;
     guint64 pipeline_start_ns;
     guint64 last_udp_activity_ns;
+    struct Recorder *recorder;
+    gboolean recorder_running;
 } PipelineState;
 
 #include "config.h"

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -52,6 +52,7 @@ typedef struct {
     gboolean recorder_enabled;
     gboolean recorder_restart_pending;
     guint64 recorder_restart_last_ns;
+    gboolean recorder_skip_initial_caps;
 } PipelineState;
 
 #include "config.h"

--- a/include/recorder.h
+++ b/include/recorder.h
@@ -1,0 +1,30 @@
+#ifndef RECORDER_H
+#define RECORDER_H
+
+#include <glib.h>
+#include <gst/gst.h>
+#include <gst/app/gstappsrc.h>
+
+#include "config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Recorder Recorder;
+
+Recorder *recorder_new(void);
+void recorder_free(Recorder *rec);
+
+gboolean recorder_start(Recorder *rec, const AppCfg *cfg, gboolean enable_audio);
+void recorder_stop(Recorder *rec);
+
+gboolean recorder_is_running(Recorder *rec);
+GstAppSrc *recorder_get_audio_appsrc(Recorder *rec);
+void recorder_push_video_buffer(Recorder *rec, GstBuffer *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RECORDER_H

--- a/include/recorder.h
+++ b/include/recorder.h
@@ -16,12 +16,15 @@ typedef struct Recorder Recorder;
 Recorder *recorder_new(void);
 void recorder_free(Recorder *rec);
 
-gboolean recorder_start(Recorder *rec, const AppCfg *cfg, gboolean enable_audio);
+gboolean recorder_start(Recorder *rec,
+                        const AppCfg *cfg,
+                        gboolean enable_audio,
+                        const GstCaps *video_caps);
 void recorder_stop(Recorder *rec);
 
 gboolean recorder_is_running(Recorder *rec);
 GstAppSrc *recorder_get_audio_appsrc(Recorder *rec);
-void recorder_push_video_buffer(Recorder *rec, GstBuffer *buffer);
+void recorder_push_video_buffer(Recorder *rec, GstBuffer *buffer, const GstCaps *caps);
 
 #ifdef __cplusplus
 }

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -62,6 +62,7 @@ typedef struct UdpReceiver UdpReceiver;
 
 UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc);
 void udp_receiver_set_audio_appsrc(UdpReceiver *ur, GstAppSrc *audio_appsrc);
+void udp_receiver_set_audio_record_appsrc(UdpReceiver *ur, GstAppSrc *audio_appsrc);
 int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);

--- a/src/config.c
+++ b/src/config.c
@@ -27,6 +27,11 @@ static void usage(const char *prog) {
             "  --no-audio                   (drop audio branch entirely)\n"
             "  --audio-optional             (auto-fallback to fakesink on failures; default)\n"
             "  --audio-required             (disable auto-fallback; keep real audio only)\n"
+            "  --record PATH                (enable recording to PATH)\n"
+            "  --record-enable              (enable recording using configured path)\n"
+            "  --record-disable             (disable recording)\n"
+            "  --record-audio               (include audio track when recording)\n"
+            "  --record-no-audio            (disable audio track when recording)\n"
             "  --osd                        (enable OSD overlay plane with stats)\n"
             "  --osd-plane-id N             (force OSD plane id; default auto)\n"
             "  --osd-refresh-ms N           (default: 500)\n"
@@ -117,6 +122,10 @@ void cfg_defaults(AppCfg *c) {
         c->splash.sequences[i].start_frame = -1;
         c->splash.sequences[i].end_frame = -1;
     }
+
+    c->record.enable = 0;
+    c->record.audio = 1;
+    c->record.output_path[0] = '\0';
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {
@@ -262,6 +271,20 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->audio_optional = 1;
         } else if (!strcmp(argv[i], "--audio-required")) {
             cfg->audio_optional = 0;
+        } else if (!strcmp(argv[i], "--record") && i + 1 < argc) {
+            cli_copy_string(cfg->record.output_path, sizeof(cfg->record.output_path), argv[++i]);
+            cfg->record.enable = 1;
+        } else if (!strcmp(argv[i], "--record") && i + 1 >= argc) {
+            LOGE("--record requires a file path argument");
+            return -1;
+        } else if (!strcmp(argv[i], "--record-enable")) {
+            cfg->record.enable = 1;
+        } else if (!strcmp(argv[i], "--record-disable")) {
+            cfg->record.enable = 0;
+        } else if (!strcmp(argv[i], "--record-audio")) {
+            cfg->record.audio = 1;
+        } else if (!strcmp(argv[i], "--record-no-audio")) {
+            cfg->record.audio = 0;
         } else if (!strcmp(argv[i], "--osd")) {
             cfg->osd_enable = 1;
         } else if (!strcmp(argv[i], "--osd-plane-id") && i + 1 < argc) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -821,6 +821,30 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "record") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->record.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "audio") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->record.audio = v;
+            return 0;
+        }
+        if (strcasecmp(key, "path") == 0 || strcasecmp(key, "file") == 0 || strcasecmp(key, "output") == 0 ||
+            strcasecmp(key, "location") == 0) {
+            ini_copy_string(cfg->record.output_path, sizeof(cfg->record.output_path), value);
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "cpu") == 0) {
         if (strcasecmp(key, "affinity") == 0) {
             return cfg_parse_cpu_list(value, cfg);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -426,12 +426,15 @@ static void pipeline_store_recorder_caps(PipelineState *ps, const GstCaps *caps)
     }
 
     g_mutex_lock(&ps->lock);
+    gboolean splash_active = ps->splash_active;
+    /* Ignore caps reported while the splash video is active so cached
+     * recorder caps always describe the real UDP stream. */
     gboolean same = FALSE;
-    if (ps->recorder_last_video_caps != NULL) {
+    if (!splash_active && ps->recorder_last_video_caps != NULL) {
         same = gst_caps_is_equal(ps->recorder_last_video_caps, (GstCaps *)caps);
     }
 
-    if (!same) {
+    if (!splash_active && !same) {
         GstCaps *caps_copy = gst_caps_copy(caps);
         if (caps_copy != NULL) {
             if (ps->recorder_last_video_caps != NULL) {

--- a/src/recorder.c
+++ b/src/recorder.c
@@ -1,0 +1,512 @@
+#define _GNU_SOURCE
+
+#include "recorder.h"
+
+#include "logging.h"
+
+#ifndef GST_USE_UNSTABLE_API
+#define GST_USE_UNSTABLE_API
+#endif
+
+#include <gst/app/gstappsrc.h>
+#include <gst/gst.h>
+
+struct Recorder {
+    GstElement *pipeline;
+    GstAppSrc *video_appsrc;
+    GstAppSrc *audio_appsrc;
+    GstElement *mux;
+    GstPad *mux_video_pad;
+    GstPad *mux_audio_pad;
+    gboolean audio_requested;
+    gboolean audio_enabled;
+    gboolean running;
+    gboolean logged_video_flow_error;
+    GMutex lock;
+};
+
+static GstBusSyncReply recorder_bus_sync_handler(GstBus *bus, GstMessage *msg, gpointer user_data) {
+    (void)bus;
+    Recorder *rec = (Recorder *)user_data;
+    if (rec == NULL || msg == NULL) {
+        return GST_BUS_PASS;
+    }
+
+    switch (GST_MESSAGE_TYPE(msg)) {
+    case GST_MESSAGE_ERROR: {
+        GError *err = NULL;
+        gchar *dbg = NULL;
+        gst_message_parse_error(msg, &err, &dbg);
+        LOGE("Recorder pipeline error: %s (debug=%s)", err != NULL ? err->message : "unknown",
+             dbg != NULL ? dbg : "none");
+        if (err != NULL) {
+            g_error_free(err);
+        }
+        g_free(dbg);
+        break;
+    }
+    case GST_MESSAGE_WARNING: {
+        GError *err = NULL;
+        gchar *dbg = NULL;
+        gst_message_parse_warning(msg, &err, &dbg);
+        LOGW("Recorder pipeline warning: %s (debug=%s)", err != NULL ? err->message : "unknown",
+             dbg != NULL ? dbg : "none");
+        if (err != NULL) {
+            g_error_free(err);
+        }
+        g_free(dbg);
+        break;
+    }
+    default:
+        break;
+    }
+    return GST_BUS_PASS;
+}
+
+Recorder *recorder_new(void) {
+    Recorder *rec = g_new0(Recorder, 1);
+    if (rec == NULL) {
+        return NULL;
+    }
+    g_mutex_init(&rec->lock);
+    rec->audio_requested = FALSE;
+    rec->audio_enabled = FALSE;
+    rec->running = FALSE;
+    rec->logged_video_flow_error = FALSE;
+    return rec;
+}
+
+static void recorder_release_pads_locked(Recorder *rec) {
+    if (rec == NULL) {
+        return;
+    }
+    if (rec->mux != NULL) {
+        if (rec->mux_video_pad != NULL) {
+            gst_element_release_request_pad(rec->mux, rec->mux_video_pad);
+            gst_object_unref(rec->mux_video_pad);
+            rec->mux_video_pad = NULL;
+        }
+        if (rec->mux_audio_pad != NULL) {
+            gst_element_release_request_pad(rec->mux, rec->mux_audio_pad);
+            gst_object_unref(rec->mux_audio_pad);
+            rec->mux_audio_pad = NULL;
+        }
+    }
+}
+
+void recorder_stop(Recorder *rec) {
+    if (rec == NULL) {
+        return;
+    }
+
+    GstElement *pipeline = NULL;
+    GstAppSrc *video_appsrc = NULL;
+    GstAppSrc *audio_appsrc = NULL;
+    GstElement *mux = NULL;
+
+    g_mutex_lock(&rec->lock);
+    if (!rec->running && rec->pipeline == NULL) {
+        g_mutex_unlock(&rec->lock);
+        return;
+    }
+
+    pipeline = rec->pipeline;
+    video_appsrc = rec->video_appsrc;
+    audio_appsrc = rec->audio_appsrc;
+    mux = rec->mux;
+
+    rec->running = FALSE;
+    rec->audio_enabled = FALSE;
+    rec->logged_video_flow_error = FALSE;
+
+    recorder_release_pads_locked(rec);
+
+    rec->pipeline = NULL;
+    rec->video_appsrc = NULL;
+    rec->audio_appsrc = NULL;
+    rec->mux = NULL;
+
+    g_mutex_unlock(&rec->lock);
+
+    if (video_appsrc != NULL) {
+        gst_app_src_end_of_stream(video_appsrc);
+    }
+    if (audio_appsrc != NULL) {
+        gst_app_src_end_of_stream(audio_appsrc);
+    }
+
+    if (pipeline != NULL) {
+        gst_element_send_event(pipeline, gst_event_new_eos());
+        gst_element_set_state(pipeline, GST_STATE_NULL);
+    }
+
+    if (pipeline != NULL) {
+        gst_object_unref(pipeline);
+    }
+    (void)mux;
+}
+
+void recorder_free(Recorder *rec) {
+    if (rec == NULL) {
+        return;
+    }
+    recorder_stop(rec);
+    g_mutex_clear(&rec->lock);
+    g_free(rec);
+}
+
+gboolean recorder_is_running(Recorder *rec) {
+    if (rec == NULL) {
+        return FALSE;
+    }
+    g_mutex_lock(&rec->lock);
+    gboolean running = rec->running;
+    g_mutex_unlock(&rec->lock);
+    return running;
+}
+
+GstAppSrc *recorder_get_audio_appsrc(Recorder *rec) {
+    if (rec == NULL) {
+        return NULL;
+    }
+    g_mutex_lock(&rec->lock);
+    GstAppSrc *src = rec->audio_enabled ? rec->audio_appsrc : NULL;
+    g_mutex_unlock(&rec->lock);
+    return src;
+}
+
+static gboolean recorder_setup_audio_branch(Recorder *rec,
+                                            const AppCfg *cfg,
+                                            gboolean enable_audio,
+                                            GstElement *pipeline,
+                                            GstElement *mux) {
+    if (rec == NULL || cfg == NULL || pipeline == NULL || mux == NULL) {
+        return FALSE;
+    }
+
+    if (!enable_audio) {
+        return FALSE;
+    }
+
+    GstElement *audio_appsrc = gst_element_factory_make("appsrc", "rec_audio_src");
+    GstElement *audio_queue = gst_element_factory_make("queue", "rec_audio_queue");
+    GstElement *audio_depay = gst_element_factory_make("rtpopusdepay", "rec_audio_depay");
+    GstElement *audio_parse = gst_element_factory_make("opusparse", "rec_audio_parse");
+
+    if (audio_appsrc == NULL || audio_queue == NULL || audio_depay == NULL || audio_parse == NULL) {
+        if (audio_appsrc != NULL) {
+            gst_object_unref(audio_appsrc);
+        }
+        if (audio_queue != NULL) {
+            gst_object_unref(audio_queue);
+        }
+        if (audio_depay != NULL) {
+            gst_object_unref(audio_depay);
+        }
+        if (audio_parse != NULL) {
+            gst_object_unref(audio_parse);
+        }
+        LOGW("Recorder: audio branch unavailable; recording without audio");
+        return FALSE;
+    }
+
+    g_object_set(audio_appsrc,
+                 "is-live",
+                 TRUE,
+                 "format",
+                 GST_FORMAT_TIME,
+                 "stream-type",
+                 GST_APP_STREAM_TYPE_STREAM,
+                 "do-timestamp",
+                 FALSE,
+                 NULL);
+    gst_app_src_set_latency(GST_APP_SRC(audio_appsrc), 0, 0);
+    gst_app_src_set_max_bytes(GST_APP_SRC(audio_appsrc), 512 * 1024);
+
+    GstCaps *audio_caps = gst_caps_new_simple("application/x-rtp",
+                                              "media",
+                                              G_TYPE_STRING,
+                                              "audio",
+                                              "payload",
+                                              G_TYPE_INT,
+                                              cfg->aud_pt,
+                                              "clock-rate",
+                                              G_TYPE_INT,
+                                              48000,
+                                              "encoding-name",
+                                              G_TYPE_STRING,
+                                              "OPUS",
+                                              NULL);
+    if (audio_caps == NULL) {
+        gst_object_unref(audio_appsrc);
+        gst_object_unref(audio_queue);
+        gst_object_unref(audio_depay);
+        gst_object_unref(audio_parse);
+        LOGW("Recorder: failed to allocate audio caps; recording without audio");
+        return FALSE;
+    }
+
+    gst_app_src_set_caps(GST_APP_SRC(audio_appsrc), audio_caps);
+    gst_caps_unref(audio_caps);
+
+    g_object_set(audio_queue, "leaky", 2, NULL);
+
+    gst_bin_add_many(GST_BIN(pipeline), audio_appsrc, audio_queue, audio_depay, audio_parse, NULL);
+
+    if (!gst_element_link_many(audio_appsrc, audio_queue, audio_depay, audio_parse, NULL)) {
+        gst_bin_remove_many(GST_BIN(pipeline), audio_appsrc, audio_queue, audio_depay, audio_parse, NULL);
+        LOGW("Recorder: failed to link audio branch; recording without audio");
+        return FALSE;
+    }
+
+    GstPad *audio_src_pad = gst_element_get_static_pad(audio_parse, "src");
+    GstPad *audio_sink_pad = gst_element_get_request_pad(mux, "audio_%u");
+    if (audio_src_pad == NULL || audio_sink_pad == NULL) {
+        if (audio_src_pad != NULL) {
+            gst_object_unref(audio_src_pad);
+        }
+        if (audio_sink_pad != NULL) {
+            gst_element_release_request_pad(mux, audio_sink_pad);
+            gst_object_unref(audio_sink_pad);
+        }
+        gst_element_unlink(audio_appsrc, audio_queue);
+        gst_element_unlink(audio_queue, audio_depay);
+        gst_element_unlink(audio_depay, audio_parse);
+        gst_bin_remove_many(GST_BIN(pipeline), audio_appsrc, audio_queue, audio_depay, audio_parse, NULL);
+        LOGW("Recorder: failed to obtain audio pads; recording without audio");
+        return FALSE;
+    }
+
+    if (gst_pad_link(audio_src_pad, audio_sink_pad) != GST_PAD_LINK_OK) {
+        gst_element_release_request_pad(mux, audio_sink_pad);
+        gst_object_unref(audio_sink_pad);
+        gst_object_unref(audio_src_pad);
+        gst_element_unlink(audio_appsrc, audio_queue);
+        gst_element_unlink(audio_queue, audio_depay);
+        gst_element_unlink(audio_depay, audio_parse);
+        gst_bin_remove_many(GST_BIN(pipeline), audio_appsrc, audio_queue, audio_depay, audio_parse, NULL);
+        LOGW("Recorder: failed to connect audio branch; recording without audio");
+        return FALSE;
+    }
+
+    gst_object_unref(audio_src_pad);
+
+    g_mutex_lock(&rec->lock);
+    rec->audio_appsrc = GST_APP_SRC(audio_appsrc);
+    rec->mux_audio_pad = audio_sink_pad;
+    rec->audio_enabled = TRUE;
+    g_mutex_unlock(&rec->lock);
+
+    return TRUE;
+}
+
+gboolean recorder_start(Recorder *rec, const AppCfg *cfg, gboolean enable_audio) {
+    if (rec == NULL || cfg == NULL) {
+        return FALSE;
+    }
+
+    recorder_stop(rec);
+
+    if (cfg->record.output_path[0] == '\0') {
+        LOGE("Recorder: output path not configured");
+        return FALSE;
+    }
+
+    GstElement *pipeline = gst_pipeline_new("pixelpilot-recorder");
+    if (pipeline == NULL) {
+        LOGE("Recorder: failed to create pipeline");
+        return FALSE;
+    }
+
+    GstElement *video_appsrc = gst_element_factory_make("appsrc", "rec_video_src");
+    GstElement *video_queue = gst_element_factory_make("queue", "rec_video_queue");
+    GstElement *video_parse = gst_element_factory_make("h265parse", "rec_video_parse");
+    GstElement *mux = gst_element_factory_make("matroskamux", "rec_mux");
+    GstElement *filesink = gst_element_factory_make("filesink", "rec_sink");
+
+    if (video_appsrc == NULL || video_queue == NULL || video_parse == NULL || mux == NULL || filesink == NULL) {
+        if (pipeline != NULL) {
+            gst_object_unref(pipeline);
+        }
+        if (video_appsrc != NULL) {
+            gst_object_unref(video_appsrc);
+        }
+        if (video_queue != NULL) {
+            gst_object_unref(video_queue);
+        }
+        if (video_parse != NULL) {
+            gst_object_unref(video_parse);
+        }
+        if (mux != NULL) {
+            gst_object_unref(mux);
+        }
+        if (filesink != NULL) {
+            gst_object_unref(filesink);
+        }
+        LOGE("Recorder: failed to construct video branch");
+        return FALSE;
+    }
+
+    g_object_set(video_appsrc,
+                 "is-live",
+                 TRUE,
+                 "format",
+                 GST_FORMAT_TIME,
+                 "stream-type",
+                 GST_APP_STREAM_TYPE_STREAM,
+                 "do-timestamp",
+                 FALSE,
+                 NULL);
+    gst_app_src_set_latency(GST_APP_SRC(video_appsrc), 0, 0);
+    gst_app_src_set_max_bytes(GST_APP_SRC(video_appsrc), 4 * 1024 * 1024);
+
+    GstCaps *video_caps = gst_caps_new_simple("video/x-h265",
+                                              "stream-format",
+                                              G_TYPE_STRING,
+                                              "byte-stream",
+                                              "alignment",
+                                              G_TYPE_STRING,
+                                              "au",
+                                              NULL);
+    if (video_caps == NULL) {
+        gst_object_unref(pipeline);
+        gst_object_unref(video_appsrc);
+        gst_object_unref(video_queue);
+        gst_object_unref(video_parse);
+        gst_object_unref(mux);
+        gst_object_unref(filesink);
+        LOGE("Recorder: failed to allocate video caps");
+        return FALSE;
+    }
+
+    gst_app_src_set_caps(GST_APP_SRC(video_appsrc), video_caps);
+    gst_caps_unref(video_caps);
+
+    g_object_set(video_queue, "leaky", 2, NULL);
+    g_object_set(video_parse, "config-interval", -1, NULL);
+    g_object_set(mux, "writing-app", "pixelpilot-mini-rk", "streamable", TRUE, NULL);
+    g_object_set(filesink, "location", cfg->record.output_path, "async", FALSE, NULL);
+
+    gst_bin_add_many(GST_BIN(pipeline), video_appsrc, video_queue, video_parse, mux, filesink, NULL);
+
+    if (!gst_element_link_many(video_appsrc, video_queue, video_parse, NULL)) {
+        gst_object_unref(pipeline);
+        LOGE("Recorder: failed to link video branch");
+        return FALSE;
+    }
+
+    if (!gst_element_link(mux, filesink)) {
+        gst_object_unref(pipeline);
+        LOGE("Recorder: failed to link mux to filesink");
+        return FALSE;
+    }
+
+    GstPad *video_src_pad = gst_element_get_static_pad(video_parse, "src");
+    GstPad *video_sink_pad = gst_element_get_request_pad(mux, "video_%u");
+    if (video_src_pad == NULL || video_sink_pad == NULL) {
+        if (video_src_pad != NULL) {
+            gst_object_unref(video_src_pad);
+        }
+        if (video_sink_pad != NULL) {
+            gst_element_release_request_pad(mux, video_sink_pad);
+            gst_object_unref(video_sink_pad);
+        }
+        gst_object_unref(pipeline);
+        LOGE("Recorder: failed to obtain video pads");
+        return FALSE;
+    }
+
+    if (gst_pad_link(video_src_pad, video_sink_pad) != GST_PAD_LINK_OK) {
+        gst_element_release_request_pad(mux, video_sink_pad);
+        gst_object_unref(video_sink_pad);
+        gst_object_unref(video_src_pad);
+        gst_object_unref(pipeline);
+        LOGE("Recorder: failed to connect video branch");
+        return FALSE;
+    }
+    gst_object_unref(video_src_pad);
+
+    gboolean audio_enabled = recorder_setup_audio_branch(rec, cfg, enable_audio && cfg->aud_pt >= 0, pipeline, mux);
+
+    GstBus *bus = gst_element_get_bus(pipeline);
+    if (bus != NULL) {
+        gst_bus_set_sync_handler(bus, recorder_bus_sync_handler, rec, NULL);
+        gst_object_unref(bus);
+    }
+
+    GstStateChangeReturn state_ret = gst_element_set_state(pipeline, GST_STATE_PLAYING);
+    if (state_ret == GST_STATE_CHANGE_FAILURE) {
+        gst_element_set_state(pipeline, GST_STATE_NULL);
+        gst_object_unref(pipeline);
+        LOGE("Recorder: failed to start pipeline");
+        return FALSE;
+    }
+
+    if (state_ret == GST_STATE_CHANGE_ASYNC) {
+        GstState current = GST_STATE_NULL;
+        GstState pending = GST_STATE_NULL;
+        state_ret = gst_element_get_state(pipeline, &current, &pending, GST_SECOND);
+        if (state_ret == GST_STATE_CHANGE_FAILURE) {
+            gst_element_set_state(pipeline, GST_STATE_NULL);
+            gst_object_unref(pipeline);
+            LOGE("Recorder: pipeline did not reach playing state");
+            return FALSE;
+        }
+    }
+
+    g_mutex_lock(&rec->lock);
+    rec->pipeline = pipeline;
+    rec->video_appsrc = GST_APP_SRC(video_appsrc);
+    rec->mux = mux;
+    rec->mux_video_pad = video_sink_pad;
+    rec->audio_requested = enable_audio ? TRUE : FALSE;
+    rec->audio_enabled = audio_enabled ? TRUE : FALSE;
+    rec->running = TRUE;
+    rec->logged_video_flow_error = FALSE;
+    if (!audio_enabled) {
+        rec->audio_appsrc = NULL;
+        if (rec->mux_audio_pad != NULL) {
+            gst_element_release_request_pad(mux, rec->mux_audio_pad);
+            gst_object_unref(rec->mux_audio_pad);
+            rec->mux_audio_pad = NULL;
+        }
+    }
+    g_mutex_unlock(&rec->lock);
+
+    LOGI("Recorder: writing Matroska to %s (%s)",
+         cfg->record.output_path,
+         audio_enabled ? "audio enabled" : "video only");
+
+    return TRUE;
+}
+
+void recorder_push_video_buffer(Recorder *rec, GstBuffer *buffer) {
+    if (rec == NULL || buffer == NULL) {
+        if (buffer != NULL) {
+            gst_buffer_unref(buffer);
+        }
+        return;
+    }
+
+    GstAppSrc *appsrc = NULL;
+    gboolean running = FALSE;
+
+    g_mutex_lock(&rec->lock);
+    running = rec->running;
+    appsrc = rec->video_appsrc;
+    g_mutex_unlock(&rec->lock);
+
+    if (!running || appsrc == NULL) {
+        gst_buffer_unref(buffer);
+        return;
+    }
+
+    GstFlowReturn flow = gst_app_src_push_buffer(appsrc, buffer);
+    if (G_UNLIKELY(flow != GST_FLOW_OK)) {
+        if (!rec->logged_video_flow_error) {
+            LOGW("Recorder: video push returned %s", gst_flow_get_name(flow));
+            rec->logged_video_flow_error = TRUE;
+        }
+    }
+}
+*** End of File

--- a/src/recorder.c
+++ b/src/recorder.c
@@ -509,4 +509,3 @@ void recorder_push_video_buffer(Recorder *rec, GstBuffer *buffer) {
         }
     }
 }
-*** End of File


### PR DESCRIPTION
## Summary
- add a dedicated Matroska recorder that reuses the video appsink stream and optionally muxes Opus audio
- extend the configuration/CLI with a [record] section and matching flags to control recording
- integrate the recorder with the pipeline and UDP receiver so audio buffers are fanned out efficiently

## Testing
- `make` *(fails: missing drm headers in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f8123a14832bb02a4e791c7ee584