### PR TITLE
Automatically request IDR frames after decoder errors

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -20,6 +20,13 @@ custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
 
+[idr]
+; Automatic HTTP trigger for forced IDR recovery.
+enable = true
+port = 80
+path = /request/idr
+timeout-ms = 200
+
 [sse]
 ; Optional Server-Sent Events streamer for UDP receiver counters.
 enable = true
@@ -95,7 +102,9 @@ line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} lat={pipeline.laten
 line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
 line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
 line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
-line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB seq={udp.expected_sequence}
+line = IDR req={udp.idr_requests}
+line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB
+line = Seq={udp.expected_sequence}
 
 ; To create additional text blocks duplicate the section with a new element
 ; name and adjust the anchor/offset. Each `line =` entry appends to that block.
@@ -184,6 +193,7 @@ grid = transparent-white
 ;   {udp.jitter.latest_ms}, {udp.jitter.avg_ms}
 ;   {udp.frames.count}, {udp.frames.incomplete}, {udp.frames.last_bytes}, {udp.frames.avg_bytes}  (frame sizes in kilobytes)
 ;   {udp.expected_sequence}, {udp.last_video_timestamp}
+;   {udp.idr_requests}          => total HTTP IDR requests issued
 ;
 ; -----------------------------------------------------------------------------
 ; Plot metrics (line elements)
@@ -198,6 +208,7 @@ grid = transparent-white
 ;   udp.frames.count             (count)
 ;   udp.video_packets            (count)
 ;   udp.duplicate_packets        (count)
+;   udp.idr_requests             (count)
 ;   udp.lost_packets             (count)
 ;   udp.reordered_packets        (count)
 ;   pipeline.restart_count       (count)

--- a/include/config.h
+++ b/include/config.h
@@ -53,6 +53,13 @@ typedef struct {
 } SseCfg;
 
 typedef struct {
+    int enable;
+    int http_port;
+    unsigned int http_timeout_ms;
+    char http_path[128];
+} IdrCfg;
+
+typedef struct {
     char card_path[64];
     char connector_name[32];
     char config_path[PATH_MAX];
@@ -88,6 +95,7 @@ typedef struct {
     SplashCfg splash;
     RecordCfg record;
     SseCfg sse;
+    IdrCfg idr;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/idr_requester.h
+++ b/include/idr_requester.h
@@ -1,0 +1,22 @@
+#ifndef IDR_REQUESTER_H
+#define IDR_REQUESTER_H
+
+#include <glib.h>
+#include <sys/socket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct IdrRequester IdrRequester;
+
+IdrRequester *idr_requester_new(void);
+void idr_requester_free(IdrRequester *req);
+void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len);
+void idr_requester_handle_warning(IdrRequester *req);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IDR_REQUESTER_H

--- a/include/idr_requester.h
+++ b/include/idr_requester.h
@@ -4,16 +4,19 @@
 #include <glib.h>
 #include <sys/socket.h>
 
+#include "config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct IdrRequester IdrRequester;
 
-IdrRequester *idr_requester_new(void);
+IdrRequester *idr_requester_new(const IdrCfg *cfg);
 void idr_requester_free(IdrRequester *req);
 void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len);
 void idr_requester_handle_warning(IdrRequester *req);
+void idr_requester_set_enabled(IdrRequester *req, gboolean enabled);
 
 #ifdef __cplusplus
 }

--- a/include/idr_requester.h
+++ b/include/idr_requester.h
@@ -17,6 +17,7 @@ void idr_requester_free(IdrRequester *req);
 void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len);
 void idr_requester_handle_warning(IdrRequester *req);
 void idr_requester_set_enabled(IdrRequester *req, gboolean enabled);
+guint64 idr_requester_get_request_count(const IdrRequester *req);
 
 #ifdef __cplusplus
 }

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -6,6 +6,7 @@
 
 #include "udp_receiver.h"
 #include "video_decoder.h"
