### PR TITLE
Add RGA-backed video stabilizer pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ PKG_GSTCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags gstreamer-1.0 g
 PKG_GSTLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs gstreamer-1.0 gstreamer-video-1.0 gstreamer-app-1.0)
 PKG_MPPCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags rockchip-mpp)
 PKG_MPPLIBS := $(shell $(PKG_CONFIG) --silence-errors --libs rockchip-mpp)
+PKG_GLIBCFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags glib-2.0)
+PKG_RGACFLAGS := $(shell $(PKG_CONFIG) --silence-errors --cflags librga)
+PKG_RGALIBS := $(shell $(PKG_CONFIG) --silence-errors --libs librga)
 
 CFLAGS ?= -O2 -Wall
 CFLAGS += -Iinclude -Ithird_party/minimp4
@@ -67,10 +70,22 @@ ifneq ($(strip $(PKG_GSTCFLAGS)),)
 CFLAGS += $(PKG_GSTCFLAGS)
 endif
 
+ifneq ($(strip $(PKG_GLIBCFLAGS)),)
+CFLAGS += $(PKG_GLIBCFLAGS)
+else
+CFLAGS += -I/usr/include/glib-2.0 -I/usr/lib/$(shell uname -m)-linux-gnu/glib-2.0/include
+endif
+
 ifneq ($(strip $(PKG_MPPCFLAGS)),)
 CFLAGS += $(PKG_MPPCFLAGS)
 else
 CFLAGS += -I/usr/include/rockchip
+endif
+
+ifneq ($(strip $(PKG_RGACFLAGS)),)
+CFLAGS += $(PKG_RGACFLAGS) -DPIXELPILOT_HAVE_RGA=1
+else
+CFLAGS += -DPIXELPILOT_HAVE_RGA=0
 endif
 
 ifneq ($(strip $(PKG_DRMLIBS)),)
@@ -91,6 +106,10 @@ else
 LDFLAGS += -lrockchip_mpp
 endif
 
+ifneq ($(strip $(PKG_RGALIBS)),)
+LDFLAGS += $(PKG_RGALIBS)
+endif
+
 LDFLAGS += -lpthread -lm
 
 TARGET := pixelpilot_mini_rk
@@ -106,6 +125,13 @@ COMPANION_LDFLAGS := -lm
 
 all: $(TARGET) $(COMPANION)
 
+tests/video_stabilizer_test: tests/video_stabilizer_test.c src/video_stabilizer.c src/logging.c
+	$(CC) $(CFLAGS) tests/video_stabilizer_test.c src/video_stabilizer.c src/logging.c -o $@ $(LDFLAGS)
+
+test: tests/video_stabilizer_test
+	@echo "Running video stabilizer smoke test"
+	./tests/video_stabilizer_test
+
 $(TARGET): $(APP_OBJ)
 	$(CC) $(APP_OBJ) -o $@ $(LDFLAGS)
 
@@ -116,7 +142,7 @@ $(COMPANION): $(COMPANION_OBJ)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(APP_OBJ) $(COMPANION_OBJ) $(TARGET) $(COMPANION)
+	rm -f $(APP_OBJ) $(COMPANION_OBJ) $(TARGET) $(COMPANION) tests/video_stabilizer_test
 
 install: all
 	install -d $(DESTDIR)$(BINDIR)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,17 @@ if the module cannot run (for example, when librga support is missing).
 When you want to validate the pipeline without the oscillating demo waveform,
 point `--config` at `config/stabilizer-manual.ini`. It enables diagnostics,
 keeps the waveform disabled, and applies a static horizontal crop so the
-stabilised buffer always differs from the decoder output.
+stabilised buffer always differs from the decoder output. The manual offsets
+are clamped by both the `max-translation` value and the decoder's stride margin
+(`hor_stride - width` / `ver_stride - height`). If your requested offset exceeds
+those limits the log will emit a one-off message such as:
+
+```
+Video stabilizer manual offsets (200,200) constrained by stride margin 32 x 0; crop=(32,0)
+```
+
+This confirms the stabiliser is still active even though the hardware cannot
+accommodate the full translation.
 
 Update `config/pixelpilot_mini.ini` (installed to `/etc/pixelpilot_mini.ini` by
 `make install`) to keep the stabiliser enabled on boot.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ to the defaults listed in `src/config.c` when omitted.
 | `[stabilizer].strength` | Multiplier applied to per-frame translation values before clamping. Mirrors `--stabilizer-strength`. |
 | `[stabilizer].max-translation` | Maximum translation (in pixels) applied horizontally/vertically. Mirrors `--stabilizer-max-translation`. |
 | `[stabilizer].max-rotation` | Rotation clamp in degrees accepted from per-frame metadata. Mirrors `--stabilizer-max-rotation`. |
+| `[stabilizer].diagnostics` | `true` prints periodic info logs confirming the stabiliser is active. Mirrors `--stabilizer-diagnostics`. |
+| `[stabilizer].demo-enable` / `demo-amplitude` / `demo-frequency` | Enables the built-in verification waveform and controls its pixel amplitude and oscillation rate. Mirrors `--stabilizer-demo-*`. |
 | `[record].enable` | `true` to persist the H.265 video elementary stream to MP4 via minimp4. |
 | `[record].path` | Optional output path or directory for the MP4 file. If omitted, files land in `/media` with a timestamped name (video only, no audio). |
 | `[record].mode` | Selects the minimp4 writer mode: `standard` (seekable, updates MP4 metadata at the end), `sequential` (append-only, avoids seeks), or `fragmented` (stream-friendly MP4 fragments). |
@@ -94,16 +96,23 @@ post-processing path:
 
 ```sh
 ./pixelpilot_mini_rk --stabilizer-enable --stabilizer-strength 1.25 \
-    --stabilizer-max-translation 24 --stabilizer-max-rotation 3
+    --stabilizer-max-translation 24 --stabilizer-max-rotation 3 \
+    --stabilizer-diagnostics --stabilizer-demo-enable \
+    --stabilizer-demo-amplitude 12 --stabilizer-demo-frequency 0.75
 ```
 
 The same values can be persisted via `[stabilizer]` keys inside an INI file. The
 new `config/stabilizer-demo.ini` sample enables the module with conservative
-translation clamps and can be used directly:
+translation clamps, diagnostics, and the built-in demo waveform so you can see
+the effect immediately:
 
 ```sh
 ./pixelpilot_mini_rk --config config/stabilizer-demo.ini
 ```
+
+Watch the log for `Video stabilizer applied crop=...` messages to confirm that
+the RGA path is actively processing frames. A single bypass message is printed
+if the module cannot run (for example, when librga support is missing).
 
 Update `config/pixelpilot_mini.ini` (installed to `/etc/pixelpilot_mini.ini` by
 `make install`) to keep the stabiliser enabled on boot.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ to the defaults listed in `src/config.c` when omitted.
 | `[audio].device` | ALSA device string handed to the sink (e.g. `plughw:CARD=rockchiphdmi0,DEV=0`). |
 | `[audio].disable` | `true` drops the audio branch entirely (equivalent to `--no-audio`). |
 | `[audio].optional` | `true` allows auto-fallback to a fakesink when the audio path fails; `false` keeps retrying the real sink. |
+| `[stabilizer].enable` | `true` copies decoded frames through the RGA-backed stabiliser. Requires librga at build time. |
+| `[stabilizer].strength` | Multiplier applied to per-frame translation values before clamping. Mirrors `--stabilizer-strength`. |
+| `[stabilizer].max-translation` | Maximum translation (in pixels) applied horizontally/vertically. Mirrors `--stabilizer-max-translation`. |
+| `[stabilizer].max-rotation` | Rotation clamp in degrees accepted from per-frame metadata. Mirrors `--stabilizer-max-rotation`. |
 | `[record].enable` | `true` to persist the H.265 video elementary stream to MP4 via minimp4. |
 | `[record].path` | Optional output path or directory for the MP4 file. If omitted, files land in `/media` with a timestamped name (video only, no audio). |
 | `[record].mode` | Selects the minimp4 writer mode: `standard` (seekable, updates MP4 metadata at the end), `sequential` (append-only, avoids seeks), or `fragmented` (stream-friendly MP4 fragments). |
@@ -82,6 +86,27 @@ to the defaults listed in `src/config.c` when omitted.
 | `[osd.element.NAME].anchor` / `offset` / `size` / color keys | Control placement and styling for OSD widgets. See inline comments in the sample file for full semantics. |
 | `[osd.element.NAME].line` | For text widgets, each `line =` entry appends a formatted row supporting `{token}` placeholders. |
 | `[osd.element.NAME].metric` | For line/bar widgets, selects the metric token (e.g. `udp.bitrate.latest_mbps`) sampled each refresh. |
+
+### Video stabiliser quick start
+
+Builds produced with `PIXELPILOT_HAVE_RGA=1` expose CLI toggles for the RGA-backed
+post-processing path:
+
+```sh
+./pixelpilot_mini_rk --stabilizer-enable --stabilizer-strength 1.25 \
+    --stabilizer-max-translation 24 --stabilizer-max-rotation 3
+```
+
+The same values can be persisted via `[stabilizer]` keys inside an INI file. The
+new `config/stabilizer-demo.ini` sample enables the module with conservative
+translation clamps and can be used directly:
+
+```sh
+./pixelpilot_mini_rk --config config/stabilizer-demo.ini
+```
+
+Update `config/pixelpilot_mini.ini` (installed to `/etc/pixelpilot_mini.ini` by
+`make install`) to keep the stabiliser enabled on boot.
 
 ## CPU affinity control
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[stabilizer].max-rotation` | Rotation clamp in degrees accepted from per-frame metadata. Mirrors `--stabilizer-max-rotation`. |
 | `[stabilizer].diagnostics` | `true` prints periodic info logs confirming the stabiliser is active. Mirrors `--stabilizer-diagnostics`. |
 | `[stabilizer].demo-enable` / `demo-amplitude` / `demo-frequency` | Enables the built-in verification waveform and controls its pixel amplitude and oscillation rate. Mirrors `--stabilizer-demo-*`. |
+| `[stabilizer].manual-enable` / `manual-offset-x` / `manual-offset-y` | Applies a fixed translation when no per-frame parameters are available. Mirrors `--stabilizer-manual-*`. |
 | `[record].enable` | `true` to persist the H.265 video elementary stream to MP4 via minimp4. |
 | `[record].path` | Optional output path or directory for the MP4 file. If omitted, files land in `/media` with a timestamped name (video only, no audio). |
 | `[record].mode` | Selects the minimp4 writer mode: `standard` (seekable, updates MP4 metadata at the end), `sequential` (append-only, avoids seeks), or `fragmented` (stream-friendly MP4 fragments). |
@@ -113,6 +114,11 @@ the effect immediately:
 Watch the log for `Video stabilizer applied crop=...` messages to confirm that
 the RGA path is actively processing frames. A single bypass message is printed
 if the module cannot run (for example, when librga support is missing).
+
+When you want to validate the pipeline without the oscillating demo waveform,
+point `--config` at `config/stabilizer-manual.ini`. It enables diagnostics,
+keeps the waveform disabled, and applies a static horizontal crop so the
+stabilised buffer always differs from the decoder output.
 
 Update `config/pixelpilot_mini.ini` (installed to `/etc/pixelpilot_mini.ini` by
 `make install`) to keep the stabiliser enabled on boot.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[stabilizer].diagnostics` | `true` prints periodic info logs confirming the stabiliser is active. Mirrors `--stabilizer-diagnostics`. |
 | `[stabilizer].demo-enable` / `demo-amplitude` / `demo-frequency` | Enables the built-in verification waveform and controls its pixel amplitude and oscillation rate. Mirrors `--stabilizer-demo-*`. |
 | `[stabilizer].manual-enable` / `manual-offset-x` / `manual-offset-y` | Applies a fixed translation when no per-frame parameters are available. Mirrors `--stabilizer-manual-*`. |
