### PR TITLE
Expose IDR backoff reset controls and telemetry

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -77,9 +77,10 @@ background = transparent-grey
 border = transparent-white
 foreground = white
 line = HDMI {display.mode} plane={drm.video_plane_id}
-line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms
+line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms src={udp.source_ip}:{udp.source_port}
 line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
-line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
+line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets} idr={udp.idr_requests}
+line = IDR backoff={udp.idr.backoff_ms}ms loss={udp.idr.loss_duration_ms}ms since={udp.idr.since_last_request_ms}ms cool={udp.idr.cooldown_ms}ms last={udp.idr.last_loss_ms}ms
 line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
 line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB seq={udp.expected_sequence}
 
@@ -170,6 +171,7 @@ grid = transparent-white
 ;   {udp.jitter.latest_ms}, {udp.jitter.avg_ms}
 ;   {udp.frames.count}, {udp.frames.incomplete}, {udp.frames.last_bytes}, {udp.frames.avg_bytes}  (frame sizes in kilobytes)
 ;   {udp.expected_sequence}, {udp.last_video_timestamp}
+;   {udp.idr_requests}, {udp.idr.backoff_ms}, {udp.idr.loss_duration_ms}, {udp.idr.since_last_request_ms}, {udp.idr.cooldown_ms}, {udp.idr.last_loss_ms}, {udp.source_ip}, {udp.source_port}
 ;
 ; -----------------------------------------------------------------------------
 ; Plot metrics (line elements)

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -53,9 +53,10 @@ background = transparent-grey
 border = transparent-white
 foreground = white
 line = HDMI {display.mode} plane={drm.video_plane_id}
-line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt}
+line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} src={udp.source_ip}:{udp.source_port}
 line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
-line = RTP loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
+line = RTP loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets} idr={udp.idr_requests}
+line = IDR backoff={udp.idr.backoff_ms}ms loss={udp.idr.loss_duration_ms}ms since={udp.idr.since_last_request_ms}ms cool={udp.idr.cooldown_ms}ms last={udp.idr.last_loss_ms}ms
 line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
 
 [osd.element.psd_histogram]

--- a/include/config.h
+++ b/include/config.h
@@ -48,6 +48,13 @@ typedef struct {
     CustomSinkMode custom_sink;
     char aud_dev[128];
 
+    int idr_request;
+    int idr_request_min_ms;
+    int idr_request_max_ms;
+    int idr_request_sustain_ms;
+    int idr_request_reset_ms;
+    int idr_request_timeout_ms;
+
     int no_audio;
     int audio_optional;
     int restart_limit;

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 #define UDP_RECEIVER_HISTORY 512
+#define UDP_RECEIVER_ADDR_MAX 64
 
 #define UDP_SAMPLE_FLAG_LOSS 0x01
 #define UDP_SAMPLE_FLAG_REORDER 0x02
@@ -52,10 +53,18 @@ typedef struct {
     double bitrate_avg_mbps;
     guint32 last_video_timestamp;
     guint16 expected_sequence;
+    char source_address[UDP_RECEIVER_ADDR_MAX];
+    guint16 source_port;
     size_t history_count;
     size_t history_head;
     UdpReceiverPacketSample history[UDP_RECEIVER_HISTORY];
     guint64 last_packet_ns;
+    guint64 idr_request_count;
+    guint64 idr_backoff_ns;
+    guint64 idr_last_request_ns;
+    guint64 idr_loss_start_ns;
+    guint64 idr_last_loss_event_ns;
+    guint64 idr_reset_deadline_ns;
 } UdpReceiverStats;
 
 typedef struct UdpReceiver UdpReceiver;

--- a/src/config.c
+++ b/src/config.c
@@ -89,6 +89,13 @@ void cfg_defaults(AppCfg *c) {
     c->custom_sink = CUSTOM_SINK_RECEIVER;
     strcpy(c->aud_dev, "plughw:CARD=rockchiphdmi0,DEV=0");
 
+    c->idr_request = 0;
+    c->idr_request_min_ms = 50;
+    c->idr_request_max_ms = 1000;
+    c->idr_request_sustain_ms = 5000;
+    c->idr_request_reset_ms = 2000;
+    c->idr_request_timeout_ms = 200;
+
     c->no_audio = 0;
     c->audio_optional = 1;
     c->restart_limit = 3;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -730,6 +730,34 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->aud_pt = atoi(value);
             return 0;
         }
+        if (strcasecmp(key, "idr-request") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->idr_request = v;
+            return 0;
+        }
+        if (strcasecmp(key, "idr-request-min-ms") == 0) {
+            cfg->idr_request_min_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "idr-request-max-ms") == 0) {
+            cfg->idr_request_max_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "idr-request-sustain-ms") == 0) {
+            cfg->idr_request_sustain_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "idr-request-reset-ms") == 0) {
+            cfg->idr_request_reset_ms = atoi(value);
+            return 0;
+        }
+        if (strcasecmp(key, "idr-request-timeout-ms") == 0) {
+            cfg->idr_request_timeout_ms = atoi(value);
+            return 0;
+        }
         return -1;
     }
     if (strcasecmp(section, "pipeline") == 0) {

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -44,9 +44,10 @@ void osd_layout_defaults(OsdLayout *layout) {
 
     const char *default_lines[] = {
         "HDMI {display.mode} plane={drm.video_plane_id}",
-        "UDP:{udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms",
+        "UDP:{udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.latency_ms}ms src={udp.source_ip}:{udp.source_port}",
         "Pipeline: {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}",
-        "RTP vpkts={udp.video_packets} net-loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets} jitter={udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms",
+        "RTP vpkts={udp.video_packets} net-loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets} idr={udp.idr_requests} jitter={udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms",
+        "IDR backoff={udp.idr.backoff_ms}ms loss={udp.idr.loss_duration_ms}ms since={udp.idr.since_last_request_ms}ms cool={udp.idr.cooldown_ms}ms last={udp.idr.last_loss_ms}ms",
         "Frames={udp.frames.count} incomplete={udp.frames.incomplete} last={udp.frames.last_bytes}KB avg={udp.frames.avg_bytes}KB seq={udp.expected_sequence}"
     };
     for (size_t i = 0; i < sizeof(default_lines) / sizeof(default_lines[0]) && i < OSD_MAX_TEXT_LINES; ++i) {


### PR DESCRIPTION
## Summary
- add configuration knobs for UDP IDR request timing, including reset-after-idle handling and configurable HTTP timeouts
- reset the UDP receiver IDR backoff when the quiet-period deadline expires and surface detailed scheduler stats
- expose the new IDR metrics to the OSD/token system and update sample layouts and docs

## Testing
- make *(fails: missing xf86drm.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e426d6f83c832b91d3a3ba52c2ea78