### PR TITLE
feat: add external OSD data bridge

### DIFF
--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -66,33 +66,15 @@ affinity = 1,2,3
 enable = true
 refresh-ms = 100
 plane-id = 0
-; Include the default stats alongside the external bridge helpers so the layout
-; remains informative when toggling between sample configurations while staying
-; within the element limit enforced by the renderer.
-elements = stats, recording_indicator, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
+; Keep the layout focused on external feed validation while staying under the
+; renderer element cap.
+elements = recording_indicator, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
 
 [osd.external]
 ; Enable the UNIX socket bridge explicitly so running this config immediately
 ; binds the socket for test publishers.
 enable = true
 socket = /run/pixelpilot/osd.sock
-
-[osd.element.stats]
-type = text
-anchor = top-left
-padding = 8
-background = transparent-grey
-border = transparent-white
-foreground = white
-line = HDMI {display.mode} plane={drm.video_plane_id}
-line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} sinkbuf={pipeline.appsink_max_buffers}
-line = Record {record.state} active={record.active} dur={record.duration_hms} size={record.megabytes}MiB
-line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
-line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
-line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
-line = IDR req={udp.idr_requests}
-line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB
-line = Seq={udp.expected_sequence}
 
 [osd.element.recording_indicator]
 type = text
@@ -145,8 +127,8 @@ line = value8: {ext.value8}
 
 [osd.element.external_value1_plot]
 type = line
-anchor = bottom-mid
-offset = 0,-12
+anchor = top-left
+offset = 16,16
 size = 320x120
 sample-spacing = 4
 metric = ext.value1
@@ -158,8 +140,8 @@ grid = transparent-white
 
 [osd.element.external_value2_plot]
 type = line
-anchor = bottom-mid
-offset = 340,-12
+anchor = mid-left
+offset = 16,0
 size = 320x120
 sample-spacing = 4
 metric = ext.value2
@@ -171,8 +153,8 @@ grid = transparent-white
 
 [osd.element.external_value3_plot]
 type = line
-anchor = bottom-mid
-offset = -340,-12
+anchor = bottom-right
+offset = -16,-16
 size = 320x120
 sample-spacing = 4
 metric = ext.value3

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -68,8 +68,8 @@ refresh-ms = 100
 plane-id = 0
 ; Include the default stats alongside the external bridge helpers so the layout
 ; remains informative when toggling between sample configurations while staying
-; within the eight element limit enforced by the renderer.
-elements = stats, recording_indicator, framesize_plot, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
+; within the element limit enforced by the renderer.
+elements = stats, recording_indicator, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
 
 [osd.external]
 ; Enable the UNIX socket bridge explicitly so running this config immediately
@@ -114,19 +114,6 @@ bar-width = 8
 metric = udp.bitrate.latest_mbps
 label = Bitrate (Mbit/s)
 foreground = blue
