### PR TITLE
Add configurable Y-axis bounds for OSD plots

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -155,6 +155,8 @@ grid = transparent-white
 ; - label is a free-form axis caption rendered along the Y axis.
 ; - info-box toggles the small badge with the latest sample (or a status
 ;   message while the stream warms up).
+; - y-min / y-max optionally lock the vertical axis to a fixed range (line and
+;   bar plots). When omitted the minimum remains at 0 and the maximum auto-scales.
 
 [osd.element.framesize_plot]
 type = bar

--- a/include/osd.h
+++ b/include/osd.h
@@ -37,6 +37,10 @@ typedef struct {
     double scale_min;
     double scale_max;
     double step_px;
+    int has_fixed_min;
+    int has_fixed_max;
+    double fixed_min;
+    double fixed_max;
     int clear_on_next_draw;
     int background_ready;
     int prev_valid;
@@ -66,6 +70,10 @@ typedef struct {
     double scale_min;
     double scale_max;
     double step_px;
+    int has_fixed_min;
+    int has_fixed_max;
+    double fixed_min;
+    double fixed_max;
     int clear_on_next_draw;
     int background_ready;
     int rescale_countdown;

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -56,6 +56,10 @@ typedef struct {
     char metric[64];
     char label[32];
     int show_info_box;
+    int has_y_min;
+    int has_y_max;
+    double y_min;
+    double y_max;
     uint32_t fg;
     uint32_t grid;
     uint32_t bg;
@@ -69,6 +73,10 @@ typedef struct {
     char metric[64];
     char label[32];
     int show_info_box;
+    int has_y_min;
+    int has_y_max;
+    double y_min;
+    double y_max;
     uint32_t fg;
     uint32_t grid;
     uint32_t bg;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -111,6 +111,10 @@ static void builder_reset_line(OsdElementConfig *elem) {
     elem->data.line.metric[0] = '\0';
     elem->data.line.label[0] = '\0';
     elem->data.line.show_info_box = 1;
+    elem->data.line.has_y_min = 0;
+    elem->data.line.has_y_max = 0;
+    elem->data.line.y_min = 0.0;
+    elem->data.line.y_max = 0.0;
     elem->data.line.fg = 0xFFFFFFFFu;
     elem->data.line.grid = 0x20FFFFFFu;
     elem->data.line.bg = 0x20000000u;
@@ -125,6 +129,10 @@ static void builder_reset_bar(OsdElementConfig *elem) {
     elem->data.bar.metric[0] = '\0';
     elem->data.bar.label[0] = '\0';
     elem->data.bar.show_info_box = 1;
+    elem->data.bar.has_y_min = 0;
+    elem->data.bar.has_y_max = 0;
+    elem->data.bar.y_min = 0.0;
+    elem->data.bar.y_max = 0.0;
     elem->data.bar.fg = 0xFF4CAF50u;
     elem->data.bar.grid = 0x20FFFFFFu;
     elem->data.bar.bg = 0x20000000u;
@@ -561,6 +569,24 @@ static int parse_osd_element_line(OsdElementConfig *elem, const char *key, const
         elem->data.line.bg = color;
         return 0;
     }
+    if (strcasecmp(key, "y-min") == 0 || strcasecmp(key, "y_min") == 0 || strcasecmp(key, "ymin") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.line.has_y_min = 1;
+        elem->data.line.y_min = v;
+        return 0;
+    }
+    if (strcasecmp(key, "y-max") == 0 || strcasecmp(key, "y_max") == 0 || strcasecmp(key, "ymax") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.line.has_y_max = 1;
+        elem->data.line.y_max = v;
+        return 0;
+    }
     return -1;
 }
 
@@ -623,6 +649,24 @@ static int parse_osd_element_bar(OsdElementConfig *elem, const char *key, const 
             return -1;
         }
         elem->data.bar.bg = color;
+        return 0;
+    }
+    if (strcasecmp(key, "y-min") == 0 || strcasecmp(key, "y_min") == 0 || strcasecmp(key, "ymin") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.bar.has_y_min = 1;
+        elem->data.bar.y_min = v;
+        return 0;
+    }
+    if (strcasecmp(key, "y-max") == 0 || strcasecmp(key, "y_max") == 0 || strcasecmp(key, "ymax") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.bar.has_y_max = 1;
+        elem->data.bar.y_max = v;
         return 0;
     }
     return -1;

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -23,6 +23,10 @@ static void line_defaults(OsdLineConfig *cfg) {
     cfg->metric[0] = '\0';
     cfg->label[0] = '\0';
     cfg->show_info_box = 1;
+    cfg->has_y_min = 0;
+    cfg->has_y_max = 0;
+    cfg->y_min = 0.0;
+    cfg->y_max = 0.0;
     cfg->fg = 0xFFFFFFFFu;
     cfg->grid = 0x20FFFFFFu;
     cfg->bg = 0x20000000u;


### PR DESCRIPTION
## Summary
- add optional y-min/y-max fields to line and bar OSD element configs and propagate them through layout/state
- update plot scaling logic to honour fixed ranges and suppress automatic rescaling when bounds are locked
- document the new configuration knobs in the sample OSD ini file

## Testing
- make *(fails: missing xf86drm.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc2790900832b9e00deb894371237