### PR TITLE
Add external zoom control via OSD text command

### DIFF
--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -91,9 +91,12 @@ When the helper thread observes that `clock_gettime(CLOCK_MONOTONIC)` exceeds
 * The DRM plane can only upscale by a factor of four in either direction, so the
   receiver enforces a minimum crop size to stay within that limit. Requests that
   would require more magnification are automatically widened or heightened to the
-  smallest allowed size and a log entry records the adjustment. On a 1080p output
-  fed with a 1920-pixel-wide stream, this means percentages below roughly
-  `25,25` cannot be honoured.
+  smallest allowed size and a log entry records the adjustment. After that clamp,
+  the crop is rounded to the chroma-aligned sizes that the Rockchip plane
+  accepts: widths and heights snap to four-pixel increments and the origin lands
+  on an even pixel. Expect the applied percentages in the log to differ slightly
+  from what was requested. On a 1080p output fed with a 1280×720 stream, this
+  means percentages much below `25,38` cannot be honoured.
 * Commands are debounced: the receiver only reprograms the plane when the text
   changes. Publish the same string again only when refreshing its TTL.
 * Include `ttl_ms` with every zoom update so the request naturally expires when

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -88,6 +88,12 @@ When the helper thread observes that `clock_gettime(CLOCK_MONOTONIC)` exceeds
   partially off-screen (for example `50,50,100,100`), the window is nudged back
   inside the frame before programming the plane. Any rejection or clamp is logged
   once when the command is applied.
+* The DRM plane can only upscale by a factor of four in either direction, so the
+  receiver enforces a minimum crop size to stay within that limit. Requests that
+  would require more magnification are automatically widened or heightened to the
+  smallest allowed size and a log entry records the adjustment. On a 1080p output
+  fed with a 1920-pixel-wide stream, this means percentages below roughly
+  `25,25` cannot be honoured.
 * Commands are debounced: the receiver only reprograms the plane when the text
   changes. Publish the same string again only when refreshing its TTL.
 * Include `ttl_ms` with every zoom update so the request naturally expires when

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -76,5 +76,6 @@ int pipeline_enable_recording(PipelineState *ps, const RecordCfg *cfg);
 void pipeline_disable_recording(PipelineState *ps);
 int pipeline_get_recording_stats(const PipelineState *ps, PipelineRecordingStats *stats);
 gboolean pipeline_consume_reinit_request(PipelineState *ps);
+void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRect *rect);
 
 #endif // PIPELINE_H

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -76,6 +76,6 @@ int pipeline_enable_recording(PipelineState *ps, const RecordCfg *cfg);
 void pipeline_disable_recording(PipelineState *ps);
 int pipeline_get_recording_stats(const PipelineState *ps, PipelineRecordingStats *stats);
 gboolean pipeline_consume_reinit_request(PipelineState *ps);
