### PR TITLE
Allow configuring CTM sharpening strength

### DIFF
--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -28,6 +28,8 @@ backend = auto
 matrix = 1,0,0,0,1,0,0,0,1
 ; Strength of the GPU luma sharpening kernel (0 disables sharpening).
 sharpness = 0.35
+; When true, render the high-pass component instead of normal video for quick verification.
+sharpness-debug = false
 
 [idr]
 ; Automatic HTTP trigger for forced IDR recovery.

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -28,8 +28,6 @@ backend = auto
 matrix = 1,0,0,0,1,0,0,0,1
 ; Strength of the GPU luma sharpening kernel (0 disables sharpening).
 sharpness = 0.35
-; When true, render the high-pass component instead of normal video for quick verification.
-sharpness-debug = false
 
 [idr]
 ; Automatic HTTP trigger for forced IDR recovery.

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -26,6 +26,8 @@ enable = false
 ; Select the processing backend: auto (default), cpu, or gpu.
 backend = auto
 matrix = 1,0,0,0,1,0,0,0,1
+; Strength of the GPU luma sharpening kernel (0 disables sharpening).
+sharpness = 0.35
 
 [idr]
 ; Automatic HTTP trigger for forced IDR recovery.

--- a/include/config.h
+++ b/include/config.h
@@ -54,6 +54,7 @@ typedef struct {
     int enable;
     VideoCtmBackend backend;
     double matrix[9];
+    double sharpness;
 } VideoCtmCfg;
 
 typedef struct {

--- a/include/config.h
+++ b/include/config.h
@@ -55,7 +55,6 @@ typedef struct {
     VideoCtmBackend backend;
     double matrix[9];
     double sharpness;
-    int sharpness_debug;
 } VideoCtmCfg;
 
 typedef struct {

--- a/include/config.h
+++ b/include/config.h
@@ -55,6 +55,7 @@ typedef struct {
     VideoCtmBackend backend;
     double matrix[9];
     double sharpness;
+    int sharpness_debug;
 } VideoCtmCfg;
 
 typedef struct {

--- a/include/video_ctm.h
+++ b/include/video_ctm.h
@@ -15,7 +15,6 @@ typedef struct VideoCtm {
     gboolean enabled;
     double matrix[9];
     double sharpness;
-    gboolean sharpness_debug;
     VideoCtmBackend backend;
     gboolean hw_supported;
     gboolean hw_applied;

--- a/include/video_ctm.h
+++ b/include/video_ctm.h
@@ -14,6 +14,7 @@ struct VideoCtmGpuState;
 typedef struct VideoCtm {
     gboolean enabled;
     double matrix[9];
+    double sharpness;
     VideoCtmBackend backend;
     gboolean hw_supported;
     gboolean hw_applied;

--- a/include/video_ctm.h
+++ b/include/video_ctm.h
@@ -15,6 +15,7 @@ typedef struct VideoCtm {
     gboolean enabled;
     double matrix[9];
     double sharpness;
+    gboolean sharpness_debug;
     VideoCtmBackend backend;
     gboolean hw_supported;
     gboolean hw_applied;

--- a/src/config.c
+++ b/src/config.c
@@ -201,6 +201,7 @@ void cfg_defaults(AppCfg *c) {
         c->video_ctm.matrix[i] = (i % 4 == 0) ? 1.0 : 0.0;
     }
     c->video_ctm.sharpness = 0.35;
+    c->video_ctm.sharpness_debug = 0;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {

--- a/src/config.c
+++ b/src/config.c
@@ -201,7 +201,6 @@ void cfg_defaults(AppCfg *c) {
         c->video_ctm.matrix[i] = (i % 4 == 0) ? 1.0 : 0.0;
     }
     c->video_ctm.sharpness = 0.35;
-    c->video_ctm.sharpness_debug = 0;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {

--- a/src/config.c
+++ b/src/config.c
@@ -200,6 +200,7 @@ void cfg_defaults(AppCfg *c) {
     for (int i = 0; i < 9; ++i) {
         c->video_ctm.matrix[i] = (i % 4 == 0) ? 1.0 : 0.0;
     }
+    c->video_ctm.sharpness = 0.35;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -994,6 +994,15 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->video_ctm.sharpness = v;
             return 0;
         }
+        if (strcasecmp(key, "sharpness-debug") == 0 || strcasecmp(key, "sharpen-debug") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                LOGE("config: video.ctm sharpness_debug expects a boolean");
+                return -1;
+            }
+            cfg->video_ctm.sharpness_debug = v;
+            return 0;
+        }
         if (strncasecmp(key, "matrix-row", 10) == 0 && strlen(key) == 11 && isdigit((unsigned char)key[10])) {
             int row = key[10] - '0';
             if (row < 0 || row > 2) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -994,15 +994,6 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->video_ctm.sharpness = v;
             return 0;
         }
-        if (strcasecmp(key, "sharpness-debug") == 0 || strcasecmp(key, "sharpen-debug") == 0) {
-            int v = 0;
-            if (parse_bool(value, &v) != 0) {
-                LOGE("config: video.ctm sharpness_debug expects a boolean");
-                return -1;
-            }
-            cfg->video_ctm.sharpness_debug = v;
-            return 0;
-        }
         if (strncasecmp(key, "matrix-row", 10) == 0 && strlen(key) == 11 && isdigit((unsigned char)key[10])) {
             int row = key[10] - '0';
             if (row < 0 || row > 2) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -985,6 +985,15 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             }
             return 0;
         }
+        if (strcasecmp(key, "sharpness") == 0 || strcasecmp(key, "sharpen-strength") == 0) {
+            double v = 0.0;
+            if (parse_double(value, &v) != 0) {
+                LOGE("config: video.ctm sharpness expects a floating point value");
+                return -1;
+            }
+            cfg->video_ctm.sharpness = v;
+            return 0;
+        }
         if (strncasecmp(key, "matrix-row", 10) == 0 && strlen(key) == 11 && isdigit((unsigned char)key[10])) {
             int row = key[10] - '0';
             if (row < 0 || row > 2) {

--- a/src/video_ctm.c
+++ b/src/video_ctm.c
@@ -50,17 +50,13 @@ typedef struct VideoCtmGpuState {
     GLint loc_tex_uv;
     GLint loc_texel;
     GLint loc_sharp_strength;
-    GLint loc_sharp_debug;
     float applied_matrix[9];
     gboolean matrix_valid;
     float applied_sharp_strength;
     gboolean sharp_strength_valid;
-    float applied_sharp_debug;
-    gboolean sharp_debug_valid;
 } VideoCtmGpuState;
 
 static gboolean video_ctm_gpu_upload_sharpness(VideoCtm *ctm);
-static gboolean video_ctm_gpu_upload_sharp_debug(VideoCtm *ctm);
 
 static const GLfloat kCtmQuadVertices[] = {
     -1.0f, -1.0f, 0.0f, 1.0f,
@@ -111,7 +107,6 @@ static GLuint video_ctm_gpu_create_program(void) {
         "uniform mat3 u_matrix;\n"
         "uniform vec2 u_texel;\n"
         "uniform float u_sharp_strength;\n"
-        "uniform float u_sharp_debug;\n"
         "varying vec2 v_texcoord;\n"
         "void main() {\n"
         "    float y_center = texture2D(u_tex_y, v_texcoord).r;\n"
@@ -123,11 +118,6 @@ static GLuint video_ctm_gpu_create_program(void) {
         "    float y_right = texture2D(u_tex_y, v_texcoord + vec2(texel.x, 0.0)).r;\n"
         "    float y_blur = (y_center * 4.0 + y_up + y_down + y_left + y_right) * 0.125;\n"
         "    float high_pass = y_center - y_blur;\n"
-        "    if (u_sharp_debug > 0.5) {\n"
-        "        float debug = clamp(0.5 + high_pass * 8.0, 0.0, 1.0);\n"
-        "        gl_FragColor = vec4(vec3(debug), 1.0);\n"
-        "        return;\n"
-        "    }\n"
         "    float y_sharp = clamp(y_center + u_sharp_strength * high_pass, 0.0, 1.0);\n"
         "    float y_adj = y_sharp * 1.16438356;\n"
         "    float u = uv.x;\n"
@@ -346,7 +336,6 @@ static gboolean video_ctm_gpu_init(VideoCtm *ctm) {
     gpu->loc_matrix = glGetUniformLocation(gpu->program, "u_matrix");
     gpu->loc_texel = glGetUniformLocation(gpu->program, "u_texel");
     gpu->loc_sharp_strength = glGetUniformLocation(gpu->program, "u_sharp_strength");
-    gpu->loc_sharp_debug = glGetUniformLocation(gpu->program, "u_sharp_debug");
     glUniform1i(gpu->loc_tex_y, 0);
     glUniform1i(gpu->loc_tex_uv, 1);
     glGenBuffers(1, &gpu->vbo);
@@ -381,10 +370,7 @@ static gboolean video_ctm_gpu_init(VideoCtm *ctm) {
     gpu->matrix_valid = FALSE;
     gpu->sharp_strength_valid = FALSE;
     gpu->applied_sharp_strength = 0.0f;
-    gpu->sharp_debug_valid = FALSE;
-    gpu->applied_sharp_debug = 0.0f;
     (void)video_ctm_gpu_upload_sharpness(ctm);
-    (void)video_ctm_gpu_upload_sharp_debug(ctm);
     return TRUE;
 }
 
@@ -475,22 +461,6 @@ static gboolean video_ctm_gpu_upload_sharpness(VideoCtm *ctm) {
     return TRUE;
 }
 
-static gboolean video_ctm_gpu_upload_sharp_debug(VideoCtm *ctm) {
-    VideoCtmGpuState *gpu = ctm != NULL ? ctm->gpu_state : NULL;
-    if (gpu == NULL || gpu->loc_sharp_debug < 0) {
-        return TRUE;
-    }
-    float debug = ctm->sharpness_debug ? 1.0f : 0.0f;
-    if (gpu->sharp_debug_valid && debug == gpu->applied_sharp_debug) {
-        return TRUE;
-    }
-    glUseProgram(gpu->program);
-    glUniform1f(gpu->loc_sharp_debug, debug);
-    gpu->applied_sharp_debug = debug;
-    gpu->sharp_debug_valid = TRUE;
-    return TRUE;
-}
-
 static gboolean video_ctm_gpu_upload_matrix(VideoCtm *ctm) {
     VideoCtmGpuState *gpu = ctm != NULL ? ctm->gpu_state : NULL;
     if (gpu == NULL) {
@@ -523,9 +493,6 @@ static gboolean video_ctm_gpu_draw(VideoCtm *ctm, int src_fd, uint32_t width, ui
         return FALSE;
     }
     if (!video_ctm_gpu_upload_sharpness(ctm)) {
-        return FALSE;
-    }
-    if (!video_ctm_gpu_upload_sharp_debug(ctm)) {
         return FALSE;
     }
     uint32_t chroma_width = (width + 1u) / 2u;
@@ -699,7 +666,6 @@ void video_ctm_init(VideoCtm *ctm, const AppCfg *cfg) {
     memset(ctm, 0, sizeof(*ctm));
     video_ctm_set_identity(ctm);
     ctm->sharpness = 0.0;
-    ctm->sharpness_debug = FALSE;
     ctm->backend = VIDEO_CTM_BACKEND_AUTO;
     ctm->hw_supported = FALSE;
     ctm->hw_applied = FALSE;
@@ -719,8 +685,7 @@ void video_ctm_init(VideoCtm *ctm, const AppCfg *cfg) {
             ctm->matrix[i] = cfg->video_ctm.matrix[i];
         }
         ctm->sharpness = cfg->video_ctm.sharpness;
-        ctm->sharpness_debug = cfg->video_ctm.sharpness_debug ? TRUE : FALSE;
-        if (ctm->sharpness != 0.0 || ctm->sharpness_debug) {
+        if (ctm->sharpness != 0.0) {
             ctm->enabled = TRUE;
         }
     }

--- a/src/video_ctm.c
+++ b/src/video_ctm.c
@@ -48,9 +48,15 @@ typedef struct VideoCtmGpuState {
     GLint loc_matrix;
     GLint loc_tex_y;
     GLint loc_tex_uv;
+    GLint loc_texel;
+    GLint loc_sharp_strength;
     float applied_matrix[9];
     gboolean matrix_valid;
+    float applied_sharp_strength;
+    gboolean sharp_strength_valid;
 } VideoCtmGpuState;
+
+static gboolean video_ctm_gpu_upload_sharpness(VideoCtm *ctm);
 
 static const GLfloat kCtmQuadVertices[] = {
     -1.0f, -1.0f, 0.0f, 1.0f,
@@ -99,11 +105,21 @@ static GLuint video_ctm_gpu_create_program(void) {
         "uniform sampler2D u_tex_y;\n"
         "uniform sampler2D u_tex_uv;\n"
         "uniform mat3 u_matrix;\n"
+        "uniform vec2 u_texel;\n"
+        "uniform float u_sharp_strength;\n"
         "varying vec2 v_texcoord;\n"
         "void main() {\n"
-        "    float y = texture2D(u_tex_y, v_texcoord).r;\n"
+        "    float y_center = texture2D(u_tex_y, v_texcoord).r;\n"
         "    vec2 uv = texture2D(u_tex_uv, v_texcoord).rg - vec2(0.5, 0.5);\n"
-        "    float y_adj = y * 1.16438356;\n"
+        "    vec2 texel = u_texel;\n"
+        "    float y_up = texture2D(u_tex_y, v_texcoord + vec2(0.0, texel.y)).r;\n"
+        "    float y_down = texture2D(u_tex_y, v_texcoord - vec2(0.0, texel.y)).r;\n"
+        "    float y_left = texture2D(u_tex_y, v_texcoord - vec2(texel.x, 0.0)).r;\n"
+        "    float y_right = texture2D(u_tex_y, v_texcoord + vec2(texel.x, 0.0)).r;\n"
+        "    float y_blur = (y_center * 4.0 + y_up + y_down + y_left + y_right) * 0.125;\n"
+        "    float high_pass = y_center - y_blur;\n"
+        "    float y_sharp = clamp(y_center + u_sharp_strength * high_pass, 0.0, 1.0);\n"
+        "    float y_adj = y_sharp * 1.16438356;\n"
         "    float u = uv.x;\n"
         "    float v = uv.y;\n"
         "    vec3 rgb = vec3(\n"
@@ -318,6 +334,8 @@ static gboolean video_ctm_gpu_init(VideoCtm *ctm) {
     gpu->loc_tex_y = glGetUniformLocation(gpu->program, "u_tex_y");
     gpu->loc_tex_uv = glGetUniformLocation(gpu->program, "u_tex_uv");
     gpu->loc_matrix = glGetUniformLocation(gpu->program, "u_matrix");
+    gpu->loc_texel = glGetUniformLocation(gpu->program, "u_texel");
+    gpu->loc_sharp_strength = glGetUniformLocation(gpu->program, "u_sharp_strength");
     glUniform1i(gpu->loc_tex_y, 0);
     glUniform1i(gpu->loc_tex_uv, 1);
     glGenBuffers(1, &gpu->vbo);
@@ -350,6 +368,9 @@ static gboolean video_ctm_gpu_init(VideoCtm *ctm) {
     gpu->dst_width = 0;
     gpu->dst_height = 0;
     gpu->matrix_valid = FALSE;
+    gpu->sharp_strength_valid = FALSE;
+    gpu->applied_sharp_strength = 0.0f;
+    (void)video_ctm_gpu_upload_sharpness(ctm);
     return TRUE;
 }
 
@@ -424,6 +445,22 @@ static gboolean video_ctm_gpu_ensure_target(VideoCtm *ctm, uint32_t width, uint3
     return TRUE;
 }
 
+static gboolean video_ctm_gpu_upload_sharpness(VideoCtm *ctm) {
+    VideoCtmGpuState *gpu = ctm != NULL ? ctm->gpu_state : NULL;
+    if (gpu == NULL || gpu->loc_sharp_strength < 0) {
+        return TRUE;
+    }
+    float sharp = (float)ctm->sharpness;
+    if (gpu->sharp_strength_valid && sharp == gpu->applied_sharp_strength) {
+        return TRUE;
+    }
+    glUseProgram(gpu->program);
+    glUniform1f(gpu->loc_sharp_strength, sharp);
+    gpu->applied_sharp_strength = sharp;
+    gpu->sharp_strength_valid = TRUE;
+    return TRUE;
+}
+
 static gboolean video_ctm_gpu_upload_matrix(VideoCtm *ctm) {
     VideoCtmGpuState *gpu = ctm != NULL ? ctm->gpu_state : NULL;
     if (gpu == NULL) {
@@ -453,6 +490,9 @@ static gboolean video_ctm_gpu_draw(VideoCtm *ctm, int src_fd, uint32_t width, ui
         return FALSE;
     }
     if (!video_ctm_gpu_upload_matrix(ctm)) {
+        return FALSE;
+    }
+    if (!video_ctm_gpu_upload_sharpness(ctm)) {
         return FALSE;
     }
     uint32_t chroma_width = (width + 1u) / 2u;
@@ -495,6 +535,11 @@ static gboolean video_ctm_gpu_draw(VideoCtm *ctm, int src_fd, uint32_t width, ui
     glBindFramebuffer(GL_FRAMEBUFFER, gpu->fbo);
     glViewport(0, 0, (GLint)width, (GLint)height);
     glUseProgram(gpu->program);
+    if (gpu->loc_texel >= 0) {
+        GLfloat inv_w = (width != 0u) ? (1.0f / (GLfloat)width) : 0.0f;
+        GLfloat inv_h = (height != 0u) ? (1.0f / (GLfloat)height) : 0.0f;
+        glUniform2f(gpu->loc_texel, inv_w, inv_h);
+    }
     glBindBuffer(GL_ARRAY_BUFFER, gpu->vbo);
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * (GLint)sizeof(GLfloat), (const GLvoid *)0);
@@ -620,6 +665,7 @@ void video_ctm_init(VideoCtm *ctm, const AppCfg *cfg) {
     }
     memset(ctm, 0, sizeof(*ctm));
     video_ctm_set_identity(ctm);
+    ctm->sharpness = 0.0;
     ctm->backend = VIDEO_CTM_BACKEND_AUTO;
     ctm->hw_supported = FALSE;
     ctm->hw_applied = FALSE;
@@ -638,6 +684,7 @@ void video_ctm_init(VideoCtm *ctm, const AppCfg *cfg) {
         for (int i = 0; i < 9; ++i) {
             ctm->matrix[i] = cfg->video_ctm.matrix[i];
         }
+        ctm->sharpness = cfg->video_ctm.sharpness;
     }
     if (ctm->backend < VIDEO_CTM_BACKEND_AUTO || ctm->backend > VIDEO_CTM_BACKEND_GPU) {
         ctm->backend = VIDEO_CTM_BACKEND_AUTO;


### PR DESCRIPTION
## Summary
- add a sharpness parameter to the video CTM configuration and plumb it into the runtime state
- update the GPU backend to upload the configured sharpening strength and avoid redundant uniform updates
- document the new sharpness setting in the sample configuration file

## Testing
- make *(fails: missing xf86drm.h headers in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_690a6122b088832bba7b4185b15aceb1