-background = transparent-grey
-grid = transparent-white
-
-[osd.element.framesize_plot]
-type = bar
-anchor = bottom-left
-offset = 380,-12
-size = 360x90
-sample-spacing = 12
-bar-width = 8
-metric = udp.frames.last_bytes
-label = Frame Size (Bytes)
-foreground = cyan
 background = transparent-grey
 grid = transparent-white
 

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -1,0 +1,208 @@
+; PixelPilot Mini configuration focused on exercising the external OSD bridge.
+; Based on config/osd-sample.ini but with an extended OSD layout that renders
+; every external text slot and plots a few numeric values for quick validation.
+
+[drm]
+card = /dev/dri/card0
+connector = HDMI-A-1
+video-plane-id = 76
+use-udev = true
+osd-plane-id = 0
+
+[udp]
+port = 5600
+video-pt = 97
+audio-pt = 98
+
+[pipeline]
+appsink-max-buffers = 8
+custom-sink = receiver
+pt97-filter = true
+
+[idr]
+enable = true
+port = 80
+path = /request/idr
+timeout-ms = 200
+
+[sse]
+enable = true
+bind = 0.0.0.0
+port = 8082
+interval-ms = 1000
+
+[splash]
+enable = true
+input = assets/spinner_ai_1080p30.h265
+fps = 30.0
+idle-timeout-ms = 5000
+default-sequence = intro
+
+[splash.sequence.intro]
+start = 0
+end = 140
+
+[audio]
+device = plughw:CARD=rockchiphdmi0,DEV=0
+disable = false
+optional = true
+
+[record]
+enable = false
+path = /media
+mode = fragmented
+
+[restarts]
+limit = 3
+window-ms = 2000
+
+[gst]
+log = false
+
+[cpu]
+affinity = 1,2,3
+
+[osd]
+enable = true
+refresh-ms = 100
+plane-id = 0
+; Include the default stats alongside the external bridge helpers so the layout
+; remains informative when toggling between sample configurations.
+elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
+
+[osd.external]
+; Enable the UNIX socket bridge explicitly so running this config immediately
+; binds the socket for test publishers.
+enable = true
+socket = /run/pixelpilot/osd.sock
+
+[osd.element.stats]
+type = text
+anchor = top-left
+padding = 8
+background = transparent-grey
+border = transparent-white
+foreground = white
+line = HDMI {display.mode} plane={drm.video_plane_id}
+line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} sinkbuf={pipeline.appsink_max_buffers}
+line = Record {record.state} active={record.active} dur={record.duration_hms} size={record.megabytes}MiB
+line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
+line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
+line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
+line = IDR req={udp.idr_requests}
+line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB
+line = Seq={udp.expected_sequence}
+
+[osd.element.recording_indicator]
+type = text
+anchor = top-right
+offset = -16,16
+padding = 6
+background = transparent-grey
+border = transparent-white
+foreground = red
+line = {record.indicator}
+
+[osd.element.bitrate_plot]
+type = bar
+anchor = bottom-left
+offset = 0,-12
+size = 360x90
+sample-spacing = 12
+bar-width = 8
+metric = udp.bitrate.latest_mbps
+label = Bitrate (Mbit/s)
+foreground = blue
+background = transparent-grey
+grid = transparent-white
+
+[osd.element.framesize_plot]
+type = bar
+anchor = bottom-left
+offset = 380,-12
+size = 360x90
+sample-spacing = 12
+bar-width = 8
+metric = udp.frames.last_bytes
+label = Frame Size (Bytes)
+foreground = cyan
+background = transparent-grey
+grid = transparent-white
+
+[osd.element.jitter_plot]
+type = line
+anchor = bottom-right
+offset = -16,-12
+size = 320x90
+sample-spacing = 4
+metric = udp.jitter.latest_ms
+label = Jitter (ms)
+info-box = false
+line-color = yellow
+background = transparent-grey
+grid = transparent-white
+
+[osd.element.external_bridge_text]
+type = text
+anchor = mid-right
+offset = -16,0
+padding = 8
+background = transparent-grey
+border = transparent-white
+foreground = light-grey
+line = External feed: {ext.status}
+line = text1: {ext.text1}
+line = text2: {ext.text2}
+line = text3: {ext.text3}
+line = text4: {ext.text4}
+line = text5: {ext.text5}
+line = text6: {ext.text6}
+line = text7: {ext.text7}
+line = text8: {ext.text8}
+line = value1: {ext.value1}
+line = value2: {ext.value2}
+line = value3: {ext.value3}
+line = value4: {ext.value4}
+line = value5: {ext.value5}
+line = value6: {ext.value6}
+line = value7: {ext.value7}
+line = value8: {ext.value8}
+
+[osd.element.external_value1_plot]
+type = line
+anchor = bottom-mid
+offset = 0,-12
+size = 320x120
+sample-spacing = 4
+metric = ext.value1
+label = ext.value1
+info-box = true
+line-color = green
+background = transparent-grey
+grid = transparent-white
+
+[osd.element.external_value2_plot]
+type = line
+anchor = bottom-mid
+offset = 340,-12
+size = 320x120
+sample-spacing = 4
+metric = ext.value2
+label = ext.value2
+info-box = true
+line-color = orange
+background = transparent-grey
+grid = transparent-white
+
+[osd.element.external_value3_plot]
+type = line
+anchor = bottom-mid
+offset = -340,-12
+size = 320x120
+sample-spacing = 4
+metric = ext.value3
+label = ext.value3
+info-box = true
+line-color = purple
+background = transparent-grey
+grid = transparent-white

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -67,8 +67,9 @@ enable = true
 refresh-ms = 100
 plane-id = 0
 ; Include the default stats alongside the external bridge helpers so the layout
-; remains informative when toggling between sample configurations.
-elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
+; remains informative when toggling between sample configurations while staying
+; within the eight element limit enforced by the renderer.
+elements = stats, recording_indicator, framesize_plot, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
 
 [osd.external]
 ; Enable the UNIX socket bridge explicitly so running this config immediately

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -130,19 +130,6 @@ foreground = cyan
 background = transparent-grey
 grid = transparent-white
 
-[osd.element.jitter_plot]
-type = line
-anchor = bottom-right
-offset = -16,-12
-size = 320x90
-sample-spacing = 4
-metric = udp.jitter.latest_ms
-label = Jitter (ms)
-info-box = false
-line-color = yellow
-background = transparent-grey
-grid = transparent-white
-
 [osd.element.external_bridge_text]
 type = text
 anchor = mid-right

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -152,7 +152,7 @@ background = transparent-grey
 grid = transparent-white
 
 [osd.element.external_value3_plot]
-type = line
+type = bar
 anchor = bottom-right
 offset = -16,-16
 size = 320x120
@@ -160,6 +160,7 @@ sample-spacing = 4
 metric = ext.value3
 label = ext.value3
 info-box = true
-line-color = purple
+bar-width = 6
+foreground = purple
 background = transparent-grey
 grid = transparent-white

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -77,6 +77,13 @@ plane-id = 0
 ; The names reference [osd.element.NAME] sections below.
 elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
 