-void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRect *rect);
+void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRequest *request);
 
 #endif // PIPELINE_H

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -12,6 +12,13 @@
 typedef struct VideoDecoder VideoDecoder;
 
 typedef struct {
+    guint32 scale_x_percent;
+    guint32 scale_y_percent;
+    guint32 center_x_percent;
+    guint32 center_y_percent;
+} VideoDecoderZoomRequest;
+
+typedef struct {
     guint32 x;
     guint32 y;
     guint32 w;
@@ -32,7 +39,7 @@ void video_decoder_send_eos(VideoDecoder *vd);
 
 void video_decoder_set_idr_requester(VideoDecoder *vd, IdrRequester *requester);
 
-int video_decoder_set_zoom(VideoDecoder *vd, gboolean enabled, const VideoDecoderZoomRect *rect);
+int video_decoder_set_zoom(VideoDecoder *vd, gboolean enabled, const VideoDecoderZoomRequest *request);
 
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
 

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -11,6 +11,13 @@
 
 typedef struct VideoDecoder VideoDecoder;
 
+typedef struct {
+    guint32 x;
+    guint32 y;
+    guint32 w;
+    guint32 h;
+} VideoDecoderZoomRect;
+
 VideoDecoder *video_decoder_new(void);
 void video_decoder_free(VideoDecoder *vd);
 
@@ -24,6 +31,8 @@ int video_decoder_feed(VideoDecoder *vd, const guint8 *data, size_t size);
 void video_decoder_send_eos(VideoDecoder *vd);
 
 void video_decoder_set_idr_requester(VideoDecoder *vd, IdrRequester *requester);
+
+int video_decoder_set_zoom(VideoDecoder *vd, gboolean enabled, const VideoDecoderZoomRect *rect);
 
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "sse_streamer.h"
 #include "udev_monitor.h"
 
+#include <glib.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sched.h>
@@ -91,6 +92,79 @@ static int write_pid_file(void) {
     close(fd);
     atexit(remove_instance_pid);
     return 0;
+}
+
+static gboolean parse_zoom_command(const char *cmd, gboolean *out_enabled, VideoDecoderZoomRect *out_rect) {
+    if (out_enabled == NULL || out_rect == NULL) {
+        return FALSE;
+    }
+    if (cmd == NULL) {
+        return FALSE;
+    }
+
+    const char *p = cmd;
+    while (*p != '\0' && g_ascii_isspace(*p)) {
+        ++p;
+    }
+    if (*p == '\0') {
+        *out_enabled = FALSE;
+        memset(out_rect, 0, sizeof(*out_rect));
+        return TRUE;
+    }
+    if (g_ascii_strncasecmp(p, "zoom=", 5) != 0) {
+        return FALSE;
+    }
+    p += 5;
+    while (*p != '\0' && g_ascii_isspace(*p)) {
+        ++p;
+    }
+    if (*p == '\0') {
+        return FALSE;
+    }
+    if (g_ascii_strcasecmp(p, "off") == 0) {
+        *out_enabled = FALSE;
+        memset(out_rect, 0, sizeof(*out_rect));
+        return TRUE;
+    }
+
+    char buf[OSD_EXTERNAL_TEXT_LEN];
+    g_strlcpy(buf, p, sizeof(buf));
+    GStrv tokens = g_strsplit(buf, ",", 0);
+    guint32 values[4] = {0};
+    int idx = 0;
+    gboolean ok = TRUE;
+
+    for (char **it = tokens; ok && it != NULL && *it != NULL; ++it) {
+        if (idx >= 4) {
+            ok = FALSE;
+            break;
+        }
+        char *token = g_strstrip(*it);
+        if (token[0] == '\0') {
+            ok = FALSE;
+            break;
+        }
+        errno = 0;
+        char *end = NULL;
+        long long v = g_ascii_strtoll(token, &end, 10);
+        if (errno != 0 || end == token || *end != '\0' || v < 0 || v > G_MAXUINT32) {
+            ok = FALSE;
+            break;
+        }
+        values[idx++] = (guint32)v;
+    }
+    g_strfreev(tokens);
+
+    if (!ok || idx != 4) {
+        return FALSE;
+    }
+
+    out_rect->w = values[0];
+    out_rect->h = values[1];
+    out_rect->x = values[2];
+    out_rect->y = values[3];
+    *out_enabled = TRUE;
+    return TRUE;
 }
 
 static int ensure_single_instance(void) {
@@ -304,6 +378,7 @@ int main(int argc, char **argv) {
     struct timespec last_hp = {0, 0};
     struct timespec last_osd;
     clock_gettime(CLOCK_MONOTONIC, &last_osd);
+    char last_zoom_command[OSD_EXTERNAL_TEXT_LEN] = "";
 
     while (!g_exit_flag) {
         pipeline_poll_child(&ps);
@@ -487,6 +562,24 @@ int main(int argc, char **argv) {
             if (ms_since(now, last_osd) >= cfg.osd_refresh_ms) {
                 OsdExternalFeedSnapshot ext_snapshot;
                 osd_external_get_snapshot(&ext_bridge, &ext_snapshot);
+                const char *zoom_text = ext_snapshot.text[OSD_EXTERNAL_MAX_TEXT - 1];
+                if (g_strcmp0(zoom_text, last_zoom_command) != 0) {
+                    gboolean zoom_enabled = FALSE;
+                    VideoDecoderZoomRect zoom_rect = {0};
+                    if (parse_zoom_command(zoom_text, &zoom_enabled, &zoom_rect)) {
+                        if (zoom_enabled) {
+                            pipeline_apply_zoom_command(&ps, TRUE, &zoom_rect);
+                        } else {
+                            pipeline_apply_zoom_command(&ps, FALSE, NULL);
+                        }
+                    } else if (zoom_text != NULL && zoom_text[0] != '\0') {
+                        LOGW("External zoom command ignored: expected 'zoom=WIDTH,HEIGHT,X,Y' or 'zoom=off' (got '%s')",
+                             zoom_text);
+                    } else if (last_zoom_command[0] != '\0') {
+                        pipeline_apply_zoom_command(&ps, FALSE, NULL);
+                    }
+                    g_strlcpy(last_zoom_command, zoom_text != NULL ? zoom_text : "", sizeof(last_zoom_command));
+                }
                 osd_update_stats(fd, &cfg, &ms, &ps, audio_disabled, restart_count, &ext_snapshot, &osd);
                 last_osd = now;
             }

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1571,7 +1571,7 @@ gboolean pipeline_consume_reinit_request(PipelineState *ps) {
     return requested;
 }
 
-void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRect *rect) {
+void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRequest *request) {
     if (ps == NULL) {
         return;
     }
@@ -1591,7 +1591,7 @@ void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const Vide
         return;
     }
 
-    int ret = video_decoder_set_zoom(decoder, enabled, enabled ? rect : NULL);
+    int ret = video_decoder_set_zoom(decoder, enabled, enabled ? request : NULL);
     if (ret != 0 && enabled) {
         LOGW("Pipeline: zoom enable request was rejected");
     }


### PR DESCRIPTION
## Summary
- add persistent zoom state to the video decoder and program the plane SRC window when cropping is enabled
- parse `ext.text8` commands from the external OSD snapshot and route them through a new pipeline helper to update zoom at runtime
- document the zoom/crop command format, including TTL guidance for publishers

## Testing
- make *(fails: missing xf86drm.h on the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d8b1f5a4832b9270676d3111aa0f