### PR TITLE
Enable live CTM updates through external OSD feed

### DIFF
--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -4,6 +4,8 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include "video_ctm.h"
+
 #ifndef OSD_EXTERNAL_BIND_ADDR_LEN
 #define OSD_EXTERNAL_BIND_ADDR_LEN 64
 #endif
@@ -28,6 +30,10 @@ typedef struct {
     uint64_t last_update_ns;
     uint64_t expiry_ns;
     OsdExternalStatus status;
+    struct {
+        VideoCtmUpdate update;
+        uint32_t serial;
+    } ctm;
 } OsdExternalFeedSnapshot;
 
 typedef struct {

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -77,5 +77,6 @@ void pipeline_disable_recording(PipelineState *ps);
 int pipeline_get_recording_stats(const PipelineState *ps, PipelineRecordingStats *stats);
 gboolean pipeline_consume_reinit_request(PipelineState *ps);
 void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRequest *request);
+void pipeline_apply_ctm_update(PipelineState *ps, const VideoCtmUpdate *update);
 
 #endif // PIPELINE_H

--- a/include/video_ctm.h
+++ b/include/video_ctm.h
@@ -36,6 +36,29 @@ typedef struct VideoCtm {
 #endif
 } VideoCtm;
 
+#define VIDEO_CTM_UPDATE_MATRIX (1u << 0)
+#define VIDEO_CTM_UPDATE_SHARPNESS (1u << 1)
+#define VIDEO_CTM_UPDATE_GAMMA (1u << 2)
+#define VIDEO_CTM_UPDATE_GAMMA_LIFT (1u << 3)
+#define VIDEO_CTM_UPDATE_GAMMA_GAIN (1u << 4)
+#define VIDEO_CTM_UPDATE_GAMMA_R_MULT (1u << 5)
+#define VIDEO_CTM_UPDATE_GAMMA_G_MULT (1u << 6)
+#define VIDEO_CTM_UPDATE_GAMMA_B_MULT (1u << 7)
+#define VIDEO_CTM_UPDATE_FLIP (1u << 8)
+
+typedef struct VideoCtmUpdate {
+    uint32_t fields;
+    double matrix[9];
+    double sharpness;
+    double gamma_value;
+    double gamma_lift;
+    double gamma_gain;
+    double gamma_r_mult;
+    double gamma_g_mult;
+    double gamma_b_mult;
+    gboolean flip;
+} VideoCtmUpdate;
+
 void video_ctm_init(VideoCtm *ctm, const AppCfg *cfg);
 void video_ctm_reset(VideoCtm *ctm);
 void video_ctm_set_render_fd(VideoCtm *ctm, int drm_fd);
@@ -46,5 +69,6 @@ int video_ctm_prepare(VideoCtm *ctm, uint32_t width, uint32_t height, uint32_t h
                       uint32_t ver_stride, uint32_t fourcc);
 int video_ctm_process(VideoCtm *ctm, int src_fd, int dst_fd, uint32_t width, uint32_t height,
                       uint32_t hor_stride, uint32_t ver_stride, uint32_t fourcc);
+void video_ctm_apply_update(VideoCtm *ctm, const VideoCtmUpdate *update);
 
 #endif // VIDEO_CTM_H

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "drm_modeset.h"
 #include "idr_requester.h"
+#include "video_ctm.h"
 
 typedef struct VideoDecoder VideoDecoder;
 
@@ -42,5 +43,6 @@ void video_decoder_set_idr_requester(VideoDecoder *vd, IdrRequester *requester);
 int video_decoder_set_zoom(VideoDecoder *vd, gboolean enabled, const VideoDecoderZoomRequest *request);
 
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
+void video_decoder_apply_ctm_update(VideoDecoder *vd, const VideoCtmUpdate *update);
 
 #endif // VIDEO_DECODER_H

--- a/src/main.c
+++ b/src/main.c
@@ -390,6 +390,7 @@ int main(int argc, char **argv) {
     struct timespec last_osd;
     clock_gettime(CLOCK_MONOTONIC, &last_osd);
     char last_zoom_command[OSD_EXTERNAL_TEXT_LEN] = "";
+    uint32_t last_ctm_serial = 0;
 
     while (!g_exit_flag) {
         pipeline_poll_child(&ps);
@@ -573,6 +574,11 @@ int main(int argc, char **argv) {
             if (ms_since(now, last_osd) >= cfg.osd_refresh_ms) {
                 OsdExternalFeedSnapshot ext_snapshot;
                 osd_external_get_snapshot(&ext_bridge, &ext_snapshot);
+                if (ext_snapshot.ctm.update.fields != 0 && ext_snapshot.ctm.serial != 0 &&
+                    ext_snapshot.ctm.serial != last_ctm_serial) {
+                    pipeline_apply_ctm_update(&ps, &ext_snapshot.ctm.update);
+                    last_ctm_serial = ext_snapshot.ctm.serial;
+                }
                 const char *zoom_text = ext_snapshot.text[OSD_EXTERNAL_MAX_TEXT - 1];
                 if (g_strcmp0(zoom_text, last_zoom_command) != 0) {
                     gboolean zoom_enabled = FALSE;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1596,3 +1596,20 @@ void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const Vide
         LOGW("Pipeline: zoom enable request was rejected");
     }
 }
+
+void pipeline_apply_ctm_update(PipelineState *ps, const VideoCtmUpdate *update) {
+    if (ps == NULL || update == NULL || update->fields == 0) {
+        return;
+    }
+
+    g_mutex_lock(&ps->lock);
+    gboolean decoder_ready = ps->decoder_initialized && ps->decoder != NULL;
+    VideoDecoder *decoder = decoder_ready ? ps->decoder : NULL;
+    g_mutex_unlock(&ps->lock);
+
+    if (!decoder_ready || decoder == NULL) {
+        return;
+    }
+
+    video_decoder_apply_ctm_update(decoder, update);
+}


### PR DESCRIPTION
## Summary
- add a VideoCtmUpdate helper and runtime application path so the decoder can refresh CTM parameters without restarting
- expose pipeline/video decoder APIs and extend the external OSD UDP parser to accept `ctm` JSON payloads and propagate them live
- document the live CTM override workflow with example payloads in the README

## Testing
- make -s *(fails: missing xf86drm headers in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e346b92cc832b8bbdd05d33b20897)