### PR TITLE
Render GPU CTM output directly to RGB plane

### DIFF
--- a/include/video_ctm.h
+++ b/include/video_ctm.h
@@ -31,6 +31,9 @@ typedef struct VideoCtm {
     uint32_t hw_prop_id;
     uint32_t hw_blob_id;
     int render_fd;
+    uint32_t src_fourcc;
+    uint32_t dst_fourcc;
+    uint32_t dst_pitch;
 #if defined(HAVE_LIBRGA) && defined(HAVE_GBM_GLES2)
     struct VideoCtmGpuState *gpu_state;
 #endif
@@ -87,10 +90,12 @@ void video_ctm_set_render_fd(VideoCtm *ctm, int drm_fd);
 void video_ctm_use_drm_property(VideoCtm *ctm, int drm_fd, uint32_t object_id,
                                 uint32_t object_type, uint32_t prop_id);
 void video_ctm_disable_drm(VideoCtm *ctm);
-int video_ctm_prepare(VideoCtm *ctm, uint32_t width, uint32_t height, uint32_t hor_stride,
-                      uint32_t ver_stride, uint32_t fourcc);
+int video_ctm_prepare(VideoCtm *ctm, uint32_t width, uint32_t height, uint32_t src_hor_stride,
+                      uint32_t src_ver_stride, uint32_t src_fourcc, uint32_t dst_pitch,
+                      uint32_t dst_fourcc);
 int video_ctm_process(VideoCtm *ctm, int src_fd, int dst_fd, uint32_t width, uint32_t height,
-                      uint32_t hor_stride, uint32_t ver_stride, uint32_t fourcc);
+                      uint32_t src_hor_stride, uint32_t src_ver_stride, uint32_t src_fourcc,
+                      uint32_t dst_pitch, uint32_t dst_fourcc);
 void video_ctm_apply_update(VideoCtm *ctm, const VideoCtmUpdate *update);
 
 typedef struct VideoCtmMetrics {

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -61,20 +61,6 @@ static void video_decoder_fourcc_to_string(uint32_t fourcc, char out[5]) {
     out[4] = '\0';
 }
 
-static void video_decoder_log_ctm_target(const VideoDecoder *vd, const char *context) {
-    if (vd == NULL || !vd->ctm.enabled) {
-        return;
-    }
-    uint32_t dst_fourcc = vd->ctm_fourcc != 0 ? vd->ctm_fourcc : DRM_FORMAT_NV12;
-    gboolean dst_is_rgb = video_decoder_fourcc_is_rgb(dst_fourcc);
-    char dst_str[5];
-    video_decoder_fourcc_to_string(dst_fourcc, dst_str);
-    if (context == NULL) {
-        context = "configured";
-    }
-    LOGI("Video decoder: CTM %s to use %s target (fourcc=%s, pitch=%u)", context,
-         dst_is_rgb ? "RGB" : "NV12", dst_str, vd->ctm_pitch);
-}
 /*
  * RK356x VOP planes sampling NV12 surfaces expect crop widths/heights that
  * align to chroma blocks and even source offsets. Align crops to 4 pixels in
@@ -154,6 +140,21 @@ struct VideoDecoder {
     uint32_t ctm_fourcc;
     uint32_t ctm_pitch;
 };
+
+static void video_decoder_log_ctm_target(const VideoDecoder *vd, const char *context) {
+    if (vd == NULL || !vd->ctm.enabled) {
+        return;
+    }
+    uint32_t dst_fourcc = vd->ctm_fourcc != 0 ? vd->ctm_fourcc : DRM_FORMAT_NV12;
+    gboolean dst_is_rgb = video_decoder_fourcc_is_rgb(dst_fourcc);
+    char dst_str[5];
+    video_decoder_fourcc_to_string(dst_fourcc, dst_str);
+    if (context == NULL) {
+        context = "configured";
+    }
+    LOGI("Video decoder: CTM %s to use %s target (fourcc=%s, pitch=%u)", context,
+         dst_is_rgb ? "RGB" : "NV12", dst_str, vd->ctm_pitch);
+}
 
 VideoDecoder *video_decoder_new(void) {
     return g_new0(VideoDecoder, 1);

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -610,9 +610,6 @@ static void log_decoder_neon_status_once(void) {
 }
 
 static void reset_frame_map(VideoDecoder *vd) {
-    uint32_t transform_fourcc = 0;
-    uint32_t transform_pitch = 0;
-
     for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
         vd->frame_map[i].prime_fd = -1;
         vd->frame_map[i].fb_id = 0;
@@ -910,6 +907,9 @@ static int setup_external_buffers(VideoDecoder *vd, MppFrame frame) {
     }
 
     reset_frame_map(vd);
+
+    uint32_t transform_fourcc = 0;
+    uint32_t transform_pitch = 0;
 
     for (int i = 0; i < DECODER_MAX_FRAMES; ++i) {
         struct drm_mode_create_dumb dmcd;


### PR DESCRIPTION
## Summary
- track the CTM source/destination format information so the GPU path knows when an RGB target is requested
- render GPU CTM output straight into imported RGB DMA-BUFs and skip the NV12 reconversion step
- allocate RGB transform framebuffers in the decoder and plumb the extra pitch/fourcc details into the CTM API

## Testing
- make *(fails: missing libdrm headers in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5d1f0264832ba8ac1eed1b5da611)