+| `[stabilizer].guard-band-x` / `guard-band-y` | Symmetric crop margin reserved on each axis to keep the steady-state crop centred and define the usable translation range. Mirrors `--stabilizer-guard-band-*`. |
 | `[record].enable` | `true` to persist the H.265 video elementary stream to MP4 via minimp4. |
 | `[record].path` | Optional output path or directory for the MP4 file. If omitted, files land in `/media` with a timestamped name (video only, no audio). |
 | `[record].mode` | Selects the minimp4 writer mode: `standard` (seekable, updates MP4 metadata at the end), `sequential` (append-only, avoids seeks), or `fragmented` (stream-friendly MP4 fragments). |
@@ -117,18 +118,20 @@ if the module cannot run (for example, when librga support is missing).
 
 When you want to validate the pipeline without the oscillating demo waveform,
 point `--config` at `config/stabilizer-manual.ini`. It enables diagnostics,
-keeps the waveform disabled, and applies a static horizontal crop so the
-stabilised buffer always differs from the decoder output. The manual offsets
-are clamped by both the `max-translation` value and the decoder's stride margin
-(`hor_stride - width` / `ver_stride - height`). If your requested offset exceeds
-those limits the log will emit a one-off message such as:
+keeps the waveform disabled, reserves a symmetric guard band, and applies a
+static horizontal crop so the stabilised buffer always differs from the decoder
+output. The manual offsets are clamped by both the `max-translation` value and
+the decoder's stride margin (`hor_stride - width` / `ver_stride - height`). If
+your requested offset exceeds those limits the log will emit a one-off message
+such as:
 
 ```
-Video stabilizer manual offsets (200,200) constrained by stride margin 32 x 0; crop=(32,0)
+Video stabilizer manual offsets (200,200) constrained by stride margin 32 x 0 (guard 16 x 0); crop=(16,0)
 ```
 
 This confirms the stabiliser is still active even though the hardware cannot
-accommodate the full translation.
+accommodate the full translation. Adjust the guard band or translation clamp to
+suit your sensor's stride headroom.
 
 Update `config/pixelpilot_mini.ini` (installed to `/etc/pixelpilot_mini.ini` by
 `make install`) to keep the stabiliser enabled on boot.

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -52,6 +52,17 @@ device = plughw:CARD=rockchiphdmi0,DEV=0
 disable = false
 optional = true
 
+[stabilizer]
+; Enable to copy decoded frames through the RGA-backed stabiliser.
+; Requires building with PIXELPILOT_HAVE_RGA=1 and a supported DRM driver.
+enable = false
+; Multiplier applied to per-frame translation parameters before clamping.
+strength = 1.0
+; Translation clamp in pixels (applied horizontally and vertically).
+max-translation = 32
+; Rotation clamp in degrees. Values above zero are currently logged only.
+max-rotation = 5
+
 [record]
 enable = false
 ; path is optional. When omitted the recorder writes to /media with a timestamped filename.

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -72,6 +72,10 @@ demo-frequency = 0.5
 manual-enable = false
 manual-offset-x = 0.0
 manual-offset-y = 0.0
+; Optional symmetric crop margins (per side) that keep the baseline crop centred.
+; Leave commented to use half of the available stride headroom automatically.
+;guard-band-x = -1
+;guard-band-y = -1
 
 [record]
 enable = false

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -68,6 +68,10 @@ diagnostics = false
 demo-enable = false
 demo-amplitude = 8.0
 demo-frequency = 0.5
+; Optional fixed translation applied when no per-frame parameters are provided.
+manual-enable = false
+manual-offset-x = 0.0
+manual-offset-y = 0.0
 
 [record]
 enable = false

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -62,6 +62,12 @@ strength = 1.0
 max-translation = 32
 ; Rotation clamp in degrees. Values above zero are currently logged only.
 max-rotation = 5
+; Emit informational logs when the stabiliser path is engaged (first frame and every 60 frames).
+diagnostics = false
+; Optional demo waveform used for quick verification when no sensor data is connected.
+demo-enable = false
+demo-amplitude = 8.0
+demo-frequency = 0.5
 
 [record]
 enable = false

--- a/config/stabilizer-demo.ini
+++ b/config/stabilizer-demo.ini
@@ -30,6 +30,10 @@ diagnostics = true
 demo-enable = true
 demo-amplitude = 12.0
 demo-frequency = 0.75
+; Manual overrides are disabled in this demo config so the waveform remains active.
+manual-enable = false
+manual-offset-x = 0.0
+manual-offset-y = 0.0
 
 ; Optional extras that play nicely with the stabilised video path
 [osd]

--- a/config/stabilizer-demo.ini
+++ b/config/stabilizer-demo.ini
@@ -24,6 +24,12 @@ enable = true
 strength = 1.15
 max-translation = 24
 max-rotation = 3
+; Print diagnostic messages so you can confirm the post-processor is active
+diagnostics = true
+; Built-in waveform that continuously nudges the crop window to highlight the effect
+demo-enable = true
+demo-amplitude = 12.0
+demo-frequency = 0.75
 
 ; Optional extras that play nicely with the stabilised video path
 [osd]

--- a/config/stabilizer-demo.ini
+++ b/config/stabilizer-demo.ini
@@ -1,0 +1,35 @@
+; PixelPilot Mini RK stabilizer demo configuration
+; Enable the RGA-backed post-processing path with tuned translation clamps.
+
+[drm]
+; Card/connector selection for the video plane
+card = /dev/dri/card0
+connector =
+video-plane-id = 76
+use-udev = true
+
+[udp]
+port = 5600
+video-pt = 97
+audio-pt = 98
+
+[pipeline]
+; Keep the custom receiver for telemetry (required for stabiliser stats updates)
+custom-sink = receiver
+appsink-max-buffers = 6
+
+[stabilizer]
+; Toggle the RGA stabiliser and adjust motion gain + clamps
+enable = true
+strength = 1.15
+max-translation = 24
+max-rotation = 3
+
+; Optional extras that play nicely with the stabilised video path
+[osd]
+enable = true
+refresh-ms = 200
+plane-id = 0
+
+[record]
+enable = false

--- a/config/stabilizer-manual.ini
+++ b/config/stabilizer-manual.ini
@@ -28,14 +28,17 @@ diagnostics = true
 demo-enable = false
 demo-amplitude = 0.0
 demo-frequency = 0.5
-; The manual offsets are clamped by both max-translation and the stride margin
-; reported by the decoder (hor_stride - width / ver_stride - height).
+; The manual offsets are clamped by both max-translation and the guard bands
+; below. Increase the guard to crop more from each edge and create a wider
+; stabilisation window.
 manual-enable = true
-manual-offset-x = 24.0
+manual-offset-x = 48.0
 manual-offset-y = 0.0
-; Reserve a symmetric guard band so the baseline crop stays centred.
-guard-band-x = 16.0
-guard-band-y = 8.0
+; Crop 96 pixels from the left/right edges and 48 pixels from the top/bottom.
+; RGA scales the reduced image back up to the full output size so the frame
+; still fills the display.
+guard-band-x = 96.0
+guard-band-y = 48.0
 
 [osd]
 enable = true

--- a/config/stabilizer-manual.ini
+++ b/config/stabilizer-manual.ini
@@ -1,27 +1,43 @@
 ; PixelPilot Mini RK stabilizer manual translation configuration
 ;
-; This sample mirrors stabilizer-demo.ini but disables the waveform in favour of a
-; fixed crop offset. Use it when you want to validate RGA processing without the
-; demo motion generator.
+; Start from the demo configuration but keep the waveform disabled so the manual
+; override is the only crop that gets applied. Diagnostics stay enabled so you
+; can confirm the RGA copy is active and whether any clamps kick in.
 
-[global]
-config-version = 1
+[drm]
+card = /dev/dri/card0
+connector =
+video-plane-id = 76
+use-udev = true
 
-[receiver]
-; Enable diagnostics so crop activity is logged.
-stabilizer-diagnostics = true
+[udp]
+port = 5600
+video-pt = 97
+audio-pt = 98
+
+[pipeline]
+custom-sink = receiver
+appsink-max-buffers = 6
 
 [stabilizer]
 enable = true
 strength = 1.0
-max-translation = 32
+max-translation = 48
 max-rotation = 5
 diagnostics = true
-; Leave the waveform disabled to avoid time-varying crops.
 demo-enable = false
 demo-amplitude = 0.0
 demo-frequency = 0.5
-; Apply a visible 12 pixel horizontal crop so the output differs from the input.
+; The manual offsets are clamped by both max-translation and the stride margin
+; reported by the decoder (hor_stride - width / ver_stride - height).
 manual-enable = true
-manual-offset-x = 12.0
+manual-offset-x = 24.0
 manual-offset-y = 0.0
+
+[osd]
+enable = true
+refresh-ms = 200
+plane-id = 0
+
+[record]
+enable = false

--- a/config/stabilizer-manual.ini
+++ b/config/stabilizer-manual.ini
@@ -33,6 +33,9 @@ demo-frequency = 0.5
 manual-enable = true
 manual-offset-x = 24.0
 manual-offset-y = 0.0
+; Reserve a symmetric guard band so the baseline crop stays centred.
+guard-band-x = 16.0
+guard-band-y = 8.0
 
 [osd]
 enable = true

