### PR TITLE
Document IDR dependence on custom receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ will then create a bare `udpsrc` element and UEP/receiver statistics are disable
 
 Use this mode when integrating with external tooling or experimenting with alternative buffering strategies where the
 application-level receiver is unnecessary. Revert with `--custom-sink receiver` (or remove the INI override) to restore the
-default behaviour and regain access to the telemetry counters.
+default behaviour and regain access to the telemetry counters. Keep in mind that the automatic IDR requester also depends on
+the custom receiver: it learns the sender's IP/port from incoming UDP packets and reuses that information when issuing HTTP
+burst requests. The bare `udpsrc` pipeline never surfaces that metadata, so even if `[idr].enable = true` is set in a minimal
+configuration the recovery logic stays inactive.
 
 ## UDP receiver statistics
 


### PR DESCRIPTION
## Summary
- explain in the README that automatic IDR requests only work with the custom UDP receiver
- clarify that the bare udpsrc pipeline cannot learn the sender address, so enabling [idr] in the minimal config has no effect

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ea4fa6a728832bba7607a7313b4974