### PR TITLE
Fix PID file name after binary rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Tune the behaviour through `[idr]` in the INI (or the matching `--idr-*` CLI fla
 
 When 64 consecutive HTTP bursts fail to clear the decoder warnings, the requester now gives up on further IDR spam and tells the main loop to rebuild the entire pipeline. This mirrors a manual restart: the pipeline tears down the UDP receiver, decoder, and sinks before bringing them back up with the existing configuration. The strategy avoids endless HTTP loops when the camera ignores triggers or the stream never delivers a usable key frame.
 
-Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixel_pilot_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
+Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
 
 ## Splash fallback playback
 

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ static volatile sig_atomic_t g_toggle_osd_flag = 0;
 static volatile sig_atomic_t g_toggle_record_flag = 0;
 static volatile sig_atomic_t g_reinit_flag = 0;
 
-static const char *g_instance_pid_path = "/tmp/pixel_pilot_rk.pid";
+static const char *g_instance_pid_path = "/tmp/pixelpilot_mini_rk.pid";
 
 static void remove_instance_pid(void) {
     if (unlink(g_instance_pid_path) != 0 && errno != ENOENT) {
@@ -106,7 +106,7 @@ static int ensure_single_instance(void) {
         if (existing_pid > 0) {
             errno = 0;
             if (kill(existing_pid, 0) == 0 || errno == EPERM) {
-                LOGE("An existing instance of pixel_pilot_rk is already running ... exiting ...");
+                LOGE("An existing instance of pixelpilot_mini_rk is already running ... exiting ...");
                 return -1;
             }
         }


### PR DESCRIPTION
## Summary
- update the PID file path and duplicate-instance log to match the pixelpilot_mini_rk binary name
- refresh the README to reference the new PID filename in the SIGHUP example

## Testing
- make *(fails: missing xf86drm.h)*

------
https://chatgpt.com/codex/tasks/task_e_68eb8f19ff54832bae3eee7c205068e7