--- a/config/stabilizer-manual.ini
+++ b/config/stabilizer-manual.ini
@@ -1,0 +1,27 @@
+; PixelPilot Mini RK stabilizer manual translation configuration
+;
+; This sample mirrors stabilizer-demo.ini but disables the waveform in favour of a
+; fixed crop offset. Use it when you want to validate RGA processing without the
+; demo motion generator.
+
+[global]
+config-version = 1
+
+[receiver]
+; Enable diagnostics so crop activity is logged.
+stabilizer-diagnostics = true
+
+[stabilizer]
+enable = true
+strength = 1.0
+max-translation = 32
+max-rotation = 5
+diagnostics = true
+; Leave the waveform disabled to avoid time-varying crops.
+demo-enable = false
+demo-amplitude = 0.0
+demo-frequency = 0.5
+; Apply a visible 12 pixel horizontal crop so the output differs from the input.
+manual-enable = true
+manual-offset-x = 12.0
+manual-offset-y = 0.0

--- a/docs/video_stabilizer.md
+++ b/docs/video_stabilizer.md
@@ -40,6 +40,11 @@ keys. Of note:
   nudges the crop window even when no motion vectors are supplied. This makes
   it obvious on-screen that the stabiliser path is active and also exercises
   the diagnostic logging.
+* `--stabilizer-manual-enable`, `--stabilizer-manual-offset-x`, and
+  `--stabilizer-manual-offset-y` apply a fixed translation whenever no
+  per-frame parameters are provided. This is useful on hardware without motion
+  metadata because it keeps the RGA copy path active even with the demo wave
+  disabled.
 
 Typical command line enablement looks like:
 
@@ -53,10 +58,16 @@ translation strength/clamps to suit the expected motion profile before passing
 it to `--config`. The demo file ships with diagnostics and the internal demo
 waveform enabled, so you can observe the stabiliser at work immediately.
 
