### PR TITLE
Wake polling threads on shutdown

### DIFF
--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -51,6 +51,7 @@ typedef struct {
     guint64 last_udp_activity_ns;
     struct VideoRecorder *recorder;
     GMutex recorder_lock;
+    int wake_fd;
 } PipelineState;
 
 #include "config.h"

--- a/include/sse_streamer.h
+++ b/include/sse_streamer.h
@@ -43,10 +43,11 @@ typedef struct {
     gboolean shutdown;
     gboolean have_stats;
     SseStatsSnapshot stats;
+    int wake_fd;
 } SseStreamer;
 
 void sse_streamer_init(SseStreamer *streamer);
-int sse_streamer_start(SseStreamer *streamer, const AppCfg *cfg);
+int sse_streamer_start(SseStreamer *streamer, const AppCfg *cfg, int wake_fd);
 void sse_streamer_publish(SseStreamer *streamer, const UdpReceiverStats *stats, gboolean have_stats);
 void sse_streamer_stop(SseStreamer *streamer);
 gboolean sse_streamer_requires_stats(const SseStreamer *streamer);

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -64,6 +64,7 @@ struct IdrRequester;
 
 UdpReceiver *udp_receiver_create(int udp_port, int vid_pt, int aud_pt, GstAppSrc *video_appsrc, struct IdrRequester *requester);
 void udp_receiver_set_audio_appsrc(UdpReceiver *ur, GstAppSrc *audio_appsrc);
+void udp_receiver_set_wake_fd(UdpReceiver *ur, int wake_fd);
 int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot);
 void udp_receiver_stop(UdpReceiver *ur);
 void udp_receiver_destroy(UdpReceiver *ur);

--- a/src/main.c
+++ b/src/main.c
@@ -477,6 +477,7 @@ int main(int argc, char **argv) {
     sse_streamer_publish(&sse_streamer, NULL, FALSE);
     sse_streamer_stop(&sse_streamer);
     if (g_shutdown_event_fd >= 0) {
+        drain_shutdown_eventfd();
         close(g_shutdown_event_fd);
         g_shutdown_event_fd = -1;
     }

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -442,6 +442,7 @@ static GstElement *create_udp_app_source(const AppCfg *cfg,
         LOGE("Failed to create UDP receiver");
         goto fail;
     }
+    udp_receiver_set_wake_fd(receiver, ps->wake_fd);
 
     if (receiver_out != NULL) {
         *receiver_out = receiver;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -411,7 +411,8 @@ static GstCaps *build_appsrc_caps(const AppCfg *cfg, gboolean video_only) {
     return gst_caps_new_empty_simple("application/x-rtp");
 }
 
-static GstElement *create_udp_app_source(const AppCfg *cfg,
+static GstElement *create_udp_app_source(PipelineState *ps,
+                                         const AppCfg *cfg,
                                          gboolean video_only,
                                          UdpReceiver **receiver_out,
                                          IdrRequester *requester) {
@@ -442,7 +443,9 @@ static GstElement *create_udp_app_source(const AppCfg *cfg,
         LOGE("Failed to create UDP receiver");
         goto fail;
     }
-    udp_receiver_set_wake_fd(receiver, ps->wake_fd);
+    if (ps != NULL) {
+        udp_receiver_set_wake_fd(receiver, ps->wake_fd);
+    }
 
     if (receiver_out != NULL) {
         *receiver_out = receiver;
@@ -497,7 +500,7 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     pipeline = gst_pipeline_new("pixelpilot-receiver");
     CHECK_ELEM(pipeline, "pipeline");
 
-    appsrc = create_udp_app_source(cfg, TRUE, &receiver, ps->idr_requester);
+    appsrc = create_udp_app_source(ps, cfg, TRUE, &receiver, ps->idr_requester);
     if (appsrc == NULL) {
         goto fail;
     }

--- a/src/sse_streamer.c
+++ b/src/sse_streamer.c
@@ -345,6 +345,7 @@ int sse_streamer_start(SseStreamer *streamer, const AppCfg *cfg, int wake_fd) {
     streamer->listen_fd = create_listen_socket(streamer->bind_address, streamer->port);
     if (streamer->listen_fd < 0) {
         streamer->configured = FALSE;
+        streamer->wake_fd = -1;
         return -1;
     }
 
@@ -357,6 +358,7 @@ int sse_streamer_start(SseStreamer *streamer, const AppCfg *cfg, int wake_fd) {
         streamer->listen_fd = -1;
         streamer->running = FALSE;
         streamer->configured = FALSE;
+        streamer->wake_fd = -1;
         return -1;
     }
     LOGI("SSE streamer: listening on %s:%d (fd=%d, interval=%ums)",


### PR DESCRIPTION
## Summary
- add a shared shutdown eventfd in main and wire it into the primary poll loop
- propagate the wake fd through the pipeline so the UDP receiver and SSE streamer poll on it and exit promptly
- log socket file descriptors when binding UDP and SSE listeners to aid debugging

## Testing
- make *(fails: missing xf86drm headers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e572d0b138832ba309718067487afb