### PR TITLE
Add hardware gamma LUT configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ to the defaults listed in `src/config.c` when omitted.
 | `[drm].video-plane-id` | Numeric plane ID used for the decoded video plane. |
 | `[drm].use-udev` | `true` to enable the hotplug listener that reapplies modes when connectors change. |
 | `[drm].osd-plane-id` | Optional explicit plane for the OSD overlay (0 keeps the auto-selection). |
+| `[drm].gamma-enable` | `true` uploads a hardware `GAMMA_LUT` on the active CRTC; defaults to `false`. |
+| `[drm].gamma-lut` | Path to a text file describing the LUT. Accepts one row per entry with `R G B` values (0-65535 or 0.0-1.0). Provide exactly the driver's reported size (1024 entries on RK). Relative paths resolve against the INI file. Use `identity` for the built-in passthrough curve. |
 | `[udp].port` | UDP port that the RTP stream arrives on. |
 | `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -8,6 +8,10 @@ connector = HDMI-A-1
 video-plane-id = 76
 use-udev = true
 osd-plane-id = 0
+; Optional hardware gamma LUT (text file with 1024 rows of R G B values in 0-65535 or 0.0-1.0)
+; Use "identity" to request the built-in passthrough curve.
+gamma-enable = false
+; gamma-lut = @ASSETDIR@/gamma_identity.lut
 
 [udp]
 port = 5600

--- a/include/config.h
+++ b/include/config.h
@@ -60,6 +60,11 @@ typedef struct {
 } IdrCfg;
 
 typedef struct {
+    int enable;
+    char lut_path[PATH_MAX];
+} GammaCfg;
+
+typedef struct {
     char card_path[64];
     char connector_name[32];
     char config_path[PATH_MAX];
@@ -98,6 +103,8 @@ typedef struct {
         char bind_address[64];
         int udp_port;
     } osd_external;
+
+    GammaCfg gamma;
 
     SplashCfg splash;
     RecordCfg record;

--- a/src/config.c
+++ b/src/config.c
@@ -160,6 +160,9 @@ void cfg_defaults(AppCfg *c) {
     strcpy(c->osd_external.bind_address, "0.0.0.0");
     c->osd_external.udp_port = 5005;
 
+    c->gamma.enable = 0;
+    c->gamma.lut_path[0] = '\0';
+
     c->gst_log = 0;
 
     c->cpu_affinity_present = 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -830,6 +830,18 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->osd_plane_id = atoi(value);
             return 0;
         }
+        if (strcasecmp(key, "gamma-lut") == 0 || strcasecmp(key, "gamma_lut") == 0) {
+            ini_copy_string(cfg->gamma.lut_path, sizeof(cfg->gamma.lut_path), value);
+            return 0;
+        }
+        if (strcasecmp(key, "gamma-enable") == 0 || strcasecmp(key, "gamma") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->gamma.enable = v;
+            return 0;
+        }
         if (strcasecmp(key, "use-udev") == 0) {
             int v = 0;
             if (parse_bool(value, &v) != 0) {

--- a/src/drm_modeset.c
+++ b/src/drm_modeset.c
@@ -3,9 +3,15 @@
 #include "drm_props.h"
 #include "logging.h"
 
+#include <ctype.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <strings.h>
+#include <stdint.h>
 #include <unistd.h>
 
 #if defined(__has_include)
@@ -19,9 +25,15 @@
 #else
 #include <drm/drm_fourcc.h>
 #endif
+#if __has_include(<libdrm/drm_mode.h>)
+#include <libdrm/drm_mode.h>
+#else
+#include <drm/drm_mode.h>
+#endif
 #else
 #include <libdrm/drm.h>
 #include <libdrm/drm_fourcc.h>
+#include <libdrm/drm_mode.h>
 #endif
 #include <xf86drm.h>
 #include <xf86drmMode.h>
@@ -35,6 +47,223 @@
 #ifndef DRM_PLANE_TYPE_CURSOR
 #define DRM_PLANE_TYPE_CURSOR 2
 #endif
+
+#define GAMMA_COMPONENT_MAX 65535u
+
+static char *trim_leading_ws(char *s) {
+    if (!s) {
+        return NULL;
+    }
+    while (*s && isspace((unsigned char)*s)) {
+        ++s;
+    }
+    return s;
+}
+
+static void trim_trailing_ws(char *s) {
+    if (!s) {
+        return;
+    }
+    size_t len = strlen(s);
+    while (len > 0 && isspace((unsigned char)s[len - 1])) {
+        s[--len] = '\0';
+    }
+}
+
+static int parse_gamma_component(const char *token, uint16_t *out) {
+    if (!token || !out) {
+        return -1;
+    }
+
+    errno = 0;
+    char *end = NULL;
+    if (strchr(token, '.') || strchr(token, 'e') || strchr(token, 'E')) {
+        double v = strtod(token, &end);
+        if (end == token || errno == ERANGE) {
+            return -1;
+        }
+        if (v < 0.0) {
+            v = 0.0;
+        } else if (v > 1.0) {
+            v = 1.0;
+        }
+        unsigned int scaled = (unsigned int)lrint(v * (double)GAMMA_COMPONENT_MAX);
+        if (scaled > GAMMA_COMPONENT_MAX) {
+            scaled = GAMMA_COMPONENT_MAX;
+        }
+        *out = (uint16_t)scaled;
+        return 0;
+    }
+
+    long v = strtol(token, &end, 0);
+    if (end == token || errno == ERANGE) {
+        return -1;
+    }
+    if (v < 0) {
+        v = 0;
+    } else if (v > (long)GAMMA_COMPONENT_MAX) {
+        v = (long)GAMMA_COMPONENT_MAX;
+    }
+    *out = (uint16_t)v;
+    return 0;
+}
+
+static int load_gamma_lut_data(const AppCfg *cfg, size_t expected_size, struct drm_color_lut **out_data) {
+    if (!cfg || !out_data || expected_size == 0) {
+        return -1;
+    }
+
+    const char *path = cfg->gamma.lut_path;
+    if (!path || path[0] == '\0') {
+        return -1;
+    }
+
+    if (strcasecmp(path, "identity") == 0 || strcasecmp(path, "builtin:identity") == 0) {
+        struct drm_color_lut *lut = calloc(expected_size, sizeof(*lut));
+        if (!lut) {
+            LOGE("gamma: failed to allocate identity LUT buffer (%zu entries)", expected_size);
+            return -1;
+        }
+        if (expected_size == 1) {
+            uint16_t value = (uint16_t)GAMMA_COMPONENT_MAX;
+            lut[0].red = value;
+            lut[0].green = value;
+            lut[0].blue = value;
+            lut[0].reserved = 0;
+        } else {
+            for (size_t i = 0; i < expected_size; ++i) {
+                double ratio = (double)i / (double)(expected_size - 1);
+                uint16_t value = (uint16_t)lrint(ratio * (double)GAMMA_COMPONENT_MAX);
+                if (value > GAMMA_COMPONENT_MAX) {
+                    value = (uint16_t)GAMMA_COMPONENT_MAX;
+                }
+                lut[i].red = value;
+                lut[i].green = value;
+                lut[i].blue = value;
+                lut[i].reserved = 0;
+            }
+        }
+        LOGI("gamma: using built-in identity LUT (%zu entries)", expected_size);
+        *out_data = lut;
+        return 0;
+    }
+
+    char resolved[PATH_MAX];
+    resolved[0] = '\0';
+    FILE *fp = fopen(path, "r");
+    if (fp) {
+        strncpy(resolved, path, sizeof(resolved) - 1);
+        resolved[sizeof(resolved) - 1] = '\0';
+    } else if (cfg->config_path[0] != '\0' && path[0] != '/' && path[0] != '\0') {
+        char base[PATH_MAX];
+        strncpy(base, cfg->config_path, sizeof(base) - 1);
+        base[sizeof(base) - 1] = '\0';
+        char *slash = strrchr(base, '/');
+        if (slash) {
+            slash[1] = '\0';
+            snprintf(resolved, sizeof(resolved), "%s%s", base, path);
+            fp = fopen(resolved, "r");
+        }
+        if (!fp) {
+            resolved[0] = '\0';
+        }
+    }
+
+    if (!fp) {
+        LOGE("gamma: failed to open LUT file '%s': %s", path, strerror(errno));
+        return -1;
+    }
+
+    if (resolved[0] == '\0') {
+        strncpy(resolved, path, sizeof(resolved) - 1);
+        resolved[sizeof(resolved) - 1] = '\0';
+    }
+
+    struct drm_color_lut *lut = calloc(expected_size, sizeof(*lut));
+    if (!lut) {
+        LOGE("gamma: failed to allocate LUT buffer (%zu entries)", expected_size);
+        fclose(fp);
+        return -1;
+    }
+
+    char line[512];
+    size_t index = 0;
+    while (fgets(line, sizeof(line), fp)) {
+        char *p = trim_leading_ws(line);
+        if (!p || *p == '\0') {
+            continue;
+        }
+        char *comment = strpbrk(p, "#;");
+        if (comment) {
+            *comment = '\0';
+        }
+        trim_trailing_ws(p);
+        if (*p == '\0') {
+            continue;
+        }
+
+        uint16_t values[3] = {0, 0, 0};
+        int count = 0;
+        char *save = NULL;
+        char *token = strtok_r(p, ", \t", &save);
+        while (token && count < 3) {
+            if (*token == '\0') {
+                token = strtok_r(NULL, ", \t", &save);
+                continue;
+            }
+            if (parse_gamma_component(token, &values[count]) != 0) {
+                LOGE("gamma: invalid component '%s' in %s", token, resolved);
+                free(lut);
+                fclose(fp);
+                return -1;
+            }
+            ++count;
+            token = strtok_r(NULL, ", \t", &save);
+        }
+
+        if (count == 0) {
+            continue;
+        }
+        if (count == 1) {
+            values[1] = values[0];
+            values[2] = values[0];
+            count = 3;
+        } else if (count == 2) {
+            values[2] = values[1];
+            count = 3;
+        }
+        if (count != 3) {
+            LOGE("gamma: expected 3 values per entry in %s", resolved);
+            free(lut);
+            fclose(fp);
+            return -1;
+        }
+        if (index >= expected_size) {
+            LOGE("gamma: too many entries in %s (expected %zu)", resolved, expected_size);
+            free(lut);
+            fclose(fp);
+            return -1;
+        }
+
+        lut[index].red = values[0];
+        lut[index].green = values[1];
+        lut[index].blue = values[2];
+        lut[index].reserved = 0;
+        ++index;
+    }
+
+    fclose(fp);
+
+    if (index != expected_size) {
+        LOGE("gamma: %s contained %zu entries; expected %zu", resolved, index, expected_size);
+        free(lut);
+        return -1;
+    }
+
+    LOGI("gamma: loaded %zu-entry LUT from %s", index, resolved);
+    *out_data = lut;
+    return 0;
+}
 
 static const char *conn_type_str(uint32_t t) {
     switch (t) {
@@ -203,10 +432,41 @@ int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResu
     }
 
     uint32_t crtc_active = 0, crtc_mode_id = 0;
+    uint32_t gamma_lut_prop = 0, gamma_lut_blob = 0;
     drm_get_prop_id(fd, crtc->crtc_id, DRM_MODE_OBJECT_CRTC, "ACTIVE", &crtc_active);
     drm_get_prop_id(fd, crtc->crtc_id, DRM_MODE_OBJECT_CRTC, "MODE_ID", &crtc_mode_id);
     drmModeAtomicAddProperty(req, crtc->crtc_id, crtc_active, 1);
     drmModeAtomicAddProperty(req, crtc->crtc_id, crtc_mode_id, mode_blob);
+
+    if (cfg->gamma.enable) {
+        if (cfg->gamma.lut_path[0] == '\0') {
+            LOGW("gamma: enable requested but no gamma-lut path provided; skipping upload");
+        } else {
+            int gamma_size = drmModeCrtcGetGammaSize(fd, crtc->crtc_id);
+            if (gamma_size <= 0) {
+                LOGW("gamma: CRTC %d reported LUT size %d; skipping upload", crtc->crtc_id, gamma_size);
+            } else if (drm_get_prop_id(fd, crtc->crtc_id, DRM_MODE_OBJECT_CRTC, "GAMMA_LUT", &gamma_lut_prop) != 0) {
+                LOGW("gamma: CRTC %d lacks GAMMA_LUT property; skipping upload", crtc->crtc_id);
+            } else {
+                struct drm_color_lut *gamma_data = NULL;
+                if (load_gamma_lut_data(cfg, (size_t)gamma_size, &gamma_data) == 0) {
+                    size_t blob_size = (size_t)gamma_size * sizeof(struct drm_color_lut);
+                    if (drmModeCreatePropertyBlob(fd, gamma_data, blob_size, &gamma_lut_blob) != 0) {
+                        LOGE("gamma: failed to create LUT blob: %s", strerror(errno));
+                        gamma_lut_blob = 0;
+                    } else {
+                        int add_ret = drmModeAtomicAddProperty(req, crtc->crtc_id, gamma_lut_prop, gamma_lut_blob);
+                        if (add_ret < 0) {
+                            LOGE("gamma: failed to queue LUT property: %s", strerror(-add_ret));
+                            drmModeDestroyPropertyBlob(fd, gamma_lut_blob);
+                            gamma_lut_blob = 0;
+                        }
+                    }
+                }
+                free(gamma_data);
+            }
+        }
+    }
 
     uint32_t conn_crtc_id = 0;
     drm_get_prop_id(fd, conn->connector_id, DRM_MODE_OBJECT_CONNECTOR, "CRTC_ID", &conn_crtc_id);
@@ -255,6 +515,9 @@ int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResu
     if (ret != 0) {
         LOGE("drmModeAtomicCommit failed: %s", strerror(errno));
         drmModeAtomicFree(req);
+        if (gamma_lut_blob) {
+            drmModeDestroyPropertyBlob(fd, gamma_lut_blob);
+        }
         drmModeDestroyPropertyBlob(fd, mode_blob);
         destroy_dumb_fb(fd, &fb);
         drmModeFreeConnector(conn);
@@ -266,6 +529,9 @@ int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResu
     LOGI("Atomic COMMIT: %dx%d@%d on %s via plane %d", w, h, hz, cname, cfg->plane_id);
 
     drmModeAtomicFree(req);
+    if (gamma_lut_blob) {
+        drmModeDestroyPropertyBlob(fd, gamma_lut_blob);
+    }
     drmModeDestroyPropertyBlob(fd, mode_blob);
     destroy_dumb_fb(fd, &fb);
 


### PR DESCRIPTION
## Summary
- add configuration fields and INI parsing for optional hardware gamma LUT uploads
- load gamma LUT files or the built-in identity curve and apply them via the CRTC GAMMA_LUT property during modeset
- document the new settings in the sample configuration and INI reference

## Testing
- make *(fails: missing libdrm headers in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_690a59cacbcc832bba4fdd233c63f5ae