### PR TITLE
Handle NV12 plane selection automatically

### DIFF
--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -45,5 +45,6 @@ int video_decoder_set_zoom(VideoDecoder *vd, gboolean enabled, const VideoDecode
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
 void video_decoder_apply_ctm_update(VideoDecoder *vd, const VideoCtmUpdate *update);
 void video_decoder_get_ctm_metrics(const VideoDecoder *vd, VideoCtmMetrics *metrics);
+uint32_t video_decoder_get_plane_id(const VideoDecoder *vd);
 
 #endif // VIDEO_DECODER_H

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1312,6 +1312,13 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
     }
     ps->decoder_initialized = TRUE;
 
+    uint32_t active_plane = video_decoder_get_plane_id(ps->decoder);
+    if (active_plane != 0 && (uint32_t)cfg->plane_id != active_plane) {
+        AppCfg *mutable_cfg = (AppCfg *)cfg;
+        LOGI("Video decoder: updating configured video plane id to %u", active_plane);
+        mutable_cfg->plane_id = (int)active_plane;
+    }
+
     video_decoder_set_idr_requester(ps->decoder, ps->idr_requester);
 
     if (video_decoder_start(ps->decoder) != 0) {

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -38,6 +38,196 @@
 #define DECODER_MAX_FRAMES 24
 #define VIDEO_DECODER_MAX_PLANE_UPSCALE 4.0
 
+static gboolean create_test_nv12_fb(int fd, uint32_t width, uint32_t height, uint32_t *out_fb_id,
+                                    uint32_t *out_handle) {
+    if (out_fb_id == NULL || out_handle == NULL) {
+        return FALSE;
+    }
+
+    struct drm_mode_create_dumb dmcd;
+    memset(&dmcd, 0, sizeof(dmcd));
+    dmcd.width = width;
+    dmcd.height = height * 2;
+    dmcd.bpp = 8;
+
+    if (ioctl(fd, DRM_IOCTL_MODE_CREATE_DUMB, &dmcd) != 0) {
+        return FALSE;
+    }
+
+    uint32_t handles[4] = {0};
+    uint32_t pitches[4] = {0};
+    uint32_t offsets[4] = {0};
+
+    handles[0] = dmcd.handle;
+    handles[1] = dmcd.handle;
+    pitches[0] = dmcd.pitch;
+    pitches[1] = dmcd.pitch;
+    offsets[0] = 0;
+    offsets[1] = dmcd.pitch * height;
+
+    uint32_t fb_id = 0;
+    if (drmModeAddFB2(fd, width, height, DRM_FORMAT_NV12, handles, pitches, offsets, &fb_id, 0) != 0) {
+        struct drm_mode_destroy_dumb destroy_req = {.handle = dmcd.handle};
+        ioctl(fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destroy_req);
+        return FALSE;
+    }
+
+    *out_fb_id = fb_id;
+    *out_handle = dmcd.handle;
+    return TRUE;
+}
+
+static void destroy_test_fb(int fd, uint32_t fb_id, uint32_t handle) {
+    if (fb_id != 0) {
+        drmModeRmFB(fd, fb_id);
+    }
+    if (handle != 0) {
+        struct drm_mode_destroy_dumb destroy_req = {.handle = handle};
+        ioctl(fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destroy_req);
+    }
+}
+
+static gboolean plane_accepts_linear_nv12(int fd, uint32_t plane_id, uint32_t crtc_id) {
+    if (plane_id == 0 || crtc_id == 0) {
+        return FALSE;
+    }
+
+    uint32_t prop_fb_id = 0;
+    uint32_t prop_crtc_id = 0;
+    uint32_t prop_crtc_x = 0;
+    uint32_t prop_crtc_y = 0;
+    uint32_t prop_crtc_w = 0;
+    uint32_t prop_crtc_h = 0;
+    uint32_t prop_src_x = 0;
+    uint32_t prop_src_y = 0;
+    uint32_t prop_src_w = 0;
+    uint32_t prop_src_h = 0;
+
+    if (drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "FB_ID", &prop_fb_id) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_ID", &prop_crtc_id) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_X", &prop_crtc_x) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_Y", &prop_crtc_y) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_W", &prop_crtc_w) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "CRTC_H", &prop_crtc_h) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "SRC_X", &prop_src_x) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "SRC_Y", &prop_src_y) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "SRC_W", &prop_src_w) != 0 ||
+        drm_get_prop_id(fd, plane_id, DRM_MODE_OBJECT_PLANE, "SRC_H", &prop_src_h) != 0) {
+        return FALSE;
+    }
+
+    uint32_t fb_id = 0;
+    uint32_t handle = 0;
+    const uint32_t test_w = 64;
+    const uint32_t test_h = 64;
+
+    if (!create_test_nv12_fb(fd, test_w, test_h, &fb_id, &handle)) {
+        return FALSE;
+    }
+
+    drmModeAtomicReq *req = drmModeAtomicAlloc();
+    if (req == NULL) {
+        destroy_test_fb(fd, fb_id, handle);
+        return FALSE;
+    }
+
+    const uint64_t src_w_q16 = (uint64_t)test_w << 16;
+    const uint64_t src_h_q16 = (uint64_t)test_h << 16;
+
+    drmModeAtomicAddProperty(req, plane_id, prop_fb_id, fb_id);
+    drmModeAtomicAddProperty(req, plane_id, prop_crtc_id, crtc_id);
+    drmModeAtomicAddProperty(req, plane_id, prop_crtc_x, 0);
+    drmModeAtomicAddProperty(req, plane_id, prop_crtc_y, 0);
+    drmModeAtomicAddProperty(req, plane_id, prop_crtc_w, test_w);
+    drmModeAtomicAddProperty(req, plane_id, prop_crtc_h, test_h);
+    drmModeAtomicAddProperty(req, plane_id, prop_src_x, 0);
+    drmModeAtomicAddProperty(req, plane_id, prop_src_y, 0);
+    drmModeAtomicAddProperty(req, plane_id, prop_src_w, src_w_q16);
+    drmModeAtomicAddProperty(req, plane_id, prop_src_h, src_h_q16);
+
+    gboolean ok = (drmModeAtomicCommit(fd, req, DRM_MODE_ATOMIC_TEST_ONLY, NULL) == 0);
+
+    drmModeAtomicFree(req);
+    destroy_test_fb(fd, fb_id, handle);
+    return ok;
+}
+
+static gboolean video_decoder_select_plane(int fd, uint32_t crtc_id, uint32_t requested,
+                                           uint32_t *out_plane) {
+    if (out_plane == NULL) {
+        return FALSE;
+    }
+
+    if (requested != 0 && plane_accepts_linear_nv12(fd, requested, crtc_id)) {
+        *out_plane = requested;
+        return TRUE;
+    }
+
+    if (requested != 0) {
+        LOGW("Video decoder: requested plane %u does not support linear NV12 on CRTC %u; searching for alternative",
+             requested, crtc_id);
+    }
+
+    drmModePlaneRes *pres = drmModeGetPlaneResources(fd);
+    if (pres == NULL) {
+        return FALSE;
+    }
+
+    drmModeRes *res = drmModeGetResources(fd);
+    int crtc_index = -1;
+    if (res != NULL) {
+        for (int i = 0; i < res->count_crtcs; ++i) {
+            if ((uint32_t)res->crtcs[i] == crtc_id) {
+                crtc_index = i;
+                break;
+            }
+        }
+        drmModeFreeResources(res);
+    }
+
+    gboolean found = FALSE;
+    for (uint32_t i = 0; i < pres->count_planes && !found; ++i) {
+        uint32_t plane_id = pres->planes[i];
+        if (plane_id == requested) {
+            continue;
+        }
+
+        drmModePlane *plane = drmModeGetPlane(fd, plane_id);
+        if (plane == NULL) {
+            continue;
+        }
+
+        gboolean possible = TRUE;
+        if (crtc_index >= 0 && (plane->possible_crtcs & (1u << crtc_index)) == 0) {
+            possible = FALSE;
+        }
+        drmModeFreePlane(plane);
+
+        if (!possible) {
+            continue;
+        }
+
+        if (plane_accepts_linear_nv12(fd, plane_id, crtc_id)) {
+            *out_plane = plane_id;
+            found = TRUE;
+        }
+    }
+
+    drmModeFreePlaneResources(pres);
+
+    if (!found) {
+        return FALSE;
+    }
+
+    if (requested != 0) {
+        LOGI("Video decoder: using plane %u instead of requested plane %u", *out_plane, requested);
+    } else {
+        LOGI("Video decoder: auto-selected plane %u for linear NV12", *out_plane);
+    }
+
+    return TRUE;
+}
+
 static gboolean video_decoder_fourcc_is_rgb(uint32_t fourcc) {
     return (fourcc == DRM_FORMAT_XRGB8888 || fourcc == DRM_FORMAT_ARGB8888 ||
             fourcc == DRM_FORMAT_ABGR8888 || fourcc == DRM_FORMAT_XBGR8888);
@@ -1239,6 +1429,13 @@ size_t video_decoder_max_packet_size(const VideoDecoder *vd) {
     return vd->packet_buf_size;
 }
 
+uint32_t video_decoder_get_plane_id(const VideoDecoder *vd) {
+    if (vd == NULL) {
+        return 0;
+    }
+    return vd->plane_id;
+}
+
 void video_decoder_apply_ctm_update(VideoDecoder *vd, const VideoCtmUpdate *update) {
     if (vd == NULL || update == NULL || update->fields == 0) {
         return;
@@ -1290,7 +1487,7 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
 
     memset(vd, 0, sizeof(*vd));
     vd->drm_fd = -1;
-    vd->plane_id = (uint32_t)cfg->plane_id;
+    vd->plane_id = 0;
     vd->crtc_id = ms->crtc_id;
     vd->mode_w = ms->mode_w;
     vd->mode_h = ms->mode_h;
@@ -1300,6 +1497,16 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     vd->frame_ver_stride = 0;
     vd->ctm_fourcc = 0;
     vd->ctm_pitch = 0;
+    vd->packet_buf_size = 0;
+    vd->packet_buf = NULL;
+
+    uint32_t chosen_plane = 0;
+    if (!video_decoder_select_plane(drm_fd, vd->crtc_id, (uint32_t)cfg->plane_id, &chosen_plane)) {
+        LOGE("Video decoder: unable to find NV12-capable plane for CRTC %u", vd->crtc_id);
+        return -1;
+    }
+    vd->plane_id = chosen_plane;
+
     vd->packet_buf_size = DECODER_READ_BUF_SIZE;
     vd->packet_buf = g_malloc0(vd->packet_buf_size);
     if (vd->packet_buf == NULL) {


### PR DESCRIPTION
## Summary
- probe DRM planes for linear NV12 support and auto-select a compatible plane when needed
- expose the active decoder plane id so the runtime configuration stays in sync with the chosen plane

## Testing
- make *(fails: libdrm headers are unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f667188d0832b89d835acf5188dce)