### PR TITLE
Add minimal udpsrc configuration profile

### DIFF
--- a/config/minimal-udpsrc.ini
+++ b/config/minimal-udpsrc.ini
@@ -1,0 +1,41 @@
+; PixelPilot Mini minimal configuration.
+; This profile disables all optional services and uses the bare udpsrc pipeline.
+
+[drm]
+card = /dev/dri/card0
+connector = HDMI-A-1
+video-plane-id = 76
+use-udev = false
+osd-plane-id = 0
+
+[udp]
+port = 5600
+video-pt = 97
+audio-pt = -1
+
+[pipeline]
+latency-ms = 8
+custom-sink = udpsrc
+pt97-filter = false
+
+[audio]
+disable = true
+optional = false
+
+[osd]
+enable = false
+
+[splash]
+enable = false
+
+[record]
+enable = false
+
+[sse]
+enable = false
+
+[idr]
+enable = false
+
+[gst]
+log = false


### PR DESCRIPTION
## Summary
- add a minimal udpsrc configuration that disables optional services for a barebones setup

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ea001a0844832b9d9848bbe5664a02