### PR TITLE
Preserve video aspect ratio when presenting frames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ else
 LDFLAGS += -lrockchip_mpp
 endif
 
-LDFLAGS += -lpthread
+LDFLAGS += -lpthread -lm
 
 TARGET := pixelpilot_mini_rk
 COMPANION := osd_ext_feed


### PR DESCRIPTION
## Summary
- calculate destination rectangles for the DRM plane that maintain the decoded frame's aspect ratio
- center letterboxed video output so non-native content is no longer stretched across the display

## Testing
- make *(fails: missing xf86drm.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef878f41c8832b9ae2feb2b2abad80