### PR TITLE
Handle SIGUSR to toggle OSD overlay

### DIFF
--- a/include/osd.h
+++ b/include/osd.h
@@ -123,6 +123,7 @@ void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const 
                       int audio_disabled, int restart_count, OSD *osd);
 int osd_is_enabled(const OSD *osd);
 int osd_is_active(const OSD *osd);
+int osd_enable(int fd, OSD *osd);
 void osd_disable(int fd, OSD *osd);
 void osd_teardown(int fd, OSD *osd);
 

--- a/src/osd.c
+++ b/src/osd.c
@@ -2475,6 +2475,23 @@ int osd_is_active(const OSD *o) {
     return o->active;
 }
 
+int osd_enable(int fd, OSD *o) {
+    if (!o->enabled) {
+        return -1;
+    }
+    if (o->active) {
+        return 0;
+    }
+    if (!o->plane_id || !o->fb.fb_id) {
+        return -1;
+    }
+    if (osd_commit_enable(fd, o->crtc_id, o) != 0) {
+        return -1;
+    }
+    o->active = 1;
+    return 0;
+}
+
 void osd_disable(int fd, OSD *o) {
     if (!o->active) {
         return;


### PR DESCRIPTION
## Summary
- add signal handlers so sending SIGUSR1 or SIGUSR2 toggles the on-screen display
- re-enable or tear down/recreate OSD resources based on current connection state while keeping receiver stats in sync
- expose an osd_enable helper to bring an existing overlay plane back online when toggled back on

## Testing
- make *(fails: missing xf86drm.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41ee812cc832b9fb30c78ff69e49d