### PR TITLE
Add systemd services and install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 PixelPilot Mini RK is a lightweight receiver that ingests RTP video/audio over UDP and drives a KMS plane on Rockchip-based devices. The application wraps a GStreamer pipeline with DRM/KMS, OSD, and udev helpers.
 
+## Systemd service integration
+
+The project ships with systemd units for both the primary `pixelpilot_mini_rk` pipeline and the companion `osd_external_feed` helper. On Debian 11 (or other systemd-based distributions) install and enable them with:
+
+```sh
+sudo make install
+```
+
+This copies the binaries to `/usr/local/bin`, installs the unit files into `/etc/systemd/system`, reloads the systemd daemon, and enables both services so they start automatically on the next boot. The install target also writes a default `/etc/pixelpilot_mini.ini` configuration and places the bundled idle spinner at `/usr/local/share/pixelpilot_mini_rk/spinner_ai_1080p30.h265`. Adjust the INI after installation to tune the pipeline.
+
+To remove the services and binaries later, run:
+
+```sh
+sudo make uninstall
+```
+
+The uninstall target disables the services, removes the installed files (including the default INI and spinner asset), and reloads the systemd daemon to pick up the changes.
+
 ## Configuration via INI
 
 All command-line options can be provided in an INI file and loaded with `--config /path/to/file.ini`. The parser merges the INI

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -1,0 +1,260 @@
+; PixelPilot Mini sample configuration
+; Lines starting with ';' are comments. Values are case-insensitive unless noted.
+
+[drm]
+; Card/connector selection for the video plane
+card = /dev/dri/card0
+connector = HDMI-A-1
+video-plane-id = 76
+use-udev = true
+osd-plane-id = 0
+
+[udp]
+port = 5600
+video-pt = 97
+audio-pt = 98
+
+[pipeline]
+appsink-max-buffers = 8
+custom-sink = receiver
+; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
+pt97-filter = true
+
+[idr]
+; Automatic HTTP trigger for forced IDR recovery.
+enable = true
+port = 80
+path = /request/idr
+timeout-ms = 200
+
+[sse]
+; Optional Server-Sent Events streamer for UDP receiver counters.
+enable = true
+bind = 0.0.0.0
+port = 8082
+interval-ms = 1000
+
+[splash]
+; Provide an Annex-B H.265 file with repeated key frames for the idle slate.
+; The installer rewrites @ASSETDIR@ with the deployment asset directory.
+enable = true
+input = @ASSETDIR@/spinner_ai_1080p30.h265
+fps = 30.0
+idle-timeout-ms = 5000
+default-sequence = intro
+
+[splash.sequence.intro]
+start = 0
+end = 140
+
+[audio]
+device = plughw:CARD=rockchiphdmi0,DEV=0
+disable = false
+optional = true
+
+[record]
+enable = false
+; path is optional. When omitted the recorder writes to /media with a timestamped filename.
+path = /media
+; mode controls the minimp4 writer strategy: standard, sequential, or fragmented.
+mode = fragmented
+
+[restarts]
+limit = 3
+window-ms = 2000
+
+[gst]
+log = false
+
+[cpu]
+; Example: affinity = 3,4,5
+affinity = 1,2,3
+
+[osd]
+enable = true
+refresh-ms = 100
+plane-id = 0
+; Order of elements rendered each update
+; The names reference [osd.element.NAME] sections below.
+elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
+
+[osd.external]
+; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
+; tokens/metrics into the OSD. Leave disabled by default so the socket is
+; only created when explicitly requested.
+enable = false
+socket = /run/pixelpilot/osd.sock
+
+; -----------------------------------------------------------------------------
+; Element placement quick reference
+;   anchor = top-left | top-mid | top-right | mid-left | mid | mid-right |
+;            bottom-left | bottom-mid | bottom-right
+;   offset = X,Y pixel nudges applied after anchoring (positive values move
+;            right/down, negative values move left/up)
+;   size   = WxH in pixels (line plots only)
+; Colors accept 8-digit ARGB hex (0xAARRGGBB) or named presets: black, white,
+; blue, green, yellow, orange, purple, cyan, magenta, grey, light-grey,
+; dark-grey, transparent, transparent-grey, transparent-white, etc. Prefixes
+; `#` or `0x` are optional. 6-digit RGB hex implies opaque alpha.
+; -----------------------------------------------------------------------------
+
+[osd.element.stats]
+type = text
+anchor = top-left
+padding = 8
+background = transparent-grey
+border = transparent-white
+foreground = white
+line = HDMI {display.mode} plane={drm.video_plane_id}
+line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} sinkbuf={pipeline.appsink_max_buffers}
+line = Record {record.state} active={record.active} dur={record.duration_hms} size={record.megabytes}MiB
+line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
+line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
+line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
+line = IDR req={udp.idr_requests}
+line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB
+line = Seq={udp.expected_sequence}
+
+[osd.element.recording_indicator]
+type = text
+anchor = top-right
+offset = -16,16
+padding = 6
+background = transparent-grey
+border = transparent-white
+foreground = red
+line = {record.indicator}
+
+; To create additional text blocks duplicate the section with a new element
+; name and adjust the anchor/offset. Each `line =` entry appends to that block.
+; Example:
+; [osd.element.pipeline]
+; type = text
+; anchor = bottom-right
+; offset = -16,-16
+; background = 0x60101010
+; line = Pipeline {pipeline.state} restart={pipeline.restart_count}
+
+[osd.element.bitrate_plot]
+type = bar
+anchor = bottom-left
+offset = 0,-12
+size = 360x90
+sample-spacing = 12
+bar-width = 8
+metric = udp.bitrate.latest_mbps
+label = Bitrate (Mbit/s)
+foreground = blue
+background = transparent-grey
+grid = transparent-white
+
+; Line plots sample a single metric each refresh and keep a rolling history.
+; - sample-spacing sets the horizontal pixel gap between samples. The plot wraps
+;   when new samples no longer fit, keeping the spacing constant.
+; - size sets the pixel footprint (wider = more samples before wrap, taller = more
+;   vertical resolution).
+; - label is a free-form axis caption rendered along the Y axis.
+; - info-box toggles the small badge with the latest sample (or a status
+;   message while the stream warms up).
+; - y-min / y-max optionally lock the vertical axis to a fixed range (line and
+;   bar plots). When omitted the minimum remains at 0 and the maximum auto-scales.
+
+[osd.element.framesize_plot]
+type = bar
+anchor = mid-left
+size = 360x90
+sample-spacing = 12
+bar-width = 8
+metric = udp.frames.last_bytes
+label = Frame Size (KB)
+info-box = true
+foreground = green
+background = transparent-grey
+grid = transparent-white
+
+[osd.element.jitter_plot]
+type = bar
+anchor = bottom-right
+size = 360x90
+sample-spacing = 12
+bar-width = 8
+metric = udp.jitter.latest_ms
+label = Jitter (ms)
+info-box = true
+foreground = red
+background = transparent-grey
+grid = transparent-white
+
+; -----------------------------------------------------------------------------
+; Text template tokens
+; Each {token} in a text line expands to the value listed below.
+; Display / DRM
+;   {display.mode}              => e.g. 1920x1080@60
+;   {display.width}             => active width in pixels
+;   {display.height}            => active height in pixels
+;   {display.refresh_hz}        => refresh rate in Hz
+;   {drm.video_plane_id}        => configured video plane id
+;   {drm.osd_plane_id}          => requested OSD plane id
+;   {osd.refresh_ms}            => OSD refresh interval
+;
+; Pipeline / configuration
+;   {pipeline.state}            => RUN / STOP / STOPPING
+;   {pipeline.restart_count}    => restart counter
+;   {pipeline.appsink_max_buffers} => configured appsink buffer queue depth
+;   {pipeline.audio_suffix}     => " audio=fakesink" when the audio branch falls back
+;   {pipeline.audio_status}     => "fakesink" or "normal"
+;
+; Recording telemetry
+;   {record.enable} / {record.enabled} => yes / no (configuration toggle)
+;   {record.active}           => yes / no (writer currently running)
+;   {record.state} / {record.status} => disabled / enabled / active
+;   {record.duration_s}       => elapsed wall-clock time in seconds
+;   {record.duration_hms}     => elapsed wall-clock time formatted as HH:MM:SS
+;   {record.media_duration_s} => encoded media duration in seconds
+;   {record.media_duration_hms} => encoded media duration as HH:MM:SS
+;   {record.bytes}            => bytes written to disk
+;   {record.megabytes}        => bytes written in MiB
+;   {record.path}             => active output path (if available)
+;   {record.indicator}        => unicode indicator (●/◐/○) + REC status text
+;
+; UDP receiver stats (n/a if metrics disabled)
+;   {udp.stats.available}       => yes / no
+;   {udp.port} / {udp.vid_pt} / {udp.aud_pt}
+;   {udp.video_packets}, {udp.audio_packets}, {udp.total_packets}
+;   {udp.ignored_packets}, {udp.duplicate_packets}, {udp.lost_packets}, {udp.reordered_packets}
+;   {udp.total_bytes}, {udp.video_bytes}, {udp.audio_bytes}
+;   {udp.bitrate.latest_mbps}, {udp.bitrate.avg_mbps}
+;   {udp.jitter.latest_ms}, {udp.jitter.avg_ms}
+;   {udp.frames.count}, {udp.frames.incomplete}, {udp.frames.last_bytes}, {udp.frames.avg_bytes}  (frame sizes in kilobytes)
+;   {udp.expected_sequence}, {udp.last_video_timestamp}
+;   {udp.idr_requests}          => total HTTP IDR requests issued
+;
+; -----------------------------------------------------------------------------
+; Plot metrics (line elements)
+; Assign these to `metric =` for each [osd.element.*] of type=line.
+; Units are already converted as noted.
+;   udp.bitrate.latest_mbps      (double, Mbps)
+;   udp.bitrate.avg_mbps         (double, Mbps)
+;   udp.jitter.latest_ms         (double, milliseconds)
+;   udp.jitter.avg_ms            (double, milliseconds)
+;   udp.frames.avg_bytes         (average frame size in kilobytes)
+;   udp.frames.last_bytes        (last frame size in kilobytes)
+;   udp.frames.count             (count)
+;   udp.video_packets            (count)
+;   udp.duplicate_packets        (count)
+;   udp.idr_requests             (count)
+;   udp.lost_packets             (count)
+;   udp.reordered_packets        (count)
+;   pipeline.restart_count       (count)
+;   pipeline.appsink_max_buffers (count)
+;   record.duration_s            (seconds)
+;   record.media_duration_s      (seconds)
+;   record.bytes                 (bytes)
+;   record.megabytes             (MiB)
+;
+; Additional visual types can be added by extending osd_token_format /
+; osd_metric_sample in src/osd.c. The `type = bar` widget renders discrete
+; samples as histogram-style bars using the same metric descriptors. Set
+; `mode = instant` to draw one or more current values as stationary bars and
+; supply a comma-separated list via `metrics = key1,key2` when multiple series
+; should be shown side-by-side.

--- a/systemd/osd_external_feed.service
+++ b/systemd/osd_external_feed.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=PixelPilot OSD External Feed
+Requires=pixelpilot_mini_rk.service
+After=pixelpilot_mini_rk.service
+
+[Service]
+Type=simple
+ExecStart=@BINDIR@/osd_ext_feed
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/pixelpilot_mini_rk.service
+++ b/systemd/pixelpilot_mini_rk.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=PixelPilot Mini RK video pipeline
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=@BINDIR@/pixelpilot_mini_rk --config @SYSCONFDIR@/pixelpilot_mini.ini
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add install and uninstall targets that deploy binaries, templated systemd units, a default configuration, and spinner assets while managing service enablement
- ensure the pixelpilot systemd unit launches with the installed /etc/pixelpilot_mini.ini and the OSD helper uses the templated binary path
- document the service installation workflow, including the new configuration file and asset deployment for Debian 11 environments

## Testing
- make -n DESTDIR=/tmp/prefix install
- make -n DESTDIR=/tmp/prefix uninstall

------
https://chatgpt.com/codex/tasks/task_e_68efd95d039c832b82dbed173a662664