### PR TITLE
Update SSE stats units for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,21 +141,21 @@ via:
 ```
 
 Each HTTP client that performs `GET /stats` receives a `text/event-stream` response. Payloads are emitted at the configured
-interval and include all counters listed above together with recording telemetry:
+interval and include all counters listed above together with recording telemetry. Byte-oriented counters are reported in
+megabytes (MiB) for readability:
 
 ```
 event: stats
 data: {"have_stats":true,"total_packets":1234,"video_packets":1234,
        "audio_packets":0,"ignored_packets":0,"duplicate_packets":0,
-       "lost_packets":2,"reordered_packets":1,"total_bytes":9876543,
-       "video_bytes":9876543,"audio_bytes":0,"frame_count":45,
+       "lost_packets":2,"reordered_packets":1,"total_mbytes":9,
+       "video_mbytes":9,"audio_mbytes":0,"frame_count":45,
        "incomplete_frames":0,"last_frame_kib":112.5,"avg_frame_kib":108.3,
        "bitrate_mbps":12.340,"bitrate_avg_mbps":10.876,"jitter_ms":3.25,
        "jitter_avg_ms":2.97,"expected_sequence":54321,
-       "last_video_timestamp":27182818,"last_packet_ns":123456789012,
        "idr_requests":7,"recording_enabled":true,
        "recording_active":false,"recording_duration_s":12.5,
-       "recording_media_s":10.0,"recording_bytes":31457280,
+       "recording_media_s":10.0,"recording_mbytes":30,
        "recording_path":"/media/pixelpilot-20240101-120000.mp4"}
 ```
 

--- a/include/sse_streamer.h
+++ b/include/sse_streamer.h
@@ -28,9 +28,7 @@ typedef struct {
     double jitter_avg_ms;
     double bitrate_mbps;
     double bitrate_avg_mbps;
-    guint32 last_video_timestamp;
     guint16 expected_sequence;
-    guint64 last_packet_ns;
     guint64 idr_requests;
     gboolean recording_enabled;
     gboolean recording_active;

--- a/src/sse_streamer.c
+++ b/src/sse_streamer.c
@@ -221,23 +221,34 @@ static void format_json_payload(char *buf, size_t buf_sz, const SseStatsSnapshot
     }
 
     g_snprintf(buf, buf_sz,
-               "{\"have_stats\":true,\"total_packets\":%" G_GUINT64_FORMAT
-               ",\"video_packets\":%" G_GUINT64_FORMAT
-               ",\"audio_packets\":%" G_GUINT64_FORMAT
-               ",\"ignored_packets\":%" G_GUINT64_FORMAT
-               ",\"duplicate_packets\":%" G_GUINT64_FORMAT
-               ",\"lost_packets\":%" G_GUINT64_FORMAT
-               ",\"reordered_packets\":%" G_GUINT64_FORMAT
-               ",\"total_mbytes\":%" G_GUINT64_FORMAT
-               ",\"video_mbytes\":%" G_GUINT64_FORMAT
-               ",\"audio_mbytes\":%" G_GUINT64_FORMAT
-               ",\"frame_count\":%" G_GUINT64_FORMAT
-               ",\"incomplete_frames\":%" G_GUINT64_FORMAT
-               ",\"last_frame_kib\":%.2f,\"avg_frame_kib\":%.2f,\"bitrate_mbps\":%.3f,\"bitrate_avg_mbps\":%.3f,""
-               "\"jitter_ms\":%.3f,\"jitter_avg_ms\":%.3f,\"expected_sequence\":%u,\"idr_requests\":%" G_GUINT64_FORMAT
-               ",\"recording_enabled\":%s,\"recording_active\":%s,\"recording_duration_s\":%.3f,""
-               "\"recording_media_s\":%.3f,\"recording_mbytes\":%" G_GUINT64_FORMAT
-               ",\"recording_path\":\"%s\"}",
+               "{"
+               "\"have_stats\":true,"
+               "\"total_packets\":%" G_GUINT64_FORMAT ","
+               "\"video_packets\":%" G_GUINT64_FORMAT ","
+               "\"audio_packets\":%" G_GUINT64_FORMAT ","
+               "\"ignored_packets\":%" G_GUINT64_FORMAT ","
+               "\"duplicate_packets\":%" G_GUINT64_FORMAT ","
+               "\"lost_packets\":%" G_GUINT64_FORMAT ","
+               "\"reordered_packets\":%" G_GUINT64_FORMAT ","
+               "\"total_mbytes\":%" G_GUINT64_FORMAT ","
+               "\"video_mbytes\":%" G_GUINT64_FORMAT ","
+               "\"audio_mbytes\":%" G_GUINT64_FORMAT ","
+               "\"frame_count\":%" G_GUINT64_FORMAT ","
+               "\"incomplete_frames\":%" G_GUINT64_FORMAT ","
+               "\"last_frame_kib\":%.2f,"
+               "\"avg_frame_kib\":%.2f,"
+               "\"bitrate_mbps\":%.3f,"
+               "\"bitrate_avg_mbps\":%.3f,"
+               "\"jitter_ms\":%.3f,"
+               "\"jitter_avg_ms\":%.3f,"
+               "\"expected_sequence\":%u,"
+               "\"idr_requests\":%" G_GUINT64_FORMAT ","
+               "\"recording_enabled\":%s,"
+               "\"recording_active\":%s,"
+               "\"recording_duration_s\":%.3f,"
+               "\"recording_media_s\":%.3f,"
+               "\"recording_mbytes\":%" G_GUINT64_FORMAT ","
+               "\"recording_path\":\"%s\"}",
                snap->total_packets, snap->video_packets, snap->audio_packets, snap->ignored_packets,
                snap->duplicate_packets, snap->lost_packets, snap->reordered_packets, total_mbytes, video_mbytes,
                audio_mbytes, snap->frame_count, snap->incomplete_frames, last_frame_kib, frame_avg_kib,


### PR DESCRIPTION
## Summary
- convert SSE JSON output to report byte counters in whole megabytes and drop unused timestamp fields
- add helper for byte-to-megabyte conversion and update README documentation to match the new payload shape

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea5c4abf4c832b9afc95c3262c3f4e