+[osd.external]
+; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
+; tokens/metrics into the OSD. Leave disabled by default so the socket is
+; only created when explicitly requested.
+enable = false
+socket = /run/pixelpilot/osd.sock
+
 ; -----------------------------------------------------------------------------
 ; Element placement quick reference
 ;   anchor = top-left | top-mid | top-right | mid-left | mid | mid-right |

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -1,0 +1,105 @@
+# External data feed for OSD widgets
+
+This note sketches an approach for letting third-party processes inject text and
+numeric values into the on-screen display without having to recompile the
+receiver. The goal is to expose up to eight text rows and eight floating-point
+metrics that downstream OSD widgets can render or plot through the existing
+`{token}` placeholder system.
+
+## Transport and lifecycle
+
+* Introduce a small helper module (for example `src/osd_bridge.c`) that owns a
+  UNIX domain datagram socket. The socket path is supplied via an INI/CLI option
+  such as `[osd.external].socket = /run/pixelpilot/osd.sock` so the feature can
+  be disabled by default.
+* The helper runs on a lightweight thread that blocks in `recvmsg()` and parses
+  newline-delimited JSON payloads (any JSON library already linked in the
+  project can be reused; otherwise a tiny hand-written parser that only handles
+  the expected schema is enough).
+* Each message simply replaces the current snapshot. Store the decoded payload
+  in a struct containing:
+  ```c
+  typedef struct {
+      char text[8][64];
+      double value[8];
+      uint64_t last_update_ns;
+  } OsdExternalFeed;
+  ```
+* Guard the snapshot with a `pthread_mutex_t`; the existing OSD refresh loop can
+  lock, copy the data into its render context, and unlock. Because refreshes are
+  already periodic (see `osd_refresh_ms` in the config), this adds no extra
+  wakeups when nobody is publishing.
+
+### Configuration
+
+Enable the listener either by passing `--osd-external-socket /run/pixelpilot/osd.sock`
+on the command line or by adding the following to the INI file:
+
+```ini
+[osd.external]
+enable = true
+socket = /run/pixelpilot/osd.sock
+```
+
+Leaving the path blank keeps the helper disabled so existing deployments are not
+affected until they opt in.
+
+## Message format
+
+External producers only need to send fields they care about. A minimal update
+looks like:
+
+```json
+{"text":["HELLO","WORLD"], "value":[12.5, 0.75]}
+```
+
+If fewer than eight entries are present, the remaining slots keep their prior
+contents. Including an empty array clears previously published data. Optional
+`ttl_ms` lets publishers request automatic expiry so stale telemetry does not
+linger:
+
+```json
+{"value":[42.0], "ttl_ms": 5000}
+```
+
+When the helper thread observes that `clock_gettime(CLOCK_MONOTONIC)` exceeds
+`last_update_ns + ttl_ms`, it zeroes the snapshot before the next OSD refresh.
+
+## Token exposure
+
+Extend `osd_token_format()` so that strings become available through
+`{ext.text1}` … `{ext.text8}` and numbers through `{ext.value1}` …
+`{ext.value8}`. The existing renderer already uppercases ASCII characters, so we
+match that convention. Numbers also double as plot metrics by teaching
+`osd_metric_sample()` to recognize keys like `ext.value3` and returning the
+cached `double`.
+
+Because the renderer falls back to printing the literal token when a key is
+unknown, configuration files created on older builds keep working: users only
+see `{ext.text1}` until they update the binary to a release containing the
+bridge.
+
+## Error handling and observability
+
+* Socket creation failures should log a warning and keep the rest of the
+  application alive, mirroring how optional features are treated elsewhere in
+  the tree.
+* Malformed JSON (missing arrays, wrong types, etc.) should trigger a single
+  rate-limited log entry but leave the previous snapshot untouched.
+* Publish the helper’s status via a new token (for example `{ext.status}` with
+  values `disabled`, `listening`, or `error`) so users can surface diagnostics in
+  the OSD itself.
+
+## Testing ideas
+
+1. Unit-test the parser with representative payloads, including boundary cases
+   (arrays longer than eight entries, missing fields, TTL expiry).
+2. Run the binary with the feature enabled and pipe updates manually:
+   ```sh
+   socat - UNIX-SENDTO:/run/pixelpilot/osd.sock <<<'{"text":["BATTERY 12.6V"]}'
+   ```
+   Confirm the OSD text widget renders the injected string and that a line plot
+   bound to `ext.value1` responds to subsequent updates.
+3. Verify that unplugging publishers does not leak descriptors or wake the OSD
+   thread unnecessarily. Use `strace -p` to ensure only the helper is blocked on
+   `recvmsg()`.

--- a/include/config.h
+++ b/include/config.h
@@ -92,6 +92,11 @@ typedef struct {
 
     OsdLayout osd_layout;
 
+    struct {
+        int enable;
+        char socket_path[PATH_MAX];
+    } osd_external;
+
     SplashCfg splash;
     RecordCfg record;
     SseCfg sse;

--- a/include/config.h
+++ b/include/config.h
@@ -94,6 +94,7 @@ typedef struct {
 
     struct {
         int enable;
+        int enable_set;
         char socket_path[PATH_MAX];
     } osd_external;
 

--- a/include/osd.h
+++ b/include/osd.h
@@ -7,6 +7,7 @@
 #include "drm_fb.h"
 #include "drm_modeset.h"
 #include "osd_layout.h"
+#include "osd_external.h"
 #include "pipeline.h"
 
 #define OSD_PLOT_MAX_SAMPLES 1024
@@ -120,7 +121,8 @@ typedef struct OSD {
 void osd_init(OSD *osd);
 int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plane_id, OSD *osd);
 void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const PipelineState *ps,
-                      int audio_disabled, int restart_count, OSD *osd);
+                      int audio_disabled, int restart_count, const OsdExternalFeedSnapshot *ext,
+                      OSD *osd);
 int osd_is_enabled(const OSD *osd);
 int osd_is_active(const OSD *osd);
 int osd_enable(int fd, OSD *osd);

--- a/include/osd.h
+++ b/include/osd.h
@@ -11,6 +11,7 @@
 #include "pipeline.h"
 
 #define OSD_PLOT_MAX_SAMPLES 1024
