### PR TITLE
Add SSE stats streamer for UDP telemetry

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -20,6 +20,13 @@ custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
 
+[sse]
+; Optional Server-Sent Events streamer for UDP receiver counters.
+enable = false
+bind = 127.0.0.1
+port = 8080
+interval-ms = 1000
+
 [splash]
 ; Provide an Annex-B H.265 file with repeated key frames for the idle slate.
 enable = true

--- a/include/config.h
+++ b/include/config.h
@@ -46,6 +46,13 @@ typedef struct {
 } RecordCfg;
 
 typedef struct {
+    int enable;
+    char bind_address[64];
+    int port;
+    unsigned int interval_ms;
+} SseCfg;
+
+typedef struct {
     char card_path[64];
     char connector_name[32];
     char config_path[PATH_MAX];
@@ -80,6 +87,7 @@ typedef struct {
 
     SplashCfg splash;
     RecordCfg record;
+    SseCfg sse;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/sse_streamer.h
+++ b/include/sse_streamer.h
@@ -1,0 +1,53 @@
+#ifndef SSE_STREAMER_H
+#define SSE_STREAMER_H
+
+#include <glib.h>
+
+#include "config.h"
+#include "udp_receiver.h"
+
+typedef struct {
+    guint64 total_packets;
+    guint64 video_packets;
+    guint64 audio_packets;
+    guint64 ignored_packets;
+    guint64 duplicate_packets;
+    guint64 lost_packets;
+    guint64 reordered_packets;
+    guint64 total_bytes;
+    guint64 video_bytes;
+    guint64 audio_bytes;
+    guint64 frame_count;
+    guint64 incomplete_frames;
+    guint64 last_frame_bytes;
+    double frame_size_avg;
+    double jitter_ms;
+    double jitter_avg_ms;
+    double bitrate_mbps;
+    double bitrate_avg_mbps;
+    guint32 last_video_timestamp;
+    guint16 expected_sequence;
+    guint64 last_packet_ns;
+} SseStatsSnapshot;
+
+typedef struct {
+    gboolean configured;
+    int listen_fd;
+    guint interval_ms;
+    char bind_address[64];
+    int port;
+    GThread *accept_thread;
+    GMutex lock;
+    gboolean running;
+    gboolean shutdown;
+    gboolean have_stats;
+    SseStatsSnapshot stats;
+} SseStreamer;
+
+void sse_streamer_init(SseStreamer *streamer);
+int sse_streamer_start(SseStreamer *streamer, const AppCfg *cfg);
+void sse_streamer_publish(SseStreamer *streamer, const UdpReceiverStats *stats, gboolean have_stats);
+void sse_streamer_stop(SseStreamer *streamer);
+gboolean sse_streamer_requires_stats(const SseStreamer *streamer);
+
+#endif // SSE_STREAMER_H

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -842,6 +842,39 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "sse") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->sse.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "bind") == 0 || strcasecmp(key, "address") == 0 ||
+            strcasecmp(key, "bind-address") == 0) {
+            ini_copy_string(cfg->sse.bind_address, sizeof(cfg->sse.bind_address), value);
+            return 0;
+        }
+        if (strcasecmp(key, "port") == 0) {
+            int port = atoi(value);
+            if (port <= 0 || port > 65535) {
+                LOGE("config: SSE port '%s' out of range", value);
+                return -1;
+            }
+            cfg->sse.port = port;
+            return 0;
+        }
+        if (strcasecmp(key, "interval-ms") == 0) {
+            int v = atoi(value);
+            if (v <= 0) {
+                v = 1;
+            }
+            cfg->sse.interval_ms = (unsigned int)v;
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "gst") == 0) {
         if (strcasecmp(key, "log") == 0) {
             int v = 0;

--- a/src/sse_streamer.c
+++ b/src/sse_streamer.c
@@ -1,0 +1,371 @@
+#include "sse_streamer.h"
+
+#include "logging.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+typedef struct {
+    SseStreamer *streamer;
+    int fd;
+} SseClientContext;
+
+static int create_listen_socket(const char *bind_address, int port) {
+    int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        LOGE("SSE streamer: socket(): %s", strerror(errno));
+        return -1;
+    }
+
+    int yes = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) != 0) {
+        LOGW("SSE streamer: setsockopt(SO_REUSEADDR) failed: %s", strerror(errno));
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)port);
+    if (bind_address == NULL || bind_address[0] == '\0') {
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    } else {
+        if (inet_pton(AF_INET, bind_address, &addr.sin_addr) != 1) {
+            LOGE("SSE streamer: invalid bind address '%s'", bind_address);
+            close(fd);
+            return -1;
+        }
+    }
+
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        LOGE("SSE streamer: bind(%s:%d): %s", bind_address && bind_address[0] ? bind_address : "0.0.0.0", port,
+             strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    if (listen(fd, 4) != 0) {
+        LOGE("SSE streamer: listen(): %s", strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+static void set_socket_timeout(int fd, int seconds) {
+    struct timeval tv = {0};
+    tv.tv_sec = seconds;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
+        LOGW("SSE streamer: setsockopt(SO_RCVTIMEO) failed: %s", strerror(errno));
+    }
+}
+
+static ssize_t send_all(int fd, const char *data, size_t len) {
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t rc = send(fd, data + sent, len - sent, MSG_NOSIGNAL);
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        if (rc == 0) {
+            break;
+        }
+        sent += (size_t)rc;
+    }
+    return (ssize_t)sent;
+}
+
+static void format_json_payload(char *buf, size_t buf_sz, const SseStatsSnapshot *snap, gboolean have_stats) {
+    if (!have_stats || snap == NULL) {
+        g_snprintf(buf, buf_sz, "{\"have_stats\":false}");
+        return;
+    }
+
+    double last_frame_kib = snap->last_frame_bytes / 1024.0;
+    double frame_avg_kib = snap->frame_size_avg / 1024.0;
+
+    g_snprintf(buf, buf_sz,
+               "{\"have_stats\":true,\"total_packets\":%" G_GUINT64_FORMAT
+               ",\"video_packets\":%" G_GUINT64_FORMAT
+               ",\"audio_packets\":%" G_GUINT64_FORMAT
+               ",\"ignored_packets\":%" G_GUINT64_FORMAT
+               ",\"duplicate_packets\":%" G_GUINT64_FORMAT
+               ",\"lost_packets\":%" G_GUINT64_FORMAT
+               ",\"reordered_packets\":%" G_GUINT64_FORMAT
+               ",\"total_bytes\":%" G_GUINT64_FORMAT
+               ",\"video_bytes\":%" G_GUINT64_FORMAT
+               ",\"audio_bytes\":%" G_GUINT64_FORMAT
+               ",\"frame_count\":%" G_GUINT64_FORMAT
+               ",\"incomplete_frames\":%" G_GUINT64_FORMAT
+               ",\"last_frame_kib\":%.2f,\"avg_frame_kib\":%.2f,\"bitrate_mbps\":%.3f,\"bitrate_avg_mbps\":%.3f,"
+               "\"jitter_ms\":%.3f,\"jitter_avg_ms\":%.3f,\"expected_sequence\":%u,\"last_video_timestamp\":%u,"
+               "\"last_packet_ns\":%" G_GUINT64_FORMAT "}",
+               snap->total_packets, snap->video_packets, snap->audio_packets, snap->ignored_packets,
+               snap->duplicate_packets, snap->lost_packets, snap->reordered_packets, snap->total_bytes,
+               snap->video_bytes, snap->audio_bytes, snap->frame_count, snap->incomplete_frames, last_frame_kib,
+               frame_avg_kib, snap->bitrate_mbps, snap->bitrate_avg_mbps, snap->jitter_ms, snap->jitter_avg_ms,
+               snap->expected_sequence, snap->last_video_timestamp, snap->last_packet_ns);
+}
+
+static void sleep_interval(const SseStreamer *streamer) {
+    guint interval = streamer->interval_ms > 0 ? streamer->interval_ms : 1000u;
+    while (interval > 0 && !streamer->shutdown) {
+        guint chunk = interval > 100 ? 100 : interval;
+        g_usleep(chunk * 1000);
+        if (interval >= chunk) {
+            interval -= chunk;
+        } else {
+            interval = 0;
+        }
+    }
+}
+
+static gpointer sse_client_thread(gpointer data) {
+    SseClientContext *ctx = data;
+    SseStreamer *streamer = ctx->streamer;
+    int fd = ctx->fd;
+
+    char request[1024];
+    ssize_t req_len = recv(fd, request, sizeof(request) - 1, 0);
+    if (req_len <= 0) {
+        goto cleanup;
+    }
+    request[req_len] = '\0';
+
+    char method[8] = {0};
+    char path[128] = {0};
+    if (sscanf(request, "%7s %127s", method, path) != 2) {
+        send_all(fd, "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n", 44);
+        goto cleanup;
+    }
+
+    if (g_strcmp0(method, "GET") != 0) {
+        send_all(fd, "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n", 58);
+        goto cleanup;
+    }
+
+    if (g_strcmp0(path, "/stats") != 0 && g_strcmp0(path, "/stats/") != 0) {
+        send_all(fd, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n", 49);
+        goto cleanup;
+    }
+
+    const char *response_header = "HTTP/1.1 200 OK\r\n"
+                                  "Content-Type: text/event-stream\r\n"
+                                  "Cache-Control: no-cache\r\n"
+                                  "Connection: keep-alive\r\n"
+                                  "Access-Control-Allow-Origin: *\r\n\r\n";
+    if (send_all(fd, response_header, strlen(response_header)) < 0) {
+        goto cleanup;
+    }
+
+    while (!streamer->shutdown) {
+        SseStatsSnapshot snapshot = {0};
+        gboolean have_stats = FALSE;
+        g_mutex_lock(&streamer->lock);
+        have_stats = streamer->have_stats;
+        if (have_stats) {
+            snapshot = streamer->stats;
+        }
+        g_mutex_unlock(&streamer->lock);
+
+        char json[768];
+        format_json_payload(json, sizeof(json), &snapshot, have_stats);
+
+        char event_buf[1024];
+        int event_len = g_snprintf(event_buf, sizeof(event_buf), "event: stats\ndata: %s\n\n", json);
+        if (event_len <= 0 || event_len >= (int)sizeof(event_buf)) {
+            break;
+        }
+        if (send_all(fd, event_buf, (size_t)event_len) < 0) {
+            break;
+        }
+
+        sleep_interval(streamer);
+    }
+
+cleanup:
+    close(fd);
+    g_free(ctx);
+    return NULL;
+}
+
+static gpointer sse_accept_thread(gpointer data) {
+    SseStreamer *streamer = data;
+    while (!streamer->shutdown) {
+        struct pollfd pfd = {
+            .fd = streamer->listen_fd,
+            .events = POLLIN,
+            .revents = 0,
+        };
+        int rc = poll(&pfd, 1, 200);
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (!streamer->shutdown) {
+                LOGW("SSE streamer: poll failed: %s", strerror(errno));
+            }
+            continue;
+        }
+        if (rc == 0) {
+            continue;
+        }
+        if (!(pfd.revents & POLLIN)) {
+            continue;
+        }
+        struct sockaddr_in addr;
+        socklen_t addrlen = sizeof(addr);
+        int fd = accept(streamer->listen_fd, (struct sockaddr *)&addr, &addrlen);
+        if (fd < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno == EBADF || errno == EINVAL) {
+                break;
+            }
+            LOGW("SSE streamer: accept failed: %s", strerror(errno));
+            continue;
+        }
+
+        set_socket_timeout(fd, 5);
+
+        SseClientContext *ctx = g_new0(SseClientContext, 1);
+        if (ctx == NULL) {
+            LOGW("SSE streamer: failed to allocate client context");
+            close(fd);
+            continue;
+        }
+        ctx->streamer = streamer;
+        ctx->fd = fd;
+        GThread *client = g_thread_new("sse-client", sse_client_thread, ctx);
+        if (client == NULL) {
+            LOGW("SSE streamer: failed to spawn client thread");
+            close(fd);
+            g_free(ctx);
+            continue;
+        }
+        g_thread_unref(client);
+    }
+    return NULL;
+}
+
+void sse_streamer_init(SseStreamer *streamer) {
+    if (streamer == NULL) {
+        return;
+    }
+    memset(streamer, 0, sizeof(*streamer));
+    streamer->configured = FALSE;
+    streamer->listen_fd = -1;
+    streamer->interval_ms = 1000;
+    streamer->port = 0;
+    g_mutex_init(&streamer->lock);
+}
+
+int sse_streamer_start(SseStreamer *streamer, const AppCfg *cfg) {
+    if (streamer == NULL || cfg == NULL) {
+        return -1;
+    }
+    if (!cfg->sse.enable) {
+        streamer->configured = FALSE;
+        return 0;
+    }
+
+    streamer->configured = TRUE;
+    streamer->interval_ms = cfg->sse.interval_ms > 0 ? (guint)cfg->sse.interval_ms : 1000u;
+    streamer->port = cfg->sse.port;
+    if (cfg->sse.bind_address[0] != '\0') {
+        g_strlcpy(streamer->bind_address, cfg->sse.bind_address, sizeof(streamer->bind_address));
+    } else {
+        streamer->bind_address[0] = '\0';
+    }
+
+    streamer->listen_fd = create_listen_socket(streamer->bind_address, streamer->port);
+    if (streamer->listen_fd < 0) {
+        streamer->configured = FALSE;
+        return -1;
+    }
+
+    streamer->shutdown = FALSE;
+    streamer->running = TRUE;
+    streamer->accept_thread = g_thread_new("sse-accept", sse_accept_thread, streamer);
+    if (streamer->accept_thread == NULL) {
+        LOGE("SSE streamer: failed to start accept thread");
+        close(streamer->listen_fd);
+        streamer->listen_fd = -1;
+        streamer->running = FALSE;
+        streamer->configured = FALSE;
+        return -1;
+    }
+    LOGI("SSE streamer: listening on %s:%d (interval=%ums)",
+         streamer->bind_address[0] ? streamer->bind_address : "0.0.0.0", streamer->port, streamer->interval_ms);
+    return 0;
+}
+
+void sse_streamer_publish(SseStreamer *streamer, const UdpReceiverStats *stats, gboolean have_stats) {
+    if (streamer == NULL || !streamer->running) {
+        return;
+    }
+    g_mutex_lock(&streamer->lock);
+    streamer->have_stats = have_stats ? TRUE : FALSE;
+    if (have_stats && stats != NULL) {
+        SseStatsSnapshot snap = {
+            .total_packets = stats->total_packets,
+            .video_packets = stats->video_packets,
+            .audio_packets = stats->audio_packets,
+            .ignored_packets = stats->ignored_packets,
+            .duplicate_packets = stats->duplicate_packets,
+            .lost_packets = stats->lost_packets,
+            .reordered_packets = stats->reordered_packets,
+            .total_bytes = stats->total_bytes,
+            .video_bytes = stats->video_bytes,
+            .audio_bytes = stats->audio_bytes,
+            .frame_count = stats->frame_count,
+            .incomplete_frames = stats->incomplete_frames,
+            .last_frame_bytes = stats->last_frame_bytes,
+            .frame_size_avg = stats->frame_size_avg,
+            .jitter_ms = stats->jitter / 90.0,
+            .jitter_avg_ms = stats->jitter_avg / 90.0,
+            .bitrate_mbps = stats->bitrate_mbps,
+            .bitrate_avg_mbps = stats->bitrate_avg_mbps,
+            .last_video_timestamp = stats->last_video_timestamp,
+            .expected_sequence = stats->expected_sequence,
+            .last_packet_ns = stats->last_packet_ns,
+        };
+        streamer->stats = snap;
+    }
+    g_mutex_unlock(&streamer->lock);
+}
+
+void sse_streamer_stop(SseStreamer *streamer) {
+    if (streamer == NULL) {
+        return;
+    }
+    streamer->shutdown = TRUE;
+    if (streamer->listen_fd >= 0) {
+        close(streamer->listen_fd);
+        streamer->listen_fd = -1;
+    }
+    if (streamer->accept_thread != NULL) {
+        g_thread_join(streamer->accept_thread);
+        streamer->accept_thread = NULL;
+    }
+    streamer->running = FALSE;
+    streamer->configured = FALSE;
+    streamer->have_stats = FALSE;
+}
+
+gboolean sse_streamer_requires_stats(const SseStreamer *streamer) {
+    return streamer != NULL && streamer->configured;
+}


### PR DESCRIPTION
## Summary
- add an SSE-based HTTP streamer that publishes cumulative udp.* counters
- extend CLI/INI configuration plus sample config to enable and tune the SSE stats server
- document the endpoint and integrate the runtime so pipeline stats stay active for SSE clients

## Testing
- make *(fails: missing libdrm headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f0f7f0d8832baadf16c5e45b9639