### PR TITLE
Improve launcher signal handling and SSE streamer robustness

### DIFF
--- a/include/sse_streamer.h
+++ b/include/sse_streamer.h
@@ -38,9 +38,12 @@ typedef struct {
     char bind_address[64];
     int port;
     GThread *accept_thread;
+    GThreadPool *client_pool;
+    guint max_clients;
     GMutex lock;
     gboolean running;
     volatile gint shutdown_flag;
+    volatile gint active_clients;
     gboolean have_stats;
     SseStatsSnapshot stats;
 } SseStreamer;


### PR DESCRIPTION
## Summary
- replace legacy signal() usage with sigaction(), install restart-friendly handlers, and guard toggle counters with signal masking
- check poll() results before consuming udev events to avoid stale revents and log poll errors
- harden the SSE streamer by adding connection timeouts, bounded client concurrency via a thread pool, and defensive HTTP request parsing

## Testing
- make *(fails: missing xf86drm headers in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68ea4873f664832b867da7091d29cf06