+#include "idr_requester.h"
 
 typedef enum {
     PIPELINE_STOPPED = 0,
@@ -22,6 +23,7 @@ typedef struct {
     GstElement *video_sink;
     GstElement *input_selector;
     UdpReceiver *udp_receiver;
+    IdrRequester *idr_requester;
     GThread *bus_thread;
     GThread *appsink_thread;
     GMutex lock;

--- a/include/sse_streamer.h
+++ b/include/sse_streamer.h
@@ -28,6 +28,7 @@ typedef struct {
     guint32 last_video_timestamp;
     guint16 expected_sequence;
     guint64 last_packet_ns;
+    guint64 idr_requests;
 } SseStatsSnapshot;
 
 typedef struct {

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -56,6 +56,7 @@ typedef struct {
     size_t history_head;
     UdpReceiverPacketSample history[UDP_RECEIVER_HISTORY];
     guint64 last_packet_ns;
+    guint64 idr_requests;
 } UdpReceiverStats;
 
 typedef struct UdpReceiver UdpReceiver;

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -59,8 +59,9 @@ typedef struct {
 } UdpReceiverStats;
 
 typedef struct UdpReceiver UdpReceiver;
+struct IdrRequester;
 
-UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc);
+UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc, struct IdrRequester *requester);
 void udp_receiver_set_audio_appsrc(UdpReceiver *ur, GstAppSrc *audio_appsrc);
 int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include "drm_modeset.h"
+#include "idr_requester.h"
 
 typedef struct VideoDecoder VideoDecoder;
 
@@ -21,6 +22,8 @@ void video_decoder_stop(VideoDecoder *vd);
 
 int video_decoder_feed(VideoDecoder *vd, const guint8 *data, size_t size);
 void video_decoder_send_eos(VideoDecoder *vd);
+
+void video_decoder_set_idr_requester(VideoDecoder *vd, IdrRequester *requester);
 
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
 

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -875,6 +875,38 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "idr") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->idr.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "port") == 0) {
+            int port = atoi(value);
+            if (port <= 0 || port > 65535) {
+                LOGE("config: IDR port '%s' out of range", value);
+                return -1;
+            }
+            cfg->idr.http_port = port;
+            return 0;
+        }
+        if (strcasecmp(key, "path") == 0 || strcasecmp(key, "request") == 0) {
+            ini_copy_string(cfg->idr.http_path, sizeof(cfg->idr.http_path), value);
+            return 0;
+        }
+        if (strcasecmp(key, "timeout-ms") == 0) {
+            int timeout = atoi(value);
+            if (timeout <= 0) {
+                timeout = 1;
+            }
+            cfg->idr.http_timeout_ms = (unsigned int)timeout;
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "gst") == 0) {
         if (strcasecmp(key, "log") == 0) {
             int v = 0;

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -1,0 +1,311 @@
+#include "idr_requester.h"
+
+#include "logging.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define IDR_INITIAL_INTERVAL_MS 500u
+#define IDR_MAX_INTERVAL_MS 8000u
+#define IDR_QUIET_RESET_MS 2000u
+#define IDR_HOST_MAX 64
+#define IDR_URL_MAX 128
+
+typedef struct {
+    IdrRequester *owner;
+    char url[IDR_URL_MAX];
+} IdrCurlTask;
+
+struct IdrRequester {
+    GMutex lock;
+    GCond cond;
+    gboolean cond_initialized;
+
+    gboolean have_source;
+    gboolean source_is_ipv6;
+    char source_host[IDR_HOST_MAX];
+
+    guint64 last_warning_ms;
+    guint64 last_request_ms;
+    guint64 next_interval_ms;
+    guint attempt_count;
+
+    gboolean active;
+    gboolean request_in_flight;
+    gboolean shutting_down;
+};
+
+static guint64 monotonic_ms(void) {
+    return (guint64)g_get_monotonic_time() / 1000ull;
+}
+
+static gpointer idr_requester_curl_worker(gpointer data) {
+    IdrCurlTask *task = (IdrCurlTask *)data;
+    if (task == NULL || task->owner == NULL) {
+        if (task != NULL) {
+            g_free(task);
+        }
+        return NULL;
+    }
+
+    gchar *argv[] = {"curl", "--max-time", "0.2", "--connect-timeout", "0.2", "-s", "-o", "/dev/null", task->url, NULL};
+    GError *error = NULL;
+    int status = 0;
+    gboolean ok = g_spawn_sync(NULL,
+                               argv,
+                               NULL,
+                               G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL,
+                               NULL,
+                               NULL,
+                               NULL,
+                               NULL,
+                               &status,
+                               &error);
+    if (!ok) {
+        static gsize curl_missing_once = 0;
+        if (error != NULL) {
+            if (error->domain == G_SPAWN_ERROR && error->code == G_SPAWN_ERROR_NOENT) {
+                if (g_once_init_enter(&curl_missing_once)) {
+                    LOGW("IDR requester: curl executable not found; cannot request IDR frames automatically");
+                    g_once_init_leave(&curl_missing_once, 1);
+                }
+            } else {
+                LOGW("IDR requester: curl invocation failed: %s", error->message);
+            }
+            g_error_free(error);
+        } else {
+            LOGW("IDR requester: curl invocation failed (unknown error)");
+        }
+    } else if (!g_spawn_check_exit_status(status, NULL)) {
+        LOGW("IDR requester: curl exited with status %d", status);
+    }
+
+    g_mutex_lock(&task->owner->lock);
+    task->owner->request_in_flight = FALSE;
+    if (task->owner->cond_initialized) {
+        g_cond_broadcast(&task->owner->cond);
+    }
+    g_mutex_unlock(&task->owner->lock);
+
+    g_free(task);
+    return NULL;
+}
+
+IdrRequester *idr_requester_new(void) {
+    IdrRequester *req = g_new0(IdrRequester, 1);
+    if (req == NULL) {
+        return NULL;
+    }
+    g_mutex_init(&req->lock);
+    g_cond_init(&req->cond);
+    req->cond_initialized = TRUE;
+    req->have_source = FALSE;
+    req->source_is_ipv6 = FALSE;
+    req->source_host[0] = '\0';
+    req->last_warning_ms = 0;
+    req->last_request_ms = 0;
+    req->next_interval_ms = IDR_INITIAL_INTERVAL_MS;
+    req->attempt_count = 0;
+    req->active = FALSE;
+    req->request_in_flight = FALSE;
+    req->shutting_down = FALSE;
+    return req;
+}
+
+void idr_requester_free(IdrRequester *req) {
+    if (req == NULL) {
+        return;
+    }
+
+    g_mutex_lock(&req->lock);
+    req->shutting_down = TRUE;
+    while (req->request_in_flight) {
+        if (req->cond_initialized) {
+            g_cond_wait(&req->cond, &req->lock);
+        } else {
+            g_mutex_unlock(&req->lock);
+            g_usleep(1000);
+            g_mutex_lock(&req->lock);
+        }
+    }
+    g_mutex_unlock(&req->lock);
+
+    if (req->cond_initialized) {
+        g_cond_clear(&req->cond);
+    }
+    g_mutex_clear(&req->lock);
+    g_free(req);
+}
+
+void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len) {
+    if (req == NULL || addr == NULL || len <= 0) {
+        return;
+    }
+
+    char host[IDR_HOST_MAX];
+    memset(host, 0, sizeof(host));
+    gboolean is_ipv6 = FALSE;
+
+    if (addr->sa_family == AF_INET) {
+        const struct sockaddr_in *sin = (const struct sockaddr_in *)addr;
+        if (inet_ntop(AF_INET, &sin->sin_addr, host, sizeof(host)) == NULL) {
+            return;
+        }
+    } else if (addr->sa_family == AF_INET6) {
+        const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)addr;
+        if (inet_ntop(AF_INET6, &sin6->sin6_addr, host, sizeof(host)) == NULL) {
+            return;
+        }
+        is_ipv6 = TRUE;
+    } else {
+        return;
+    }
+
+    g_mutex_lock(&req->lock);
+    if (req->shutting_down) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    gboolean changed = FALSE;
+    if (!req->have_source || req->source_is_ipv6 != is_ipv6 || g_strcmp0(req->source_host, host) != 0) {
+        g_strlcpy(req->source_host, host, sizeof(req->source_host));
+        req->source_is_ipv6 = is_ipv6;
+        req->have_source = TRUE;
+        req->next_interval_ms = IDR_INITIAL_INTERVAL_MS;
+        req->last_request_ms = 0;
+        req->attempt_count = 0;
+        req->active = FALSE;
+        changed = TRUE;
+    }
+    g_mutex_unlock(&req->lock);
+
+    if (changed) {
+        if (is_ipv6) {
+            LOGI("IDR requester: tracking source [%s]", host);
+        } else {
+            LOGI("IDR requester: tracking source %s", host);
+        }
+    }
+}
+
+void idr_requester_handle_warning(IdrRequester *req) {
+    if (req == NULL) {
+        return;
+    }
+
+    guint64 now_ms = monotonic_ms();
+    IdrCurlTask *task = NULL;
+    gboolean launch = FALSE;
+    guint attempt = 0;
+
+    g_mutex_lock(&req->lock);
+    if (req->shutting_down) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    if (req->active && req->last_warning_ms != 0 && now_ms > req->last_warning_ms) {
+        guint64 quiet = now_ms - req->last_warning_ms;
+        if (quiet > IDR_QUIET_RESET_MS) {
+            req->active = FALSE;
+            req->next_interval_ms = IDR_INITIAL_INTERVAL_MS;
+            req->last_request_ms = 0;
+            req->attempt_count = 0;
+        }
+    }
+
+    if (!req->active) {
+        req->active = TRUE;
+        req->next_interval_ms = IDR_INITIAL_INTERVAL_MS;
+        req->last_request_ms = 0;
+        req->attempt_count = 0;
+    }
+
+    req->last_warning_ms = now_ms;
+
+    if (!req->have_source) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    gboolean time_ready = FALSE;
+    if (req->last_request_ms == 0) {
+        time_ready = TRUE;
+    } else if (now_ms > req->last_request_ms) {
+        guint64 elapsed = now_ms - req->last_request_ms;
+        if (elapsed >= req->next_interval_ms) {
+            time_ready = TRUE;
+        }
+    }
+
+    if (time_ready && !req->request_in_flight) {
+        req->request_in_flight = TRUE;
+        req->last_request_ms = now_ms;
+        attempt = ++req->attempt_count;
+
+        guint64 next_interval = req->next_interval_ms * 2u;
+        if (next_interval > IDR_MAX_INTERVAL_MS) {
+            next_interval = IDR_MAX_INTERVAL_MS;
+        }
+        if (next_interval < IDR_INITIAL_INTERVAL_MS) {
+            next_interval = IDR_INITIAL_INTERVAL_MS;
+        }
+        req->next_interval_ms = next_interval;
+
+        task = g_new0(IdrCurlTask, 1);
+        if (task != NULL) {
+            task->owner = req;
+            if (req->source_is_ipv6) {
+                g_snprintf(task->url, sizeof(task->url), "http://[%s]/request/idr", req->source_host);
+            } else {
+                g_snprintf(task->url, sizeof(task->url), "http://%s/request/idr", req->source_host);
+            }
+            launch = TRUE;
+        } else {
+            req->request_in_flight = FALSE;
+            req->attempt_count--;
+            req->last_request_ms = 0;
+            if (req->cond_initialized) {
+                g_cond_broadcast(&req->cond);
+            }
+        }
+    }
+
+    char url_copy[IDR_URL_MAX];
+    url_copy[0] = '\0';
+    if (launch && task != NULL) {
+        g_strlcpy(url_copy, task->url, sizeof(url_copy));
+    }
+    g_mutex_unlock(&req->lock);
+
+    if (!launch || task == NULL) {
+        if (task != NULL) {
+            g_free(task);
+        }
+        return;
+    }
+
+    LOGW("IDR requester: triggering IDR via %s (attempt %u)", url_copy, attempt);
+
+    GThread *thread = g_thread_new("idr-request", idr_requester_curl_worker, task);
+    if (thread == NULL) {
+        LOGE("IDR requester: failed to create curl helper thread");
+        g_mutex_lock(&req->lock);
+        req->request_in_flight = FALSE;
+        if (req->attempt_count > 0) {
+            req->attempt_count--;
+        }
+        req->last_request_ms = 0;
+        if (req->cond_initialized) {
+            g_cond_broadcast(&req->cond);
+        }
+        g_mutex_unlock(&req->lock);
+        g_free(task);
+        return;
+    }
+
+    g_thread_unref(thread);
+}

