### PR TITLE
Handle per-slot TTL for external OSD feed

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -95,7 +95,8 @@ typedef struct {
     struct {
         int enable;
         int enable_set;
-        char socket_path[PATH_MAX];
+        char bind_address[64];
+        int udp_port;
     } osd_external;
 
     SplashCfg splash;

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -3,7 +3,10 @@
 
 #include <pthread.h>
 #include <stdint.h>
-#include <sys/un.h>
+
+#ifndef OSD_EXTERNAL_BIND_ADDR_LEN
+#define OSD_EXTERNAL_BIND_ADDR_LEN 64
+#endif
 
 #ifndef UNIX_PATH_MAX
 #define UNIX_PATH_MAX 108
@@ -28,19 +31,29 @@ typedef struct {
 } OsdExternalFeedSnapshot;
 
 typedef struct {
+    int text_active;
+    int value_active;
+    int is_metric;
+    uint64_t text_expiry_ns;
+    uint64_t value_expiry_ns;
+} OsdExternalSlotState;
+
+typedef struct {
     pthread_t thread;
     int thread_started;
     int stop_flag;
     int sock_fd;
-    char socket_path[UNIX_PATH_MAX];
+    char bind_address[OSD_EXTERNAL_BIND_ADDR_LEN];
+    int udp_port;
     pthread_mutex_t lock;
     OsdExternalFeedSnapshot snapshot;
     uint64_t expiry_ns;
     uint64_t last_error_log_ns;
+    OsdExternalSlotState slots[OSD_EXTERNAL_MAX_TEXT];
 } OsdExternalBridge;
 
 void osd_external_init(OsdExternalBridge *bridge);
-int osd_external_start(OsdExternalBridge *bridge, const char *socket_path);
+int osd_external_start(OsdExternalBridge *bridge, const char *bind_address, int udp_port);
 void osd_external_stop(OsdExternalBridge *bridge);
 void osd_external_get_snapshot(OsdExternalBridge *bridge, OsdExternalFeedSnapshot *out);
 const char *osd_external_status_name(OsdExternalStatus status);

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -955,11 +955,21 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->osd_external.enable_set = 1;
             return 0;
         }
-        if (strcasecmp(key, "socket") == 0 || strcasecmp(key, "path") == 0) {
-            ini_copy_string(cfg->osd_external.socket_path, sizeof(cfg->osd_external.socket_path), value);
-            if (!cfg->osd_external.enable_set && cfg->osd_external.socket_path[0] != '\0') {
-                cfg->osd_external.enable = 1;
+        if (strcasecmp(key, "udp-port") == 0 || strcasecmp(key, "port") == 0) {
+            cfg->osd_external.udp_port = atoi(value);
+            if (cfg->osd_external.udp_port > 0 && cfg->osd_external.udp_port <= 65535) {
+                if (!cfg->osd_external.enable_set) {
+                    cfg->osd_external.enable = 1;
+                }
+            } else {
+                LOGW("Ignoring invalid osd.external port value: %s", value);
+                cfg->osd_external.udp_port = 0;
             }
+            return 0;
+        }
+        if (strcasecmp(key, "bind") == 0 || strcasecmp(key, "address") == 0 ||
+            strcasecmp(key, "host") == 0) {
+            ini_copy_string(cfg->osd_external.bind_address, sizeof(cfg->osd_external.bind_address), value);
             return 0;
         }
         return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -334,11 +334,18 @@ int main(int argc, char **argv) {
     }
 
     if (cfg.osd_external.enable) {
-        if (cfg.osd_external.socket_path[0] == '\0') {
-            LOGW("External OSD feed enabled but no socket path configured; disabling listener");
+        if (cfg.osd_external.udp_port <= 0 || cfg.osd_external.udp_port > 65535) {
+            LOGW("External OSD feed enabled but invalid UDP port configured; disabling listener");
             cfg.osd_external.enable = 0;
-        } else if (osd_external_start(&ext_bridge, cfg.osd_external.socket_path) != 0) {
-            LOGW("Failed to start external OSD feed listener; continuing without external data");
+        } else {
+            const char *bind_addr = cfg.osd_external.bind_address;
+            char default_bind[] = "0.0.0.0";
+            if (!bind_addr || bind_addr[0] == '\0') {
+                bind_addr = default_bind;
+            }
+            if (osd_external_start(&ext_bridge, bind_addr, cfg.osd_external.udp_port) != 0) {
+                LOGW("Failed to start external OSD feed listener; continuing without external data");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- track per-slot activity and TTL metadata in the UDP bridge so text/value entries expire independently and respect active timers
- gate updates that omit ttl_ms while a slot is under an active TTL, mirroring the osd_ext_feed multiplexing behaviour, and recompute expiry hints accordingly
- document the per-slot TTL semantics for publishers in the external OSD feed guide

## Testing
- make *(fails: missing system dependency xf86drm.h in the container)*

------
https://chatgpt.com/codex/tasks/task_e_690680552628832b8340fd2cdd092733