+#define OSD_MAX_DAMAGE_RECTS 64
 
 typedef struct {
     int x;
@@ -96,6 +97,12 @@ typedef struct OSD {
     size_t scratch_size;
     uint32_t *draw_map;
     int draw_pitch;
+
+    /* Damage tracking for incremental shadow flushes */
+    int damage_active;
+    int damage_full;
+    int damage_count;
+    OSDRect damage_rects[OSD_MAX_DAMAGE_RECTS];
 
     uint32_t p_fb_id, p_crtc_id, p_crtc_x, p_crtc_y, p_crtc_w, p_crtc_h;
     uint32_t p_src_x, p_src_y, p_src_w, p_src_h;

--- a/include/osd.h
+++ b/include/osd.h
@@ -91,6 +91,12 @@ typedef struct OSD {
     int refresh_ms;
     uint32_t crtc_id;
 
+    /* CPU-side shadow buffer to compose frames without tearing */
+    uint8_t *scratch;
+    size_t scratch_size;
+    uint32_t *draw_map;
+    int draw_pitch;
+
     uint32_t p_fb_id, p_crtc_id, p_crtc_x, p_crtc_y, p_crtc_w, p_crtc_h;
     uint32_t p_src_x, p_src_y, p_src_w, p_src_h;
     uint32_t p_zpos;

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -1,0 +1,48 @@
+#ifndef OSD_EXTERNAL_H
+#define OSD_EXTERNAL_H
+
+#include <pthread.h>
+#include <stdint.h>
+#include <sys/un.h>
+
+#ifndef UNIX_PATH_MAX
+#define UNIX_PATH_MAX 108
+#endif
+
+#define OSD_EXTERNAL_MAX_TEXT 8
+#define OSD_EXTERNAL_TEXT_LEN 64
+#define OSD_EXTERNAL_MAX_VALUES 8
+
+typedef enum {
+    OSD_EXTERNAL_STATUS_DISABLED = 0,
+    OSD_EXTERNAL_STATUS_LISTENING,
+    OSD_EXTERNAL_STATUS_ERROR,
+} OsdExternalStatus;
+
+typedef struct {
+    char text[OSD_EXTERNAL_MAX_TEXT][OSD_EXTERNAL_TEXT_LEN];
+    double value[OSD_EXTERNAL_MAX_VALUES];
+    uint64_t last_update_ns;
+    uint64_t expiry_ns;
+    OsdExternalStatus status;
+} OsdExternalFeedSnapshot;
+
+typedef struct {
+    pthread_t thread;
+    int thread_started;
+    int stop_flag;
+    int sock_fd;
+    char socket_path[UNIX_PATH_MAX];
+    pthread_mutex_t lock;
+    OsdExternalFeedSnapshot snapshot;
+    uint64_t expiry_ns;
+    uint64_t last_error_log_ns;
+} OsdExternalBridge;
+
+void osd_external_init(OsdExternalBridge *bridge);
+int osd_external_start(OsdExternalBridge *bridge, const char *socket_path);
+void osd_external_stop(OsdExternalBridge *bridge);
+void osd_external_get_snapshot(OsdExternalBridge *bridge, OsdExternalFeedSnapshot *out);
+const char *osd_external_status_name(OsdExternalStatus status);
+
+#endif // OSD_EXTERNAL_H

--- a/src/config.c
+++ b/src/config.c
@@ -154,6 +154,7 @@ void cfg_defaults(AppCfg *c) {
     c->osd_plane_id = 0;
     c->osd_refresh_ms = 500;
     c->osd_external.enable = 0;
+    c->osd_external.enable_set = 0;
     c->osd_external.socket_path[0] = '\0';
 
     c->gst_log = 0;
@@ -347,12 +348,14 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->osd_refresh_ms = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--osd-external-socket") && i + 1 < argc) {
             cfg->osd_external.enable = 1;
+            cfg->osd_external.enable_set = 1;
             cli_copy_string(cfg->osd_external.socket_path, sizeof(cfg->osd_external.socket_path), argv[++i]);
         } else if (!strcmp(argv[i], "--osd-external-socket")) {
             LOGE("--osd-external-socket requires a path");
             return -1;
         } else if (!strcmp(argv[i], "--no-osd-external")) {
             cfg->osd_external.enable = 0;
+            cfg->osd_external.enable_set = 1;
             cfg->osd_external.socket_path[0] = '\0';
         } else if (!strcmp(argv[i], "--record-video")) {
             cfg->record.enable = 1;

--- a/src/config.c
+++ b/src/config.c
@@ -30,6 +30,8 @@ static void usage(const char *prog) {
             "  --osd                        (enable OSD overlay plane with stats)\n"
             "  --osd-plane-id N             (force OSD plane id; default auto)\n"
             "  --osd-refresh-ms N           (default: 500)\n"
+            "  --osd-external-socket PATH   (UNIX datagram socket for external OSD data)\n"
+            "  --no-osd-external            (disable external OSD feed)\n"
             "  --record-video [PATH]        (enable MP4 capture; optional PATH or directory, default /media)\n"
             "  --record-mode MODE           (standard|sequential|fragmented; default: sequential)\n"
             "  --no-record-video            (disable MP4 recording)\n"
@@ -151,6 +153,8 @@ void cfg_defaults(AppCfg *c) {
     c->osd_enable = 0;
     c->osd_plane_id = 0;
     c->osd_refresh_ms = 500;
+    c->osd_external.enable = 0;
+    c->osd_external.socket_path[0] = '\0';
 
     c->gst_log = 0;
 
@@ -341,6 +345,15 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->osd_plane_id = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--osd-refresh-ms") && i + 1 < argc) {
             cfg->osd_refresh_ms = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--osd-external-socket") && i + 1 < argc) {
+            cfg->osd_external.enable = 1;
+            cli_copy_string(cfg->osd_external.socket_path, sizeof(cfg->osd_external.socket_path), argv[++i]);
+        } else if (!strcmp(argv[i], "--osd-external-socket")) {
+            LOGE("--osd-external-socket requires a path");
+            return -1;
+        } else if (!strcmp(argv[i], "--no-osd-external")) {
+            cfg->osd_external.enable = 0;
+            cfg->osd_external.socket_path[0] = '\0';
         } else if (!strcmp(argv[i], "--record-video")) {
             cfg->record.enable = 1;
             if (i + 1 < argc && argv[i + 1][0] != '-') {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -822,6 +822,24 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "osd.external") == 0 || strcasecmp(section, "osd_external") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->osd_external.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "socket") == 0 || strcasecmp(key, "path") == 0) {
+            ini_copy_string(cfg->osd_external.socket_path, sizeof(cfg->osd_external.socket_path), value);
+            if (cfg->osd_external.socket_path[0] != '\0') {
+                cfg->osd_external.enable = 1;
+            }
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "record") == 0) {
         if (strcasecmp(key, "enable") == 0) {
             int v = 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -829,11 +829,12 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
                 return -1;
             }
             cfg->osd_external.enable = v;
+            cfg->osd_external.enable_set = 1;
             return 0;
         }
         if (strcasecmp(key, "socket") == 0 || strcasecmp(key, "path") == 0) {
             ini_copy_string(cfg->osd_external.socket_path, sizeof(cfg->osd_external.socket_path), value);
-            if (cfg->osd_external.socket_path[0] != '\0') {
+            if (!cfg->osd_external.enable_set && cfg->osd_external.socket_path[0] != '\0') {
                 cfg->osd_external.enable = 1;
             }
             return 0;

--- a/src/osd.c
+++ b/src/osd.c
@@ -203,6 +203,13 @@ static void osd_fill_rect(OSD *o, int x, int y, int w, int h, uint32_t argb) {
     }
 }
 
+static void osd_clear_rect(OSD *o, const OSDRect *r) {
+    if (!r || r->w <= 0 || r->h <= 0) {
+        return;
+    }
+    osd_fill_rect(o, r->x, r->y, r->w, r->h, 0x00000000u);
+}
+
 static void osd_store_rect(OSDRect *r, int x, int y, int w, int h) {
     if (!r) {
         return;
@@ -819,13 +826,6 @@ static void osd_format_metric_value(const char *metric_key, double value, char *
     } else {
         snprintf(buf, buf_sz, "%.0f", value);
     }
-}
-
-static void osd_clear_rect(OSD *o, const OSDRect *r) {
-    if (!r || r->w <= 0 || r->h <= 0) {
-        return;
-    }
-    osd_fill_rect(o, r->x, r->y, r->w, r->h, 0x00000000u);
 }
 
 static void osd_draw_hline(OSD *o, int x, int y, int w, uint32_t argb) {

--- a/src/osd_external.c
+++ b/src/osd_external.c
@@ -1,0 +1,561 @@
+#include "osd_external.h"
+#include "logging.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <time.h>
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#endif
+
+static uint64_t timespec_to_ns(const struct timespec *ts) {
+    if (!ts) {
+        return 0;
+    }
+    return (uint64_t)ts->tv_sec * 1000000000ull + (uint64_t)ts->tv_nsec;
+}
+
+static uint64_t monotonic_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return timespec_to_ns(&ts);
+}
+
+static void osd_external_reset_locked(OsdExternalBridge *bridge) {
+    if (!bridge) {
+        return;
+    }
+    memset(bridge->snapshot.text, 0, sizeof(bridge->snapshot.text));
+    for (size_t i = 0; i < ARRAY_SIZE(bridge->snapshot.value); ++i) {
+        bridge->snapshot.value[i] = 0.0;
+    }
+    bridge->snapshot.last_update_ns = 0;
+    bridge->snapshot.expiry_ns = 0;
+}
+
+static void osd_external_expire_locked(OsdExternalBridge *bridge, uint64_t now_ns) {
+    if (!bridge) {
+        return;
+    }
+    if (bridge->expiry_ns > 0 && now_ns >= bridge->expiry_ns) {
+        osd_external_reset_locked(bridge);
+        bridge->expiry_ns = 0;
+    }
+    bridge->snapshot.expiry_ns = bridge->expiry_ns;
+}
+
+static int should_log_error(OsdExternalBridge *bridge, uint64_t now_ns) {
+    if (!bridge) {
+        return 0;
+    }
+    const uint64_t interval_ns = 2000000000ull; // 2 seconds
+    if (bridge->last_error_log_ns == 0 || now_ns - bridge->last_error_log_ns >= interval_ns) {
+        bridge->last_error_log_ns = now_ns;
+        return 1;
+    }
+    return 0;
+}
+
+typedef struct {
+    int has_text;
+    int text_count;
+    char text[OSD_EXTERNAL_MAX_TEXT][OSD_EXTERNAL_TEXT_LEN];
+    int has_value;
+    int value_count;
+    double value[OSD_EXTERNAL_MAX_VALUES];
+    int has_ttl;
+    uint64_t ttl_ms;
+} OsdExternalMessage;
+
+static const char *skip_ws(const char *p) {
+    while (p && *p && isspace((unsigned char)*p)) {
+        ++p;
+    }
+    return p;
+}
+
+static const char *parse_string(const char *p, char *out, size_t out_sz) {
+    if (!p || *p != '"') {
+        return NULL;
+    }
+    ++p;
+    size_t idx = 0;
+    while (*p && *p != '"') {
+        if (*p == '\\' && p[1] != '\0') {
+            ++p;
+        }
+        if (idx + 1 < out_sz) {
+            out[idx++] = *p;
+        }
+        ++p;
+    }
+    if (*p != '"') {
+        return NULL;
+    }
+    if (out && out_sz > 0) {
+        out[idx] = '\0';
+    }
+    return p + 1;
+}
+
+static const char *parse_string_array(const char *p, OsdExternalMessage *msg) {
+    if (!p || *p != '[') {
+        return NULL;
+    }
+    ++p;
+    p = skip_ws(p);
+    int idx = 0;
+    if (*p == ']') {
+        msg->text_count = 0;
+        return p + 1;
+    }
+    while (*p) {
+        p = skip_ws(p);
+        if (*p != '"') {
+            return NULL;
+        }
+        char tmp[OSD_EXTERNAL_TEXT_LEN];
+        const char *next = parse_string(p, tmp, sizeof(tmp));
+        if (!next) {
+            return NULL;
+        }
+        if (idx < OSD_EXTERNAL_MAX_TEXT) {
+            strncpy(msg->text[idx], tmp, sizeof(msg->text[idx]) - 1);
+            msg->text[idx][sizeof(msg->text[idx]) - 1] = '\0';
+            idx++;
+        }
+        p = skip_ws(next);
+        if (*p == ',') {
+            ++p;
+            continue;
+        }
+        if (*p == ']') {
+            break;
+        }
+        return NULL;
+    }
+    if (*p != ']') {
+        return NULL;
+    }
+    msg->text_count = idx;
+    return p + 1;
+}
+
+static const char *parse_number_array(const char *p, OsdExternalMessage *msg) {
+    if (!p || *p != '[') {
+        return NULL;
+    }
+    ++p;
+    p = skip_ws(p);
+    int idx = 0;
+    if (*p == ']') {
+        msg->value_count = 0;
+        return p + 1;
+    }
+    while (*p) {
+        char *end = NULL;
+        double v = strtod(p, &end);
+        if (end == p) {
+            return NULL;
+        }
+        if (idx < OSD_EXTERNAL_MAX_VALUES) {
+            msg->value[idx++] = v;
+        }
+        p = skip_ws(end);
+        if (*p == ',') {
+            ++p;
+            continue;
+        }
+        if (*p == ']') {
+            break;
+        }
+        return NULL;
+    }
+    if (*p != ']') {
+        return NULL;
+    }
+    msg->value_count = idx;
+    return p + 1;
+}
+
+static int parse_message(const char *payload, OsdExternalMessage *msg) {
+    if (!payload || !msg) {
+        return -1;
+    }
+    memset(msg, 0, sizeof(*msg));
+    const char *p = skip_ws(payload);
+    if (*p != '{') {
+        return -1;
+    }
+    ++p;
+    while (*p) {
+        p = skip_ws(p);
+        if (*p == '}') {
+            return 0;
+        }
+        if (*p != '"') {
+            return -1;
+        }
+        char key[32];
+        const char *next = parse_string(p, key, sizeof(key));
+        if (!next) {
+            return -1;
+        }
+        p = skip_ws(next);
+        if (*p != ':') {
+            return -1;
+        }
+        ++p;
+        p = skip_ws(p);
+        if (strcmp(key, "text") == 0) {
+            msg->has_text = 1;
+            p = parse_string_array(p, msg);
+            if (!p) {
+                return -1;
+            }
+        } else if (strcmp(key, "value") == 0) {
+            msg->has_value = 1;
+            p = parse_number_array(p, msg);
+            if (!p) {
+                return -1;
+            }
+        } else if (strcmp(key, "ttl_ms") == 0) {
+            char *end = NULL;
+            long long ttl = strtoll(p, &end, 10);
+            if (end == p) {
+                return -1;
+            }
+            if (ttl < 0) {
+                ttl = 0;
+            }
+            msg->has_ttl = 1;
+            msg->ttl_ms = (uint64_t)ttl;
+            p = end;
+        } else {
+            // Skip unknown value (best effort: handle nested objects/arrays by counting braces)
+            int depth = 0;
+            if (*p == '{') {
+                depth = 1;
+                ++p;
+                while (*p && depth > 0) {
+                    if (*p == '{') {
+                        depth++;
+                    } else if (*p == '}') {
+                        depth--;
+                    } else if (*p == '"') {
+                        const char *tmp = parse_string(p, NULL, 0);
+                        if (!tmp) {
+                            return -1;
+                        }
+                        p = tmp;
+                        continue;
+                    }
+                    ++p;
+                }
+                if (depth != 0) {
+                    return -1;
+                }
+            } else if (*p == '[') {
+                depth = 1;
+                ++p;
+                while (*p && depth > 0) {
+                    if (*p == '[') {
+                        depth++;
+                    } else if (*p == ']') {
+                        depth--;
+                    } else if (*p == '"') {
+                        const char *tmp = parse_string(p, NULL, 0);
+                        if (!tmp) {
+                            return -1;
+                        }
+                        p = tmp;
+                        continue;
+                    }
+                    ++p;
+                }
+                if (depth != 0) {
+                    return -1;
+                }
+            } else if (*p == '"') {
+                p = parse_string(p, NULL, 0);
+                if (!p) {
+                    return -1;
+                }
+            } else {
+                while (*p && *p != ',' && *p != '}') {
+                    ++p;
+                }
+            }
+        }
+        p = skip_ws(p);
+        if (*p == ',') {
+            ++p;
+            continue;
+        }
+        if (*p == '}') {
+            return 0;
+        }
+        return -1;
+    }
+    return -1;
+}
+
+static void apply_message(OsdExternalBridge *bridge, const OsdExternalMessage *msg, uint64_t now_ns) {
+    if (!bridge || !msg) {
+        return;
+    }
+    pthread_mutex_lock(&bridge->lock);
+    if (msg->has_text) {
+        if (msg->text_count == 0) {
+            memset(bridge->snapshot.text, 0, sizeof(bridge->snapshot.text));
+        } else {
+            for (int i = 0; i < msg->text_count && i < OSD_EXTERNAL_MAX_TEXT; ++i) {
+                strncpy(bridge->snapshot.text[i], msg->text[i], sizeof(bridge->snapshot.text[i]) - 1);
+                bridge->snapshot.text[i][sizeof(bridge->snapshot.text[i]) - 1] = '\0';
+            }
+        }
+    }
+    if (msg->has_value) {
+        if (msg->value_count == 0) {
+            for (int i = 0; i < OSD_EXTERNAL_MAX_VALUES; ++i) {
+                bridge->snapshot.value[i] = 0.0;
+            }
+        } else {
+            for (int i = 0; i < msg->value_count && i < OSD_EXTERNAL_MAX_VALUES; ++i) {
+                bridge->snapshot.value[i] = msg->value[i];
+            }
+        }
+    }
+    bridge->snapshot.last_update_ns = now_ns;
+    if (msg->has_ttl && msg->ttl_ms > 0) {
+        uint64_t ttl_ns = msg->ttl_ms * 1000000ull;
+        if (ttl_ns / 1000000ull != msg->ttl_ms) {
+            ttl_ns = 0;
+        }
+        if (ttl_ns > 0) {
+            bridge->expiry_ns = now_ns + ttl_ns;
+        } else {
+            bridge->expiry_ns = 0;
+        }
+    } else if (msg->has_ttl && msg->ttl_ms == 0) {
+        bridge->expiry_ns = now_ns;
+    } else {
+        bridge->expiry_ns = 0;
+    }
+    bridge->snapshot.expiry_ns = bridge->expiry_ns;
+    pthread_mutex_unlock(&bridge->lock);
+}
+
+static void *osd_external_thread(void *arg) {
+    OsdExternalBridge *bridge = (OsdExternalBridge *)arg;
+    if (!bridge) {
+        return NULL;
+    }
+    pthread_mutex_lock(&bridge->lock);
+    bridge->status = OSD_EXTERNAL_STATUS_LISTENING;
+    pthread_mutex_unlock(&bridge->lock);
+    while (1) {
+        uint64_t now_ns = monotonic_ns();
+        pthread_mutex_lock(&bridge->lock);
+        int stop = bridge->stop_flag;
+        osd_external_expire_locked(bridge, now_ns);
+        pthread_mutex_unlock(&bridge->lock);
+        if (stop) {
+            break;
+        }
+        struct pollfd pfd = {
+            .fd = bridge->sock_fd,
+            .events = POLLIN,
+        };
+        int rc = poll(&pfd, 1, 500);
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            uint64_t err_ns = monotonic_ns();
+            pthread_mutex_lock(&bridge->lock);
+            if (should_log_error(bridge, err_ns)) {
+                LOGW("OSD external feed: poll failed: %s", strerror(errno));
+            }
+            bridge->status = OSD_EXTERNAL_STATUS_ERROR;
+            pthread_mutex_unlock(&bridge->lock);
+            break;
+        }
+        if (rc == 0) {
+            continue;
+        }
+        if (!(pfd.revents & POLLIN)) {
+            continue;
+        }
+        char buf[2048];
+        ssize_t len = recv(bridge->sock_fd, buf, sizeof(buf) - 1, 0);
+        if (len < 0) {
+            if (errno == EINTR || errno == EAGAIN) {
+                continue;
+            }
+            uint64_t err_ns = monotonic_ns();
+            pthread_mutex_lock(&bridge->lock);
+            if (should_log_error(bridge, err_ns)) {
+                LOGW("OSD external feed: recv failed: %s", strerror(errno));
+            }
+            bridge->status = OSD_EXTERNAL_STATUS_ERROR;
+            pthread_mutex_unlock(&bridge->lock);
+            break;
+        }
+        buf[len] = '\0';
+        OsdExternalMessage msg;
+        if (parse_message(buf, &msg) != 0) {
+            uint64_t err_ns = monotonic_ns();
+            pthread_mutex_lock(&bridge->lock);
+            if (should_log_error(bridge, err_ns)) {
+                LOGW("OSD external feed: ignoring malformed payload: %s", buf);
+            }
+            pthread_mutex_unlock(&bridge->lock);
+            continue;
+        }
+        apply_message(bridge, &msg, monotonic_ns());
+    }
+    pthread_mutex_lock(&bridge->lock);
+    bridge->thread_started = 0;
+    bridge->stop_flag = 0;
+    bridge->status = (bridge->sock_fd >= 0) ? bridge->status : OSD_EXTERNAL_STATUS_DISABLED;
+    pthread_mutex_unlock(&bridge->lock);
+    return NULL;
+}
+
+void osd_external_init(OsdExternalBridge *bridge) {
+    if (!bridge) {
+        return;
+    }
+    memset(bridge, 0, sizeof(*bridge));
+    bridge->sock_fd = -1;
+    pthread_mutex_init(&bridge->lock, NULL);
+    bridge->status = OSD_EXTERNAL_STATUS_DISABLED;
+}
+
+static void close_socket(OsdExternalBridge *bridge) {
+    if (!bridge) {
+        return;
+    }
+    if (bridge->sock_fd >= 0) {
+        close(bridge->sock_fd);
+        bridge->sock_fd = -1;
+    }
+    if (bridge->socket_path[0] != '\0') {
+        unlink(bridge->socket_path);
+        bridge->socket_path[0] = '\0';
+    }
+}
+
+int osd_external_start(OsdExternalBridge *bridge, const char *socket_path) {
+    if (!bridge) {
+        return -1;
+    }
+    osd_external_stop(bridge);
+    if (!socket_path || socket_path[0] == '\0') {
+        return 0;
+    }
+    size_t path_len = strnlen(socket_path, UNIX_PATH_MAX - 1);
+    if (path_len == 0 || path_len >= UNIX_PATH_MAX) {
+        LOGW("OSD external feed: socket path too long: %s", socket_path);
+        return -1;
+    }
+    int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        LOGW("OSD external feed: socket() failed: %s", strerror(errno));
+        pthread_mutex_lock(&bridge->lock);
+        bridge->status = OSD_EXTERNAL_STATUS_ERROR;
+        pthread_mutex_unlock(&bridge->lock);
+        return -1;
+    }
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+    unlink(addr.sun_path);
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        LOGW("OSD external feed: bind(%s) failed: %s", socket_path, strerror(errno));
+        close(fd);
+        pthread_mutex_lock(&bridge->lock);
+        bridge->status = OSD_EXTERNAL_STATUS_ERROR;
+        pthread_mutex_unlock(&bridge->lock);
+        return -1;
+    }
+    pthread_mutex_lock(&bridge->lock);
+    bridge->sock_fd = fd;
+    strncpy(bridge->socket_path, socket_path, sizeof(bridge->socket_path) - 1);
+    bridge->socket_path[sizeof(bridge->socket_path) - 1] = '\0';
+    bridge->stop_flag = 0;
+    bridge->status = OSD_EXTERNAL_STATUS_LISTENING;
+    pthread_mutex_unlock(&bridge->lock);
+    if (pthread_create(&bridge->thread, NULL, osd_external_thread, bridge) != 0) {
+        LOGW("OSD external feed: pthread_create failed: %s", strerror(errno));
+        close_socket(bridge);
+        pthread_mutex_lock(&bridge->lock);
+        bridge->status = OSD_EXTERNAL_STATUS_ERROR;
+        pthread_mutex_unlock(&bridge->lock);
+        return -1;
+    }
+    pthread_mutex_lock(&bridge->lock);
+    bridge->thread_started = 1;
+    pthread_mutex_unlock(&bridge->lock);
+    LOGI("OSD external feed: listening on %s", socket_path);
+    return 0;
+}
+
+void osd_external_stop(OsdExternalBridge *bridge) {
+    if (!bridge) {
+        return;
+    }
+    pthread_mutex_lock(&bridge->lock);
+    int running = bridge->thread_started;
+    if (running) {
+        bridge->stop_flag = 1;
+    }
+    pthread_mutex_unlock(&bridge->lock);
+    if (running) {
+        pthread_join(bridge->thread, NULL);
+    }
+    close_socket(bridge);
+    pthread_mutex_lock(&bridge->lock);
+    bridge->status = OSD_EXTERNAL_STATUS_DISABLED;
+    bridge->thread_started = 0;
+    bridge->stop_flag = 0;
+    bridge->expiry_ns = 0;
+    bridge->last_error_log_ns = 0;
+    osd_external_reset_locked(bridge);
+    pthread_mutex_unlock(&bridge->lock);
+}
+
+void osd_external_get_snapshot(OsdExternalBridge *bridge, OsdExternalFeedSnapshot *out) {
+    if (!bridge || !out) {
+        return;
+    }
+    uint64_t now_ns = monotonic_ns();
+    pthread_mutex_lock(&bridge->lock);
+    osd_external_expire_locked(bridge, now_ns);
+    *out = bridge->snapshot;
+    out->status = bridge->status;
+    pthread_mutex_unlock(&bridge->lock);
+}
+
+const char *osd_external_status_name(OsdExternalStatus status) {
+    switch (status) {
+    case OSD_EXTERNAL_STATUS_DISABLED:
+        return "disabled";
+    case OSD_EXTERNAL_STATUS_LISTENING:
+        return "listening";
+    case OSD_EXTERNAL_STATUS_ERROR:
+        return "error";
+    default:
+        return "unknown";
+    }
+}


### PR DESCRIPTION
## Summary
- add a UNIX datagram listener that ingests external OSD text/value updates with TTL handling
- expose the bridge through new ext.textN/ext.valueN tokens, ext.status, and integrate sampling into existing widgets
- surface configuration knobs and documentation for enabling the external feed

## Testing
- make *(fails: missing xf86drm.h headers in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb8fbaa5d8832ba4c56edc9da34dce