--- a/src/osd.c
+++ b/src/osd.c
@@ -421,6 +421,10 @@ static int osd_token_format(const OsdRenderContext *ctx, const char *token, char
         snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.reordered_packets);
         return 0;
     }
+    if (strcmp(key, "udp.idr_requests") == 0) {
+        snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.idr_requests);
+        return 0;
+    }
     if (strcmp(key, "udp.total_bytes") == 0) {
         snprintf(buf, buf_sz, "%llu", (unsigned long long)ctx->stats.total_bytes);
         return 0;
@@ -516,6 +520,10 @@ static int osd_metric_sample(const OsdRenderContext *ctx, const char *key, doubl
     }
     if (metric && strcmp(metric, "udp.frames.count") == 0) {
         *out_value = (double)ctx->stats.frame_count;
+        return 1;
+    }
+    if (metric && strcmp(metric, "udp.idr_requests") == 0) {
+        *out_value = (double)ctx->stats.idr_requests;
         return 1;
     }
     if (metric && strcmp(metric, "udp.frames.last_bytes") == 0) {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1221,9 +1221,13 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
         idr_requester_free(ps->idr_requester);
         ps->idr_requester = NULL;
     }
-    ps->idr_requester = idr_requester_new();
-    if (ps->idr_requester == NULL) {
-        LOGW("IDR requester: allocation failed; automatic IDR recovery disabled");
+    if (cfg->idr.enable) {
+        ps->idr_requester = idr_requester_new(&cfg->idr);
+        if (ps->idr_requester == NULL) {
+            LOGW("IDR requester: allocation failed; automatic IDR recovery disabled");
+        }
+    } else {
+        LOGI("IDR requester: disabled via configuration");
     }
 
     GstElement *pipeline = NULL;

--- a/src/sse_streamer.c
+++ b/src/sse_streamer.c
@@ -110,13 +110,13 @@ static void format_json_payload(char *buf, size_t buf_sz, const SseStatsSnapshot
                ",\"frame_count\":%" G_GUINT64_FORMAT
                ",\"incomplete_frames\":%" G_GUINT64_FORMAT
                ",\"last_frame_kib\":%.2f,\"avg_frame_kib\":%.2f,\"bitrate_mbps\":%.3f,\"bitrate_avg_mbps\":%.3f,"
-               "\"jitter_ms\":%.3f,\"jitter_avg_ms\":%.3f,\"expected_sequence\":%u,\"last_video_timestamp\":%u,"
-               "\"last_packet_ns\":%" G_GUINT64_FORMAT "}",
+                "\"jitter_ms\":%.3f,\"jitter_avg_ms\":%.3f,\"expected_sequence\":%u,\"last_video_timestamp\":%u,"
+                "\"last_packet_ns\":%" G_GUINT64_FORMAT ",\"idr_requests\":%" G_GUINT64_FORMAT "}",
                snap->total_packets, snap->video_packets, snap->audio_packets, snap->ignored_packets,
                snap->duplicate_packets, snap->lost_packets, snap->reordered_packets, snap->total_bytes,
                snap->video_bytes, snap->audio_bytes, snap->frame_count, snap->incomplete_frames, last_frame_kib,
-               frame_avg_kib, snap->bitrate_mbps, snap->bitrate_avg_mbps, snap->jitter_ms, snap->jitter_avg_ms,
-               snap->expected_sequence, snap->last_video_timestamp, snap->last_packet_ns);
+                frame_avg_kib, snap->bitrate_mbps, snap->bitrate_avg_mbps, snap->jitter_ms, snap->jitter_avg_ms,
+                snap->expected_sequence, snap->last_video_timestamp, snap->last_packet_ns, snap->idr_requests);
 }
 
 static void sleep_interval(const SseStreamer *streamer) {
@@ -342,6 +342,7 @@ void sse_streamer_publish(SseStreamer *streamer, const UdpReceiverStats *stats, 
             .last_video_timestamp = stats->last_video_timestamp,
             .expected_sequence = stats->expected_sequence,
             .last_packet_ns = stats->last_packet_ns,
+            .idr_requests = stats->idr_requests,
         };
         streamer->stats = snap;
     }

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -2,6 +2,7 @@
 
 #include "udp_receiver.h"
 #include "logging.h"
