### PR TITLE
Restore DRM state on shutdown

### DIFF
--- a/include/drm_modeset.h
+++ b/include/drm_modeset.h
@@ -3,6 +3,16 @@
 
 #include <stdint.h>
 
+#if defined(__has_include)
+#if __has_include(<libdrm/xf86drmMode.h>)
+#include <libdrm/xf86drmMode.h>
+#else
+#include <xf86drmMode.h>
+#endif
+#else
+#include <libdrm/xf86drmMode.h>
+#endif
+
 #include "config.h"
 
 typedef struct {
@@ -11,9 +21,18 @@ typedef struct {
     int mode_w;
     int mode_h;
     int mode_hz;
+    uint32_t prev_fb_id;
+    int prev_x;
+    int prev_y;
+    int prev_mode_valid;
+    drmModeModeInfo prev_mode;
+    uint32_t *prev_connectors;
+    int prev_connector_count;
 } ModesetResult;
 
 int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResult *out);
+int atomic_modeset_restore(int fd, const ModesetResult *ms);
+void modeset_result_cleanup(ModesetResult *ms);
 int is_any_connected(int fd, const AppCfg *cfg);
 
 #endif // DRM_MODESET_H

--- a/src/main.c
+++ b/src/main.c
@@ -644,6 +644,8 @@ int main(int argc, char **argv) {
         udev_monitor_close(&um);
     }
     osd_external_stop(&ext_bridge);
+    atomic_modeset_restore(fd, &ms);
+    modeset_result_cleanup(&ms);
     close(fd);
     PipelineRecordingStats rec_stats = {0};
     sse_streamer_publish(&sse_streamer, NULL, FALSE, cfg.record.enable ? TRUE : FALSE, &rec_stats);


### PR DESCRIPTION
## Summary
- capture the original CRTC framebuffer, mode, and connectors before switching into the application mode
- add helpers to restore the saved DRM state and release any allocated connector metadata
- invoke the restore routine during shutdown so the console reappears after pixelpilot exits

## Testing
- make *(fails: missing libdrm/glib headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4b5724d34832b87d1fca324947d3d