+If you prefer to keep the source frame aligned while still exercising the
+stabiliser, use `config/stabilizer-manual.ini`. It enables diagnostics, turns
+off the waveform, and requests a static 12 pixel horizontal crop so the output
+frame visibly differs from the raw decoder buffer. Adjust the offsets to match
+your test scenario.
+
 With diagnostics enabled the log will periodically emit entries such as:
 
 ```
-Video stabilizer applied crop=(6,2) demo=yes params=no frame=60
+Video stabilizer applied crop=(6,2) demo=yes manual=no params=no frame=60
 ```
 
 If the module cannot run you will see a one-off bypass reason (for example when

--- a/docs/video_stabilizer.md
+++ b/docs/video_stabilizer.md
@@ -1,0 +1,38 @@
+# Video Stabilizer Pipeline
+
+The video stabilizer module (`src/video_stabilizer.c`) provides an optional
+post-processing stage that copies decoded NV12 frames into a secondary pool of
+DMA-BUF backed buffers using Rockchip's RGA hardware. The module exposes a
+simple lifecycle:
+
+1. Allocate an instance with `video_stabilizer_new()` and initialise it with a
+   `StabilizerConfig` derived from the runtime configuration file or CLI
+   flags.
+2. Whenever the decoder's geometry changes, call
+   `video_stabilizer_configure()` to update the input/output dimensions and
+   DMA strides.
+3. For each decoded frame, invoke `video_stabilizer_process()` with the source
+   PRIME FD, destination PRIME FD, and the per-frame `StabilizerParams`. The
+   decoder can update the parameters via
+   `video_decoder_set_stabilizer_params()` to apply motion-vector or gyro
+   driven offsets. When librga is unavailable, the module automatically
+   bypasses processing.
+
+The decoder owns two frame pools: the raw MPP buffers and a matching set of
+DRM dumb buffers that hold the stabilised frames. Synchronisation is handled by
+propagating the stabiliser's release fence to the KMS plane via the
+`IN_FENCE_FD`/`OUT_FENCE_PTR` properties when the driver supports them.
+
+## Configuration
+
+`config.ini` and CLI flags gain a `[stabilizer]` section and corresponding
+`--stabilizer-*` options. These settings control whether the stabiliser is
+active and the translation/rotation clamps used when interpreting per-frame
+parameters. Refer to `src/config.c` and `src/config_ini.c` for the available
+keys.
+
+## Testing
+
+Run `make test` to build and execute `tests/video_stabilizer_test`. The smoke
+test validates basic API coverage on all platforms and attempts a real DMA-BUF
+round-trip when both librga and a DRM device are present.

--- a/docs/video_stabilizer.md
+++ b/docs/video_stabilizer.md
@@ -29,7 +29,17 @@ propagating the stabiliser's release fence to the KMS plane via the
 `--stabilizer-*` options. These settings control whether the stabiliser is
 active and the translation/rotation clamps used when interpreting per-frame
 parameters. Refer to `src/config.c` and `src/config_ini.c` for the available
-keys.
+keys. Of note:
+
+* `--stabilizer-diagnostics` (or `diagnostics = true` in the INI) prints an
+  info log on the first processed frame and every 60th frame afterwards,
+  confirming whether the module is cropping based on external parameters or
+  the demo wave. A bypass reason is logged once if the module cannot run.
+* `--stabilizer-demo-enable`, `--stabilizer-demo-amplitude`, and
+  `--stabilizer-demo-frequency` enable a built-in sine/cosine waveform that
+  nudges the crop window even when no motion vectors are supplied. This makes
+  it obvious on-screen that the stabiliser path is active and also exercises
+  the diagnostic logging.
 
 Typical command line enablement looks like:
 
@@ -40,7 +50,17 @@ Typical command line enablement looks like:
 
 For INI-driven deployments copy `config/stabilizer-demo.ini` and tweak the
 translation strength/clamps to suit the expected motion profile before passing
-it to `--config`.
+it to `--config`. The demo file ships with diagnostics and the internal demo
+waveform enabled, so you can observe the stabiliser at work immediately.
+
+With diagnostics enabled the log will periodically emit entries such as:
+
+```
+Video stabilizer applied crop=(6,2) demo=yes params=no frame=60
+```
+
+If the module cannot run you will see a one-off bypass reason (for example when
+RGA support is unavailable or when per-frame metadata disables the transform).
 
 ## Testing
 

--- a/docs/video_stabilizer.md
+++ b/docs/video_stabilizer.md
@@ -45,6 +45,12 @@ keys. Of note:
   per-frame parameters are provided. This is useful on hardware without motion
   metadata because it keeps the RGA copy path active even with the demo wave
   disabled.
+* `--stabilizer-guard-band-x` / `--stabilizer-guard-band-y` (or
+  `guard-band-x` / `guard-band-y` in the INI) reserve a symmetric crop margin
+  around the decoded frame. The guard band keeps the steady-state crop centred
+  and defines how much negative and positive translation is possible before the
+  stabiliser hits the stride boundary. Leaving these options unset defaults to
+  half of the available stride headroom on each axis.
 
 Typical command line enablement looks like:
 
@@ -60,16 +66,17 @@ waveform enabled, so you can observe the stabiliser at work immediately.
 
 If you prefer to keep the source frame aligned while still exercising the
 stabiliser, use `config/stabilizer-manual.ini`. It enables diagnostics, turns
-off the waveform, and requests a static horizontal crop so the output frame
-visibly differs from the raw decoder buffer. Manual offsets are clamped by both
-`max-translation` and the stride margin exposed by the decoder. When an offset
-is reduced you will see a one-off diagnostic similar to:
+off the waveform, reserves a symmetric guard band, and requests a static
+horizontal crop so the output frame visibly differs from the raw decoder
+buffer. Manual offsets are clamped by both `max-translation` and the stride
+margin exposed by the decoder. When an offset is reduced you will see a one-off
+diagnostic similar to:
 
 ```
-Video stabilizer manual offsets (200,200) constrained by stride margin 32 x 0; crop=(32,0)
+Video stabilizer manual offsets (200,200) constrained by stride margin 32 x 0 (guard 16 x 0); crop=(16,0)
 ```
 
-Increase `max-translation` or adjust your expectations based on the available
+Increase `max-translation` or adjust the guard band based on the available
 stride headroom for the format you are decoding.
 
 With diagnostics enabled the log will periodically emit entries such as:

--- a/docs/video_stabilizer.md
+++ b/docs/video_stabilizer.md
@@ -31,6 +31,17 @@ active and the translation/rotation clamps used when interpreting per-frame
 parameters. Refer to `src/config.c` and `src/config_ini.c` for the available
 keys.
 
+Typical command line enablement looks like:
+
+```sh
+./pixelpilot_mini_rk --stabilizer-enable --stabilizer-strength 1.15 \
+    --stabilizer-max-translation 24 --stabilizer-max-rotation 3
+```
+
+For INI-driven deployments copy `config/stabilizer-demo.ini` and tweak the
+translation strength/clamps to suit the expected motion profile before passing
+it to `--config`.
+
 ## Testing
 
 Run `make test` to build and execute `tests/video_stabilizer_test`. The smoke

--- a/docs/video_stabilizer.md
+++ b/docs/video_stabilizer.md
@@ -60,9 +60,17 @@ waveform enabled, so you can observe the stabiliser at work immediately.
 
 If you prefer to keep the source frame aligned while still exercising the
 stabiliser, use `config/stabilizer-manual.ini`. It enables diagnostics, turns
-off the waveform, and requests a static 12 pixel horizontal crop so the output
-frame visibly differs from the raw decoder buffer. Adjust the offsets to match
-your test scenario.
+off the waveform, and requests a static horizontal crop so the output frame
+visibly differs from the raw decoder buffer. Manual offsets are clamped by both
+`max-translation` and the stride margin exposed by the decoder. When an offset
+is reduced you will see a one-off diagnostic similar to:
+
+```
+Video stabilizer manual offsets (200,200) constrained by stride margin 32 x 0; crop=(32,0)
+```
+
+Increase `max-translation` or adjust your expectations based on the available
+stride headroom for the format you are decoding.
 
 With diagnostics enabled the log will periodically emit entries such as:
 

--- a/docs/video_stabilizer_review.md
+++ b/docs/video_stabilizer_review.md
@@ -1,0 +1,85 @@
+# Video Stabilizer Review and Roadmap
+
+## Current implementation snapshot
+
+The decoder allocates paired DRM dumb buffers for each frame slot so that raw
+MPP output can be copied into a stabilised surface via the RGA wrapper before it
+is queued to the KMS plane.【F:src/video_decoder.c†L393-L666】  The stabiliser
+module itself crops the decoded NV12 frame according to configurable guard
+bands, applies optional manual/demo translations, and blits the cropped region
+back into the processed buffer while scaling it to the original output size.【F:src/video_stabilizer.c†L282-L520】  Runtime configuration exposes knobs for
+manual offsets, demo mode, guard bands, and diagnostics but no automatic motion
+estimation pipeline feeds per-frame transforms into the decoder.
+
+The `video_decoder_set_stabilizer_params()` entrypoint simply stores the most
+recent parameters provided by external code, leaving the stabiliser to operate
+purely on manual or demo offsets when no caller injects motion data.【F:src/video_decoder.c†L1041-L1056】  As a consequence, the stabiliser only
+produces static crops unless another subsystem actively pushes per-frame
+translations.
+
+## Gaps preventing real stabilisation
+
+1. **Missing motion source.** Nothing inside the decoder or pipeline estimates
+   frame-to-frame motion, so `StabilizerParams` remains unset in normal runs and
+   the RGA stage merely copies or applies static/manual crops.
+2. **Limited guard-band management.** Guard bands default to zero and must be
+   tuned manually, yet meaningful stabilisation requires symmetric margins that
+   accommodate the expected translation range without exhausting the decoder’s
+   stride slack.
+3. **No smoothing or history.** Even if external code supplied translations, the
+   stabiliser would apply them directly without filtering or dampening, risking
+   jitter.
+4. **Translation-only path.** Rotation fields are accepted but ignored; only
+   integer translations end up in the crop window, so the pipeline cannot handle
+   angular motion or sub-pixel adjustments.【F:src/video_stabilizer.c†L392-L433】
+
+## Goal
+
+Deliver true image stabilisation by deriving per-frame transforms from the
+incoming video stream (or auxiliary sensors) and feeding those into the existing
+RGA copy path so that the displayed output compensates for camera shake in real
+time.
+
+## Plan of record
+
+1. **Introduce a motion-estimation module.**
+   - Map the luminance plane of decoded frames (using `drmModeMapDumb` on the
+     raw buffer handles) and downsample to a manageable resolution for analysis.
+   - Implement a coarse-to-fine search (e.g., block matching or phase
+     correlation) to estimate integer/sub-pixel translations against the
+     previous frame, tracking confidence/quality metrics.
+   - Maintain a low-pass filtered translation history to smooth abrupt changes
+     before emitting `StabilizerParams`.
+
+2. **Integrate with the decoder.**
+   - Instantiate the estimator alongside the stabiliser and update it from the
+     frame thread prior to invoking `video_stabilizer_process()` so every frame
+     has a fresh transform.【F:src/video_decoder.c†L600-L666】
+   - When the estimator yields a confident motion vector, call
+     `video_decoder_set_stabilizer_params()` with the filtered translation; fall
+     back to manual/demo options when estimation fails.
+
+3. **Automate guard-band selection.**
+   - Derive default guard bands from the configured maximum translation (e.g.,
+     `guard = ceil(max_translation)`), clamping to stride headroom to avoid RGA
+     errors.
+   - Surface diagnostics that report both the chosen guard band and any clipping
+     imposed by stride margins so operators know when the requested motion
+     exceeds the safe window.
+
+4. **Enhance configurability and observability.**
+   - Add INI/CLI toggles for estimator behaviour (enable/disable, search radius,
+     filter strength) and expose runtime counters (e.g., estimation success
+     rate, average translation) through existing diagnostics logging.
+
+5. **Testing strategy.**
+   - Extend `tests/video_stabilizer_test` with synthetic jitter sequences to
+     validate that estimator-generated parameters move the crop window as
+     expected.
+   - Provide a scripted integration test that replays a shaky clip, captures the
+     stabilised output, and verifies the residual motion falls within the target
+     tolerance.
+
+Executing this plan will bridge the current gap between the static RGA cropper
+and a genuine stabilisation pipeline, enabling real-time correction without
+relying on demo waveforms or manual offsets.

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,7 @@
 #include <sched.h>
 
 #include "osd_layout.h"
+#include "video_stabilizer.h"
 
 #define SPLASH_MAX_SEQUENCES 32
 
@@ -102,6 +103,7 @@ typedef struct {
     RecordCfg record;
     SseCfg sse;
     IdrCfg idr;
+    StabilizerConfig stabilizer;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "drm_modeset.h"
 #include "idr_requester.h"
+#include "video_stabilizer.h"
 
 typedef struct VideoDecoder VideoDecoder;
 
@@ -24,6 +25,7 @@ int video_decoder_feed(VideoDecoder *vd, const guint8 *data, size_t size);
 void video_decoder_send_eos(VideoDecoder *vd);
 
 void video_decoder_set_idr_requester(VideoDecoder *vd, IdrRequester *requester);
+void video_decoder_set_stabilizer_params(VideoDecoder *vd, const StabilizerParams *params);
 
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
 

--- a/include/video_stabilizer.h
+++ b/include/video_stabilizer.h
@@ -20,6 +20,8 @@ typedef struct {
     int manual_enable;
     float manual_offset_x_px;
     float manual_offset_y_px;
+    float guard_band_x_px;
+    float guard_band_y_px;
 } StabilizerConfig;
 
 typedef struct {

--- a/include/video_stabilizer.h
+++ b/include/video_stabilizer.h
@@ -17,6 +17,9 @@ typedef struct {
     int demo_enable;
     float demo_amplitude_px;
     float demo_frequency_hz;
+    int manual_enable;
+    float manual_offset_x_px;
+    float manual_offset_y_px;
 } StabilizerConfig;
 
 typedef struct {

--- a/include/video_stabilizer.h
+++ b/include/video_stabilizer.h
@@ -13,6 +13,10 @@ typedef struct {
     float strength;
     float max_translation_px;
     float max_rotation_deg;
+    int diagnostics;
+    int demo_enable;
+    float demo_amplitude_px;
+    float demo_frequency_hz;
 } StabilizerConfig;
 
 typedef struct {

--- a/include/video_stabilizer.h
+++ b/include/video_stabilizer.h
@@ -1,0 +1,42 @@
+#ifndef VIDEO_STABILIZER_H
+#define VIDEO_STABILIZER_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#ifndef PIXELPILOT_HAVE_RGA
+#define PIXELPILOT_HAVE_RGA 0
+#endif
+
+typedef struct {
+    int enable;
+    float strength;
+    float max_translation_px;
+    float max_rotation_deg;
+} StabilizerConfig;
+
+typedef struct {
+    gboolean enable;
+    int acquire_fence_fd;
+    gboolean has_transform;
+    float transform[9];
+    float translate_x;
+    float translate_y;
+    float rotate_deg;
+} StabilizerParams;
+
+typedef struct VideoStabilizer VideoStabilizer;
+
+VideoStabilizer *video_stabilizer_new(void);
+void video_stabilizer_free(VideoStabilizer *stabilizer);
+
+int video_stabilizer_init(VideoStabilizer *stabilizer, const StabilizerConfig *config);
+void video_stabilizer_shutdown(VideoStabilizer *stabilizer);
+int video_stabilizer_configure(VideoStabilizer *stabilizer, uint32_t width, uint32_t height,
+                               uint32_t hor_stride, uint32_t ver_stride);
+int video_stabilizer_update(VideoStabilizer *stabilizer, const StabilizerConfig *config);
+int video_stabilizer_process(VideoStabilizer *stabilizer, int in_fd, int out_fd,
+                             const StabilizerParams *params, int *release_fence_fd);
+gboolean video_stabilizer_is_available(const VideoStabilizer *stabilizer);
+
+#endif // VIDEO_STABILIZER_H

--- a/src/config.c
+++ b/src/config.c
@@ -59,6 +59,8 @@ static void usage(const char *prog) {
             "  --stabilizer-manual-disable  (disable manual translation override)\n"
             "  --stabilizer-manual-offset-x PX (horizontal manual translation in pixels)\n"
             "  --stabilizer-manual-offset-y PX (vertical manual translation in pixels)\n"
+            "  --stabilizer-guard-band-x PX (base crop margin per side along X; default: auto)\n"
+            "  --stabilizer-guard-band-y PX (base crop margin per side along Y; default: auto)\n"
             "  --gst-log                    (set GST_DEBUG=3 if not set)\n"
             "  --cpu-list LIST              (comma-separated CPU IDs for affinity)\n"
             "  --verbose\n",
@@ -218,6 +220,8 @@ void cfg_defaults(AppCfg *c) {
     c->stabilizer.manual_enable = 0;
     c->stabilizer.manual_offset_x_px = 0.0f;
     c->stabilizer.manual_offset_y_px = 0.0f;
+    c->stabilizer.guard_band_x_px = -1.0f;
+    c->stabilizer.guard_band_y_px = -1.0f;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {
@@ -512,6 +516,14 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->stabilizer.manual_offset_y_px = (float)atof(argv[++i]);
         } else if (!strcmp(argv[i], "--stabilizer-manual-offset-y")) {
             LOGE("--stabilizer-manual-offset-y requires a numeric argument");
+        } else if (!strcmp(argv[i], "--stabilizer-guard-band-x") && i + 1 < argc) {
+            cfg->stabilizer.guard_band_x_px = (float)atof(argv[++i]);
+        } else if (!strcmp(argv[i], "--stabilizer-guard-band-x")) {
+            LOGE("--stabilizer-guard-band-x requires a numeric argument");
+        } else if (!strcmp(argv[i], "--stabilizer-guard-band-y") && i + 1 < argc) {
+            cfg->stabilizer.guard_band_y_px = (float)atof(argv[++i]);
+        } else if (!strcmp(argv[i], "--stabilizer-guard-band-y")) {
+            LOGE("--stabilizer-guard-band-y requires a numeric argument");
             return -1;
         } else if (!strcmp(argv[i], "--gst-log")) {
             cfg->gst_log = 1;

--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,10 @@ static void usage(const char *prog) {
             "  --stabilizer-demo-disable    (disable built-in demo motion path)\n"
             "  --stabilizer-demo-amplitude PX (demo motion amplitude in pixels)\n"
             "  --stabilizer-demo-frequency HZ (demo motion frequency; default: 0.5)\n"
+            "  --stabilizer-manual-enable   (force a fixed translation when no params provided)\n"
+            "  --stabilizer-manual-disable  (disable manual translation override)\n"
+            "  --stabilizer-manual-offset-x PX (horizontal manual translation in pixels)\n"
+            "  --stabilizer-manual-offset-y PX (vertical manual translation in pixels)\n"
             "  --gst-log                    (set GST_DEBUG=3 if not set)\n"
             "  --cpu-list LIST              (comma-separated CPU IDs for affinity)\n"
             "  --verbose\n",
@@ -211,6 +215,9 @@ void cfg_defaults(AppCfg *c) {
     c->stabilizer.demo_enable = 0;
     c->stabilizer.demo_amplitude_px = 0.0f;
     c->stabilizer.demo_frequency_hz = 0.5f;
+    c->stabilizer.manual_enable = 0;
+    c->stabilizer.manual_offset_x_px = 0.0f;
+    c->stabilizer.manual_offset_y_px = 0.0f;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {
@@ -491,6 +498,20 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             }
         } else if (!strcmp(argv[i], "--stabilizer-demo-frequency")) {
             LOGE("--stabilizer-demo-frequency requires a numeric argument");
+            return -1;
+        } else if (!strcmp(argv[i], "--stabilizer-manual-enable")) {
+            cfg->stabilizer.manual_enable = 1;
+        } else if (!strcmp(argv[i], "--stabilizer-manual-disable")) {
+            cfg->stabilizer.manual_enable = 0;
+        } else if (!strcmp(argv[i], "--stabilizer-manual-offset-x") && i + 1 < argc) {
+            cfg->stabilizer.manual_offset_x_px = (float)atof(argv[++i]);
+        } else if (!strcmp(argv[i], "--stabilizer-manual-offset-x")) {
+            LOGE("--stabilizer-manual-offset-x requires a numeric argument");
+            return -1;
+        } else if (!strcmp(argv[i], "--stabilizer-manual-offset-y") && i + 1 < argc) {
+            cfg->stabilizer.manual_offset_y_px = (float)atof(argv[++i]);
+        } else if (!strcmp(argv[i], "--stabilizer-manual-offset-y")) {
+            LOGE("--stabilizer-manual-offset-y requires a numeric argument");
             return -1;
         } else if (!strcmp(argv[i], "--gst-log")) {
             cfg->gst_log = 1;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1083,6 +1083,36 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             }
             return 0;
         }
+        if (strcasecmp(key, "diagnostics") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->stabilizer.diagnostics = v;
+            return 0;
+        }
+        if (strcasecmp(key, "demo-enable") == 0 || strcasecmp(key, "demo") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->stabilizer.demo_enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "demo-amplitude") == 0) {
+            cfg->stabilizer.demo_amplitude_px = strtof(value, NULL);
+            if (cfg->stabilizer.demo_amplitude_px < 0.0f) {
+                cfg->stabilizer.demo_amplitude_px = 0.0f;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "demo-frequency") == 0) {
+            cfg->stabilizer.demo_frequency_hz = strtof(value, NULL);
+            if (cfg->stabilizer.demo_frequency_hz <= 0.0f) {
+                cfg->stabilizer.demo_frequency_hz = 0.1f;
+            }
+            return 0;
+        }
         return -1;
     }
     if (strcasecmp(section, "gst") == 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1113,6 +1113,22 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             }
             return 0;
         }
+        if (strcasecmp(key, "manual-enable") == 0 || strcasecmp(key, "manual") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->stabilizer.manual_enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "manual-offset-x") == 0) {
+            cfg->stabilizer.manual_offset_x_px = strtof(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "manual-offset-y") == 0) {
+            cfg->stabilizer.manual_offset_y_px = strtof(value, NULL);
+            return 0;
+        }
         return -1;
     }
     if (strcasecmp(section, "gst") == 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -813,6 +813,27 @@ static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name
 }
 
 static int apply_general_key(AppCfg *cfg, const char *section, const char *key, const char *value) {
+    if (section == NULL) {
+        section = "";
+    }
+    if (*section == '\0' || strcasecmp(section, "global") == 0) {
+        if (strcasecmp(key, "config-version") == 0) {
+            /* Reserved for future compatibility checks. */
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(section, "receiver") == 0) {
+        if (strcasecmp(key, "stabilizer-diagnostics") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->stabilizer.diagnostics = v;
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "drm") == 0) {
         if (strcasecmp(key, "card") == 0) {
         ini_copy_string(cfg->card_path, sizeof(cfg->card_path), value);

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1150,6 +1150,14 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->stabilizer.manual_offset_y_px = strtof(value, NULL);
             return 0;
         }
+        if (strcasecmp(key, "guard-band-x") == 0 || strcasecmp(key, "base-crop-x") == 0) {
+            cfg->stabilizer.guard_band_x_px = strtof(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "guard-band-y") == 0 || strcasecmp(key, "base-crop-y") == 0) {
+            cfg->stabilizer.guard_band_y_px = strtof(value, NULL);
+            return 0;
+        }
         return -1;
     }
     if (strcasecmp(section, "gst") == 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1053,6 +1053,38 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "stabilizer") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->stabilizer.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "strength") == 0) {
+            cfg->stabilizer.strength = strtof(value, NULL);
+            if (cfg->stabilizer.strength <= 0.0f) {
+                cfg->stabilizer.strength = 0.1f;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "max-translation") == 0 || strcasecmp(key, "translation") == 0) {
+            cfg->stabilizer.max_translation_px = strtof(value, NULL);
+            if (cfg->stabilizer.max_translation_px <= 0.0f) {
+                cfg->stabilizer.max_translation_px = 1.0f;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "max-rotation") == 0 || strcasecmp(key, "rotation") == 0) {
+            cfg->stabilizer.max_rotation_deg = strtof(value, NULL);
+            if (cfg->stabilizer.max_rotation_deg < 0.0f) {
+                cfg->stabilizer.max_rotation_deg = 0.0f;
+            }
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "gst") == 0) {
         if (strcasecmp(key, "log") == 0) {
             int v = 0;

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -3,12 +3,14 @@
 #include "drm_props.h"
 #include "idr_requester.h"
 #include "logging.h"
+#include "video_stabilizer.h"
 
 #include <errno.h>
 #include <fcntl.h>
 #include <math.h>
 #include <string.h>
 #include <stdint.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <time.h>
 #include <unistd.h>
@@ -40,6 +42,9 @@ struct FrameSlot {
     int prime_fd;
     uint32_t fb_id;
     uint32_t handle;
+    int processed_prime_fd;
+    uint32_t processed_fb_id;
+    uint32_t processed_handle;
 };
 
 struct VideoDecoder {
@@ -69,6 +74,8 @@ struct VideoDecoder {
     uint32_t prop_src_y;
     uint32_t prop_src_w;
     uint32_t prop_src_h;
+    uint32_t prop_in_fence_fd;
+    uint32_t prop_out_fence_ptr;
 
     MppCtx ctx;
     MppApi *mpi;
@@ -83,11 +90,20 @@ struct VideoDecoder {
     GCond cond;
     uint32_t pending_fb;
     uint64_t pending_pts;
+    int pending_in_fence_fd;
+    uint32_t pending_src_w;
+    uint32_t pending_src_h;
 
     GThread *frame_thread;
     GThread *display_thread;
 
     IdrRequester *idr_requester;
+    VideoStabilizer *stabilizer;
+    StabilizerConfig stabilizer_cfg;
+    gboolean stabilizer_ready;
+    StabilizerParams pending_stabilizer_params;
+    gboolean stabilizer_params_valid;
+    int last_out_fence_fd;
 };
 
 VideoDecoder *video_decoder_new(void) {
@@ -145,6 +161,24 @@ static inline void copy_packet_data(guint8 *dst, const guint8 *src, size_t size)
 #endif
 }
 
+static int wait_for_fence_fd(int fence_fd) {
+    if (fence_fd < 0) {
+        return 0;
+    }
+    struct pollfd pfd = {.fd = fence_fd, .events = POLLIN};
+    while (TRUE) {
+        int ret = poll(&pfd, 1, -1);
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -errno;
+        }
+        break;
+    }
+    return 0;
+}
+
 static void log_decoder_neon_status_once(void) {
     static gsize once_init = 0;
     if (g_once_init_enter(&once_init)) {
@@ -164,6 +198,9 @@ static void reset_frame_map(VideoDecoder *vd) {
         vd->frame_map[i].prime_fd = -1;
         vd->frame_map[i].fb_id = 0;
         vd->frame_map[i].handle = 0;
+        vd->frame_map[i].processed_prime_fd = -1;
+        vd->frame_map[i].processed_fb_id = 0;
+        vd->frame_map[i].processed_handle = 0;
     }
 }
 
@@ -185,12 +222,26 @@ static void release_frame_group(VideoDecoder *vd) {
             ioctl(vd->drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dmd);
             vd->frame_map[i].handle = 0;
         }
+        if (vd->frame_map[i].processed_fb_id) {
+            drmModeRmFB(vd->drm_fd, vd->frame_map[i].processed_fb_id);
+            vd->frame_map[i].processed_fb_id = 0;
+        }
+        if (vd->frame_map[i].processed_prime_fd >= 0) {
+            close(vd->frame_map[i].processed_prime_fd);
+            vd->frame_map[i].processed_prime_fd = -1;
+        }
+        if (vd->frame_map[i].processed_handle) {
+            struct drm_mode_destroy_dumb dmd_out = {.handle = vd->frame_map[i].processed_handle};
+            ioctl(vd->drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dmd_out);
+            vd->frame_map[i].processed_handle = 0;
+        }
     }
     mpp_buffer_group_clear(vd->frm_grp);
     mpp_buffer_group_put(vd->frm_grp);
     vd->frm_grp = NULL;
     vd->src_w = 0;
     vd->src_h = 0;
+    vd->stabilizer_ready = FALSE;
 }
 
 static void set_control_verbose(MppApi *mpi, MppCtx ctx, MpiCmd control, RK_U32 enable) {
@@ -228,10 +279,15 @@ static void set_mpp_decoding_parameters(VideoDecoder *vd) {
     set_control_verbose(vd->mpi, vd->ctx, MPP_DEC_SET_ENABLE_FAST_PLAY, 0xffff);
 }
 
-static int commit_plane(VideoDecoder *vd, uint32_t fb_id, uint32_t src_w, uint32_t src_h) {
+static int commit_plane(VideoDecoder *vd, uint32_t fb_id, uint32_t src_w, uint32_t src_h, int in_fence_fd,
+                        int *out_fence_fd) {
     drmModeAtomicReq *req = drmModeAtomicAlloc();
     if (!req) {
         return -1;
+    }
+
+    if (out_fence_fd) {
+        *out_fence_fd = -1;
     }
 
     if (src_w == 0) {
@@ -291,6 +347,21 @@ static int commit_plane(VideoDecoder *vd, uint32_t fb_id, uint32_t src_w, uint32
     drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_src_w, (uint64_t)src_w << 16);
     drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_src_h, (uint64_t)src_h << 16);
 
+    if (vd->prop_in_fence_fd != 0 && in_fence_fd >= 0) {
+        drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_in_fence_fd, (uint64_t)in_fence_fd);
+    } else if (in_fence_fd >= 0) {
+        int wait_ret = wait_for_fence_fd(in_fence_fd);
+        if (wait_ret != 0) {
+            LOGW("Video decoder: wait on input fence failed: %s", g_strerror(-wait_ret));
+        }
+    }
+
+    int local_out_fence_fd = -1;
+    if (vd->prop_out_fence_ptr != 0 && out_fence_fd != NULL) {
+        drmModeAtomicAddProperty(req, vd->plane_id, vd->prop_out_fence_ptr,
+                                 (uint64_t)(uintptr_t)&local_out_fence_fd);
+    }
+
     int ret = drmModeAtomicCommit(vd->drm_fd, req, DRM_MODE_ATOMIC_NONBLOCK, NULL);
     if (ret != 0 && errno == EBUSY) {
         ret = drmModeAtomicCommit(vd->drm_fd, req, 0, NULL);
@@ -298,7 +369,18 @@ static int commit_plane(VideoDecoder *vd, uint32_t fb_id, uint32_t src_w, uint32
     if (ret != 0) {
         LOGW("Atomic commit failed: %s", g_strerror(errno));
     }
+    if (vd->prop_in_fence_fd != 0 && in_fence_fd >= 0) {
+        close(in_fence_fd);
+    } else if (vd->prop_in_fence_fd == 0 && in_fence_fd >= 0) {
+        close(in_fence_fd);
+    }
+
     drmModeAtomicFree(req);
+    if (ret == 0 && vd->prop_out_fence_ptr != 0 && out_fence_fd != NULL) {
+        *out_fence_fd = local_out_fence_fd;
+    } else if (out_fence_fd) {
+        *out_fence_fd = -1;
+    }
     return ret;
 }
 
@@ -322,6 +404,15 @@ static int setup_external_buffers(VideoDecoder *vd, MppFrame frame) {
     }
 
     reset_frame_map(vd);
+
+    gboolean need_stabilizer = FALSE;
+    gboolean stabilizer_buffers_ok = TRUE;
+    if (vd->stabilizer && vd->stabilizer_cfg.enable) {
+        need_stabilizer = video_stabilizer_is_available(vd->stabilizer);
+        if (!need_stabilizer) {
+            LOGI("Video stabilizer not available; continuing without post-processing");
+        }
+    }
 
     for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
         struct drm_mode_create_dumb dmcd;
@@ -384,6 +475,64 @@ static int setup_external_buffers(VideoDecoder *vd, MppFrame frame) {
             LOGW("drmModeAddFB2 failed: %s", g_strerror(errno));
             continue;
         }
+
+        if (need_stabilizer) {
+            struct drm_mode_create_dumb dmcd_out;
+            memset(&dmcd_out, 0, sizeof(dmcd_out));
+            dmcd_out.bpp = dmcd.bpp;
+            dmcd_out.width = hor_stride;
+            dmcd_out.height = ver_stride * 2;
+
+            do {
+                ret = ioctl(vd->drm_fd, DRM_IOCTL_MODE_CREATE_DUMB, &dmcd_out);
+            } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+            if (ret != 0) {
+                LOGW("DRM_IOCTL_MODE_CREATE_DUMB (processed) failed: %s", g_strerror(errno));
+                stabilizer_buffers_ok = FALSE;
+                continue;
+            }
+            vd->frame_map[i].processed_handle = dmcd_out.handle;
+
+            struct drm_prime_handle dph_out;
+            memset(&dph_out, 0, sizeof(dph_out));
+            dph_out.handle = dmcd_out.handle;
+            dph_out.fd = -1;
+            do {
+                ret = ioctl(vd->drm_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &dph_out);
+            } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+            if (ret != 0) {
+                LOGW("PRIME_HANDLE_TO_FD (processed) failed: %s", g_strerror(errno));
+                struct drm_mode_destroy_dumb dmd_out = {.handle = dmcd_out.handle};
+                ioctl(vd->drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dmd_out);
+                vd->frame_map[i].processed_handle = 0;
+                stabilizer_buffers_ok = FALSE;
+                continue;
+            }
+            vd->frame_map[i].processed_prime_fd = dph_out.fd;
+
+            uint32_t proc_handles[4] = {0};
+            uint32_t proc_pitches[4] = {0};
+            uint32_t proc_offsets[4] = {0};
+            proc_handles[0] = vd->frame_map[i].processed_handle;
+            proc_handles[1] = vd->frame_map[i].processed_handle;
+            proc_pitches[0] = dmcd_out.pitch;
+            proc_pitches[1] = dmcd_out.pitch;
+            proc_offsets[0] = 0;
+            proc_offsets[1] = dmcd_out.pitch * ver_stride;
+
+            ret = drmModeAddFB2(vd->drm_fd, width, height, DRM_FORMAT_NV12, proc_handles, proc_pitches, proc_offsets,
+                                &vd->frame_map[i].processed_fb_id, 0);
+            if (ret != 0) {
+                LOGW("drmModeAddFB2 (processed) failed: %s", g_strerror(errno));
+                close(vd->frame_map[i].processed_prime_fd);
+                vd->frame_map[i].processed_prime_fd = -1;
+                struct drm_mode_destroy_dumb dmd_out = {.handle = dmcd_out.handle};
+                ioctl(vd->drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dmd_out);
+                vd->frame_map[i].processed_handle = 0;
+                stabilizer_buffers_ok = FALSE;
+                continue;
+            }
+        }
     }
 
     vd->mpi->control(vd->ctx, MPP_DEC_SET_EXT_BUF_GROUP, vd->frm_grp);
@@ -391,7 +540,18 @@ static int setup_external_buffers(VideoDecoder *vd, MppFrame frame) {
 
     vd->src_w = width;
     vd->src_h = height;
-    commit_plane(vd, vd->frame_map[0].fb_id, width, height);
+    if (need_stabilizer && stabilizer_buffers_ok && vd->stabilizer) {
+        if (video_stabilizer_configure(vd->stabilizer, width, height, hor_stride, ver_stride) == 0) {
+            vd->stabilizer_ready = TRUE;
+        } else {
+            LOGW("Video stabilizer: failed to configure geometry; disabling");
+            vd->stabilizer_ready = FALSE;
+        }
+    } else {
+        vd->stabilizer_ready = FALSE;
+    }
+
+    commit_plane(vd, vd->frame_map[0].fb_id, width, height, -1, NULL);
     return 0;
 }
 
@@ -434,9 +594,63 @@ static gpointer frame_thread_func(gpointer data) {
                 if (mpp_buffer_info_get(buffer, &info) == MPP_OK) {
                     for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
                         if (vd->frame_map[i].prime_fd == info.fd) {
+                            uint32_t fb_to_signal = vd->frame_map[i].fb_id;
+                            int in_fence_fd = -1;
+
+                            if (vd->stabilizer && vd->stabilizer_ready && vd->frame_map[i].processed_prime_fd >= 0 &&
+                                vd->frame_map[i].processed_fb_id != 0) {
+                                StabilizerParams params = {0};
+                                params.enable = vd->stabilizer_cfg.enable ? TRUE : FALSE;
+                                params.acquire_fence_fd = -1;
+                                params.has_transform = FALSE;
+                                params.translate_x = 0.0f;
+                                params.translate_y = 0.0f;
+                                params.rotate_deg = 0.0f;
+
+                                g_mutex_lock(&vd->lock);
+                                if (vd->stabilizer_params_valid) {
+                                    params = vd->pending_stabilizer_params;
+                                }
+                                g_mutex_unlock(&vd->lock);
+
+                                if (!vd->stabilizer_cfg.enable) {
+                                    params.enable = FALSE;
+                                }
+
+                                if (params.enable) {
+                                    int acquire_fd = mpp_frame_get_fd(frame);
+                                    if (acquire_fd >= 0 && acquire_fd != info.fd) {
+                                        params.acquire_fence_fd = dup(acquire_fd);
+                                        if (params.acquire_fence_fd < 0) {
+                                            LOGW("Video stabilizer: failed to dup acquire fence: %s", g_strerror(errno));
+                                        }
+                                    }
+                                    int release_fence_fd = -1;
+                                    int process_ret = video_stabilizer_process(vd->stabilizer, info.fd,
+                                                                               vd->frame_map[i].processed_prime_fd,
+                                                                               &params, &release_fence_fd);
+                                    if (process_ret == 0) {
+                                        fb_to_signal = vd->frame_map[i].processed_fb_id;
+                                        in_fence_fd = release_fence_fd;
+                                    } else if (process_ret < 0) {
+                                        if (release_fence_fd >= 0) {
+                                            close(release_fence_fd);
+                                        }
+                                        LOGW("Video stabilizer: processing failed (%d); using raw frame", process_ret);
+                                    }
+                                }
+                            }
+
                             g_mutex_lock(&vd->lock);
-                            vd->pending_fb = vd->frame_map[i].fb_id;
+                            if (vd->pending_in_fence_fd >= 0) {
+                                close(vd->pending_in_fence_fd);
+                                vd->pending_in_fence_fd = -1;
+                            }
+                            vd->pending_fb = fb_to_signal;
                             vd->pending_pts = mpp_frame_get_pts(frame);
+                            vd->pending_in_fence_fd = in_fence_fd;
+                            vd->pending_src_w = mpp_frame_get_width(frame);
+                            vd->pending_src_h = mpp_frame_get_height(frame);
                             g_cond_signal(&vd->cond);
                             g_mutex_unlock(&vd->lock);
                             break;
@@ -470,15 +684,33 @@ static gpointer display_thread_func(gpointer data) {
             g_cond_wait(&vd->cond, &vd->lock);
         }
         uint32_t fb = vd->pending_fb;
+        uint32_t src_w = vd->pending_src_w;
+        uint32_t src_h = vd->pending_src_h;
+        int in_fence_fd = vd->pending_in_fence_fd;
         vd->pending_fb = 0;
+        vd->pending_src_w = 0;
+        vd->pending_src_h = 0;
+        vd->pending_in_fence_fd = -1;
         gboolean still_running = vd->running;
         g_mutex_unlock(&vd->lock);
 
         if (!still_running && fb == 0) {
+            if (in_fence_fd >= 0) {
+                close(in_fence_fd);
+            }
             break;
         }
         if (fb != 0) {
-            commit_plane(vd, fb, 0, 0);
+            int out_fence_fd = -1;
+            commit_plane(vd, fb, src_w, src_h, in_fence_fd, &out_fence_fd);
+            if (out_fence_fd >= 0) {
+                if (vd->last_out_fence_fd >= 0) {
+                    close(vd->last_out_fence_fd);
+                }
+                vd->last_out_fence_fd = out_fence_fd;
+            }
+        } else if (in_fence_fd >= 0) {
+            close(in_fence_fd);
         }
         if (!still_running) {
             break;
@@ -515,6 +747,22 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
         return -1;
     }
 
+    vd->pending_in_fence_fd = -1;
+    vd->last_out_fence_fd = -1;
+    vd->stabilizer_cfg = cfg->stabilizer;
+    vd->stabilizer_params_valid = FALSE;
+    vd->stabilizer_ready = FALSE;
+    vd->stabilizer = video_stabilizer_new();
+    if (vd->stabilizer != NULL) {
+        if (video_stabilizer_init(vd->stabilizer, &vd->stabilizer_cfg) != 0) {
+            LOGW("Video stabilizer: initialization failed");
+            video_stabilizer_free(vd->stabilizer);
+            vd->stabilizer = NULL;
+        } else if (vd->stabilizer_cfg.enable && !video_stabilizer_is_available(vd->stabilizer)) {
+            LOGW("Video stabilizer requested but unavailable; continuing without it");
+        }
+    }
+
     int dup_fd = fcntl(drm_fd, F_DUPFD_CLOEXEC, 0);
     if (dup_fd < 0) {
         LOGE("Video decoder: failed to dup DRM fd: %s", g_strerror(errno));
@@ -537,6 +785,13 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
         LOGE("Video decoder: failed to query plane properties");
         video_decoder_deinit(vd);
         return -1;
+    }
+
+    if (drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "IN_FENCE_FD", &vd->prop_in_fence_fd) != 0) {
+        vd->prop_in_fence_fd = 0;
+    }
+    if (drm_get_prop_id(vd->drm_fd, vd->plane_id, DRM_MODE_OBJECT_PLANE, "OUT_FENCE_PTR", &vd->prop_out_fence_ptr) != 0) {
+        vd->prop_out_fence_ptr = 0;
     }
 
     if (mpp_create(&vd->ctx, &vd->mpi) != MPP_OK) {
@@ -594,6 +849,21 @@ void video_decoder_deinit(VideoDecoder *vd) {
     }
 
     video_decoder_stop(vd);
+
+    if (vd->pending_in_fence_fd >= 0) {
+        close(vd->pending_in_fence_fd);
+        vd->pending_in_fence_fd = -1;
+    }
+    if (vd->last_out_fence_fd >= 0) {
+        close(vd->last_out_fence_fd);
+        vd->last_out_fence_fd = -1;
+    }
+
+    if (vd->stabilizer) {
+        video_stabilizer_free(vd->stabilizer);
+        vd->stabilizer = NULL;
+        vd->stabilizer_ready = FALSE;
+    }
 
     if (vd->packet) {
         mpp_packet_deinit(&vd->packet);
@@ -757,4 +1027,23 @@ void video_decoder_set_idr_requester(VideoDecoder *vd, IdrRequester *requester) 
         return;
     }
     vd->idr_requester = requester;
+}
+
+void video_decoder_set_stabilizer_params(VideoDecoder *vd, const StabilizerParams *params) {
+    if (vd == NULL) {
+        return;
+    }
+    if (vd->lock_initialized) {
+        g_mutex_lock(&vd->lock);
+    }
+    if (params != NULL) {
+        vd->pending_stabilizer_params = *params;
+        vd->stabilizer_params_valid = TRUE;
+    } else {
+        memset(&vd->pending_stabilizer_params, 0, sizeof(vd->pending_stabilizer_params));
+        vd->stabilizer_params_valid = FALSE;
+    }
+    if (vd->lock_initialized) {
+        g_mutex_unlock(&vd->lock);
+    }
 }

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -19,6 +19,12 @@
 #include <rockchip/rk_mpi.h>
 #include <rockchip/mpp_err.h>
 
+#if defined(__GNUC__)
+extern int mpp_frame_get_fd(MppFrame frame) __attribute__((weak));
+#else
+extern int mpp_frame_get_fd(MppFrame frame);
+#endif
+
 #if defined(PIXELPILOT_DISABLE_NEON)
 #define PIXELPILOT_NEON_AVAILABLE 0
 #elif defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(PIXELPILOT_HAS_NEON)
@@ -618,7 +624,10 @@ static gpointer frame_thread_func(gpointer data) {
                                 }
 
                                 if (params.enable) {
-                                    int acquire_fd = mpp_frame_get_fd(frame);
+                                    int acquire_fd = -1;
+                                    if (mpp_frame_get_fd) {
+                                        acquire_fd = mpp_frame_get_fd(frame);
+                                    }
                                     if (acquire_fd >= 0 && acquire_fd != info.fd) {
                                         params.acquire_fence_fd = dup(acquire_fd);
                                         if (params.acquire_fence_fd < 0) {

--- a/src/video_stabilizer.c
+++ b/src/video_stabilizer.c
@@ -235,7 +235,8 @@ int video_stabilizer_process(VideoStabilizer *stabilizer, int in_fd, int out_fd,
     }
     gboolean force_demo =
         stabilizer->config.demo_enable && stabilizer->config.demo_amplitude_px > 0.0f;
-    if (params && !params->enable && !force_demo) {
+    gboolean manual_override = stabilizer->config.manual_enable;
+    if (params && !params->enable && !force_demo && !manual_override) {
         if (stabilizer->config.diagnostics && !stabilizer->diag_logged_no_params) {
             LOGI("Video stabilizer bypassed: per-frame parameters disabled");
             stabilizer->diag_logged_no_params = TRUE;

--- a/src/video_stabilizer.c
+++ b/src/video_stabilizer.c
@@ -152,6 +152,7 @@ static int wait_for_fence(int fence_fd) {
     return 0;
 }
 
+#if PIXELPILOT_HAVE_RGA
 static int stabilizer_apply_transform(const StabilizerParams *params) {
     if (params == NULL) {
         return 0;
@@ -164,6 +165,7 @@ static int stabilizer_apply_transform(const StabilizerParams *params) {
     }
     return 0;
 }
+#endif
 
 int video_stabilizer_process(VideoStabilizer *stabilizer, int in_fd, int out_fd,
                              const StabilizerParams *params, int *release_fence_fd) {

--- a/src/video_stabilizer.c
+++ b/src/video_stabilizer.c
@@ -1,0 +1,277 @@
+#include "video_stabilizer.h"
+
+#include "logging.h"
+
+#include <errno.h>
+#include <glib.h>
+#include <math.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#if PIXELPILOT_HAVE_RGA
+#include <rga/RgaApi.h>
+#include <rga/rga.h>
+#endif
+
+struct VideoStabilizer {
+    StabilizerConfig config;
+    gboolean initialized;
+    gboolean configured;
+    gboolean available;
+    uint32_t width;
+    uint32_t height;
+    uint32_t hor_stride;
+    uint32_t ver_stride;
+};
+
+VideoStabilizer *video_stabilizer_new(void) {
+    return g_new0(VideoStabilizer, 1);
+}
+
+void video_stabilizer_free(VideoStabilizer *stabilizer) {
+    if (stabilizer == NULL) {
+        return;
+    }
+    video_stabilizer_shutdown(stabilizer);
+    g_free(stabilizer);
+}
+
+static void stabilizer_copy_defaults(StabilizerConfig *cfg) {
+    if (cfg == NULL) {
+        return;
+    }
+    if (cfg->strength <= 0.0f) {
+        cfg->strength = 1.0f;
+    }
+    if (cfg->max_translation_px <= 0.0f) {
+        cfg->max_translation_px = 32.0f;
+    }
+    if (cfg->max_rotation_deg <= 0.0f) {
+        cfg->max_rotation_deg = 5.0f;
+    }
+}
+
+int video_stabilizer_init(VideoStabilizer *stabilizer, const StabilizerConfig *config) {
+    if (stabilizer == NULL) {
+        return -EINVAL;
+    }
+    memset(stabilizer, 0, sizeof(*stabilizer));
+
+    StabilizerConfig cfg = {0};
+    if (config) {
+        cfg = *config;
+    }
+    stabilizer_copy_defaults(&cfg);
+
+    stabilizer->config = cfg;
+    stabilizer->initialized = TRUE;
+#if PIXELPILOT_HAVE_RGA
+    stabilizer->available = cfg.enable ? TRUE : FALSE;
+#else
+    if (cfg.enable) {
+        LOGW("Video stabilizer requested but librga support is not available at build time");
+    }
+    stabilizer->available = FALSE;
+#endif
+    return 0;
+}
+
+void video_stabilizer_shutdown(VideoStabilizer *stabilizer) {
+    if (stabilizer == NULL) {
+        return;
+    }
+    stabilizer->initialized = FALSE;
+    stabilizer->configured = FALSE;
+    stabilizer->available = FALSE;
+    stabilizer->width = 0;
+    stabilizer->height = 0;
+    stabilizer->hor_stride = 0;
+    stabilizer->ver_stride = 0;
+}
+
+int video_stabilizer_update(VideoStabilizer *stabilizer, const StabilizerConfig *config) {
+    if (stabilizer == NULL) {
+        return -EINVAL;
+    }
+    if (!stabilizer->initialized) {
+        return video_stabilizer_init(stabilizer, config);
+    }
+    StabilizerConfig cfg = stabilizer->config;
+    if (config) {
+        cfg = *config;
+    }
+    stabilizer_copy_defaults(&cfg);
+    stabilizer->config = cfg;
+#if PIXELPILOT_HAVE_RGA
+    stabilizer->available = cfg.enable ? TRUE : FALSE;
+#else
+    if (cfg.enable) {
+        LOGW("Video stabilizer requested but librga support is not available at build time");
+    }
+    stabilizer->available = FALSE;
+#endif
+    return 0;
+}
+
+int video_stabilizer_configure(VideoStabilizer *stabilizer, uint32_t width, uint32_t height,
+                               uint32_t hor_stride, uint32_t ver_stride) {
+    if (stabilizer == NULL) {
+        return -EINVAL;
+    }
+    if (!stabilizer->initialized) {
+        return -EINVAL;
+    }
+    stabilizer->width = width;
+    stabilizer->height = height;
+    stabilizer->hor_stride = hor_stride;
+    stabilizer->ver_stride = ver_stride;
+    stabilizer->configured = TRUE;
+    return 0;
+}
+
+static int wait_for_fence(int fence_fd) {
+    if (fence_fd < 0) {
+        return 0;
+    }
+    struct pollfd pfd = {.fd = fence_fd, .events = POLLIN};
+    while (TRUE) {
+        int ret = poll(&pfd, 1, -1);
+        if (ret == 0) {
+            continue;
+        }
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -errno;
+        }
+        break;
+    }
+    return 0;
+}
+
+static int stabilizer_apply_transform(const StabilizerParams *params) {
+    if (params == NULL) {
+        return 0;
+    }
+    if (params->has_transform) {
+        return 1;
+    }
+    if (params->translate_x != 0.0f || params->translate_y != 0.0f || params->rotate_deg != 0.0f) {
+        return 1;
+    }
+    return 0;
+}
+
+int video_stabilizer_process(VideoStabilizer *stabilizer, int in_fd, int out_fd,
+                             const StabilizerParams *params, int *release_fence_fd) {
+    if (release_fence_fd) {
+        *release_fence_fd = -1;
+    }
+    if (stabilizer == NULL || !stabilizer->initialized) {
+        return -EINVAL;
+    }
+    if (!stabilizer->config.enable || !stabilizer->available) {
+        return 1; // bypass
+    }
+    if (!stabilizer->configured) {
+        LOGW("Video stabilizer invoked without frame configuration");
+        return -EINVAL;
+    }
+    if (params && !params->enable) {
+        return 1;
+    }
+    int fence_fd = params ? params->acquire_fence_fd : -1;
+    if (fence_fd >= 0) {
+        int wait_ret = wait_for_fence(fence_fd);
+        if (wait_ret != 0) {
+            LOGW("Video stabilizer: acquire fence wait failed: %s", g_strerror(-wait_ret));
+            close(fence_fd);
+            return wait_ret;
+        }
+        close(fence_fd);
+        fence_fd = -1;
+    }
+
+#if PIXELPILOT_HAVE_RGA
+    rga_info_t src;
+    rga_info_t dst;
+    memset(&src, 0, sizeof(src));
+    memset(&dst, 0, sizeof(dst));
+
+    src.fd = in_fd;
+    src.mmuFlag = 1;
+    src.format = RK_FORMAT_YCbCr_420_SP;
+    src.blend = 0;
+    src.rect.x = 0;
+    src.rect.y = 0;
+    src.rect.w = (int)stabilizer->width;
+    src.rect.h = (int)stabilizer->height;
+    src.rect.wstride = (int)stabilizer->hor_stride;
+    src.rect.hstride = (int)stabilizer->ver_stride;
+
+    dst.fd = out_fd;
+    dst.mmuFlag = 1;
+    dst.format = RK_FORMAT_YCbCr_420_SP;
+    dst.blend = 0;
+    dst.rect.x = 0;
+    dst.rect.y = 0;
+    dst.rect.w = (int)stabilizer->width;
+    dst.rect.h = (int)stabilizer->height;
+    dst.rect.wstride = (int)stabilizer->hor_stride;
+    dst.rect.hstride = (int)stabilizer->ver_stride;
+
+    if (stabilizer_apply_transform(params)) {
+        if (params && params->has_transform) {
+            LOGW("Video stabilizer: affine matrix transforms not implemented; falling back to translation-only");
+        }
+        if (params && params->rotate_deg != 0.0f) {
+            LOGW("Video stabilizer: rotation %.2f deg requested but not currently supported", params->rotate_deg);
+        }
+        int tx = 0;
+        int ty = 0;
+        if (params) {
+            tx = (int)lroundf(params->translate_x * stabilizer->config.strength);
+            ty = (int)lroundf(params->translate_y * stabilizer->config.strength);
+            if (tx > (int)stabilizer->config.max_translation_px) {
+                tx = (int)stabilizer->config.max_translation_px;
+            }
+            if (tx < -(int)stabilizer->config.max_translation_px) {
+                tx = -(int)stabilizer->config.max_translation_px;
+            }
+            if (ty > (int)stabilizer->config.max_translation_px) {
+                ty = (int)stabilizer->config.max_translation_px;
+            }
+            if (ty < -(int)stabilizer->config.max_translation_px) {
+                ty = -(int)stabilizer->config.max_translation_px;
+            }
+        }
+        src.rect.x = CLAMP(tx, -(int)stabilizer->hor_stride / 4, (int)stabilizer->hor_stride / 4);
+        src.rect.y = CLAMP(ty, -(int)stabilizer->ver_stride / 4, (int)stabilizer->ver_stride / 4);
+        src.rect.x = CLAMP(src.rect.x, 0, (int)stabilizer->hor_stride - (int)stabilizer->width);
+        src.rect.y = CLAMP(src.rect.y, 0, (int)stabilizer->ver_stride - (int)stabilizer->height);
+    }
+
+    int ret = c_RkRgaBlit(&src, &dst, NULL);
+    if (ret != 0) {
+        LOGW("Video stabilizer: RGA blit failed (%d)", ret);
+        return -EIO;
+    }
+    c_RkRgaFlush();
+    if (release_fence_fd) {
+        *release_fence_fd = -1;
+    }
+    return 0;
+#else
+    (void)in_fd;
+    (void)out_fd;
+    (void)params;
+    return 1;
+#endif
+}
+
+gboolean video_stabilizer_is_available(const VideoStabilizer *stabilizer) {
+    return stabilizer != NULL && stabilizer->available;
+}

--- a/tests/video_stabilizer_test.c
+++ b/tests/video_stabilizer_test.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>

--- a/tests/video_stabilizer_test.c
+++ b/tests/video_stabilizer_test.c
@@ -1,0 +1,158 @@
+#include "video_stabilizer.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+static int create_nv12_buffer(int drm_fd, uint32_t width, uint32_t height, uint32_t *handle_out, int *prime_fd_out,
+                              uint32_t *pitch_out) {
+    struct drm_mode_create_dumb dmcd;
+    memset(&dmcd, 0, sizeof(dmcd));
+    dmcd.bpp = 8;
+    dmcd.width = width;
+    dmcd.height = height * 2;
+    if (ioctl(drm_fd, DRM_IOCTL_MODE_CREATE_DUMB, &dmcd) != 0) {
+        return -1;
+    }
+    struct drm_prime_handle dph;
+    memset(&dph, 0, sizeof(dph));
+    dph.handle = dmcd.handle;
+    dph.fd = -1;
+    if (ioctl(drm_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &dph) != 0) {
+        struct drm_mode_destroy_dumb destroy_req = {.handle = dmcd.handle};
+        ioctl(drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destroy_req);
+        return -1;
+    }
+    if (handle_out) {
+        *handle_out = dmcd.handle;
+    }
+    if (prime_fd_out) {
+        *prime_fd_out = dph.fd;
+    }
+    if (pitch_out) {
+        *pitch_out = dmcd.pitch;
+    }
+    return 0;
+}
+
+static void destroy_buffer(int drm_fd, uint32_t handle, int prime_fd) {
+    if (prime_fd >= 0) {
+        close(prime_fd);
+    }
+    if (handle != 0) {
+        struct drm_mode_destroy_dumb destroy_req = {.handle = handle};
+        ioctl(drm_fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destroy_req);
+    }
+}
+
+int main(void) {
+    StabilizerConfig cfg = {0};
+    cfg.enable = 0;
+    cfg.strength = 1.0f;
+    cfg.max_translation_px = 16.0f;
+    cfg.max_rotation_deg = 5.0f;
+
+    VideoStabilizer *stabilizer = video_stabilizer_new();
+    assert(stabilizer != NULL);
+    assert(video_stabilizer_init(stabilizer, &cfg) == 0);
+
+    StabilizerParams params;
+    memset(&params, 0, sizeof(params));
+    params.enable = TRUE;
+    params.acquire_fence_fd = -1;
+
+    int release_fd = -1;
+    int ret = video_stabilizer_process(stabilizer, -1, -1, &params, &release_fd);
+    assert(ret == 1);
+    assert(release_fd == -1);
+
+    cfg.enable = 1;
+    video_stabilizer_update(stabilizer, &cfg);
+
+    if (!video_stabilizer_is_available(stabilizer)) {
+        printf("librga unavailable; skipping DMA smoke test\n");
+        video_stabilizer_free(stabilizer);
+        return 0;
+    }
+
+    const char *drm_candidates[] = {"/dev/dri/renderD128", "/dev/dri/renderD129", "/dev/dri/card0"};
+    int drm_fd = -1;
+    for (size_t i = 0; i < G_N_ELEMENTS(drm_candidates); ++i) {
+        drm_fd = open(drm_candidates[i], O_RDWR | O_CLOEXEC);
+        if (drm_fd >= 0) {
+            break;
+        }
+    }
+    if (drm_fd < 0) {
+        printf("DRM device unavailable; skipping DMA smoke test\n");
+        video_stabilizer_free(stabilizer);
+        return 0;
+    }
+
+    uint32_t src_handle = 0;
+    int src_prime = -1;
+    uint32_t pitch = 0;
+    if (create_nv12_buffer(drm_fd, 64, 64, &src_handle, &src_prime, &pitch) != 0) {
+        printf("Failed to allocate source buffer: %s\n", g_strerror(errno));
+        close(drm_fd);
+        video_stabilizer_free(stabilizer);
+        return 1;
+    }
+
+    uint32_t dst_handle = 0;
+    int dst_prime = -1;
+    if (create_nv12_buffer(drm_fd, 64, 64, &dst_handle, &dst_prime, NULL) != 0) {
+        printf("Failed to allocate destination buffer: %s\n", g_strerror(errno));
+        destroy_buffer(drm_fd, src_handle, src_prime);
+        close(drm_fd);
+        video_stabilizer_free(stabilizer);
+        return 1;
+    }
+
+    if (video_stabilizer_configure(stabilizer, 64, 64, pitch, 64) != 0) {
+        printf("Failed to configure stabilizer geometry\n");
+        destroy_buffer(drm_fd, dst_handle, dst_prime);
+        destroy_buffer(drm_fd, src_handle, src_prime);
+        close(drm_fd);
+        video_stabilizer_free(stabilizer);
+        return 1;
+    }
+
+    memset(&params, 0, sizeof(params));
+    params.enable = TRUE;
+    params.acquire_fence_fd = -1;
+    params.translate_x = 2.0f;
+    params.translate_y = -1.5f;
+
+    release_fd = -1;
+    ret = video_stabilizer_process(stabilizer, src_prime, dst_prime, &params, &release_fd);
+    if (ret != 0) {
+        printf("video_stabilizer_process failed (%d)\n", ret);
+        if (release_fd >= 0) {
+            close(release_fd);
+        }
+        destroy_buffer(drm_fd, dst_handle, dst_prime);
+        destroy_buffer(drm_fd, src_handle, src_prime);
+        close(drm_fd);
+        video_stabilizer_free(stabilizer);
+        return 1;
+    }
+    if (release_fd >= 0) {
+        close(release_fd);
+    }
+
+    destroy_buffer(drm_fd, dst_handle, dst_prime);
+    destroy_buffer(drm_fd, src_handle, src_prime);
+    close(drm_fd);
+    video_stabilizer_free(stabilizer);
+    printf("Video stabilizer smoke test completed successfully\n");
+    return 0;
+}

--- a/tests/video_stabilizer_test.c
+++ b/tests/video_stabilizer_test.c
@@ -67,6 +67,8 @@ int main(void) {
     cfg.manual_enable = 0;
     cfg.manual_offset_x_px = 0.0f;
     cfg.manual_offset_y_px = 0.0f;
+    cfg.guard_band_x_px = -1.0f;
+    cfg.guard_band_y_px = -1.0f;
 
     VideoStabilizer *stabilizer = video_stabilizer_new();
     assert(stabilizer != NULL);
@@ -188,6 +190,8 @@ int main(void) {
     cfg.manual_enable = 1;
     cfg.manual_offset_x_px = 4.0f;
     cfg.manual_offset_y_px = 0.0f;
+    cfg.guard_band_x_px = 8.0f;
+    cfg.guard_band_y_px = 8.0f;
     video_stabilizer_update(stabilizer, &cfg);
 
     memset(&params, 0, sizeof(params));


### PR DESCRIPTION
## Summary
- add a librga-backed video stabilizer module with runtime configuration hooks
- allocate processed DRM buffer pools and run the stabilizer in the frame thread with fence propagation
- document the stabilizer pipeline and add a smoke test harness for DMA-BUF processing

## Testing
- make test *(fails: missing glib development headers in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68f2afcd60d4832b95a819e30af2098d