+#include "idr_requester.h"
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -110,6 +111,8 @@ struct UdpReceiver {
     gboolean have_video_ssrc;
 
     guint64 last_packet_ns;
+
+    IdrRequester *idr;
 };
 
 // Helpers to update/read last_packet_ns without assuming 64-bit GLib atomics
@@ -753,6 +756,7 @@ static gpointer receiver_thread(gpointer data) {
         GstMapInfo maps[UDP_RECEIVER_BATCH];
         struct mmsghdr msgs[UDP_RECEIVER_BATCH];
         struct iovec iovecs[UDP_RECEIVER_BATCH];
+        struct sockaddr_storage addrs[UDP_RECEIVER_BATCH];
         guint prepared = 0;
 
         while (prepared < UDP_RECEIVER_BATCH) {
@@ -774,10 +778,13 @@ static gpointer receiver_thread(gpointer data) {
 
             buffers[prepared] = gstbuf;
             memset(&msgs[prepared], 0, sizeof(msgs[prepared]));
+            memset(&addrs[prepared], 0, sizeof(addrs[prepared]));
             iovecs[prepared].iov_base = maps[prepared].data;
             iovecs[prepared].iov_len = max_pkt;
             msgs[prepared].msg_hdr.msg_iov = &iovecs[prepared];
             msgs[prepared].msg_hdr.msg_iovlen = 1;
+            msgs[prepared].msg_hdr.msg_name = &addrs[prepared];
+            msgs[prepared].msg_hdr.msg_namelen = sizeof(addrs[prepared]);
             prepared++;
         }
 
@@ -820,6 +827,12 @@ static gpointer receiver_thread(gpointer data) {
         }
 
         for (int i = 0; i < received; i++) {
+            if (ur->idr != NULL && msgs[i].msg_hdr.msg_name != NULL && msgs[i].msg_hdr.msg_namelen > 0) {
+                idr_requester_note_source(ur->idr,
+                                          (const struct sockaddr *)msgs[i].msg_hdr.msg_name,
+                                          msgs[i].msg_hdr.msg_namelen);
+            }
+
             if (msgs[i].msg_hdr.msg_flags & MSG_TRUNC) {
                 LOGW("UDP receiver: truncated UDP packet dropped");
                 gst_buffer_unmap(buffers[i], &maps[i]);
@@ -839,7 +852,11 @@ static gpointer receiver_thread(gpointer data) {
     return NULL;
 }
 
-UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc) {
+UdpReceiver *udp_receiver_create(int udp_port,
+                                 int vid_pt,
+                                 int aud_pt,
+                                 GstAppSrc *video_appsrc,
+                                 IdrRequester *requester) {
     if (video_appsrc == NULL) {
         return NULL;
     }
@@ -861,6 +878,7 @@ UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc
     ur->pool = NULL;
     ur->buffer_size = 0;
     ur->last_packet_ns = 0;
+    ur->idr = requester;
     return ur;
 }
 

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -1071,6 +1071,11 @@ void udp_receiver_get_stats(UdpReceiver *ur, UdpReceiverStats *stats) {
     copy_history(stats->history, ur->history, UDP_RECEIVER_HISTORY);
     g_mutex_unlock(&ur->lock);
     stats->last_packet_ns = udp_receiver_last_packet_load(ur);
+    guint64 idr_total = 0;
+    if (ur->idr != NULL) {
+        idr_total = idr_requester_get_request_count(ur->idr);
+    }
+    stats->idr_requests = idr_total;
 }
 
 void udp_receiver_set_stats_enabled(UdpReceiver *ur, gboolean enabled) {


### PR DESCRIPTION
## Summary
- add an IDR requester helper that issues HTTP IDR requests with exponential backoff and short timeouts
- capture the latest UDP source address and forward decoder warning events to the requester
- connect the requester into the pipeline and decoder so dropped-frame warnings automatically trigger recovery attempts

## Testing
- make *(fails: missing xf86drm.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e549138cc8832ba12c435766fa338d