### PR TITLE
Fix DRM mode selection to prefer highest refresh rate

### DIFF
--- a/src/drm_modeset.c
+++ b/src/drm_modeset.c
@@ -68,21 +68,23 @@ static inline int mode_is_preferred(const drmModeModeInfo *m) {
 }
 
 static int better_mode(const drmModeModeInfo *a, const drmModeModeInfo *b) {
+    int ahz = vrefresh(a), bhz = vrefresh(b);
+    if (ahz != bhz) {
+        return ahz > bhz;
+    }
+
+    long long aa = (long long)a->hdisplay * a->vdisplay;
+    long long bb = (long long)b->hdisplay * b->vdisplay;
+    if (aa != bb) {
+        return aa > bb;
+    }
+
     int ap = mode_is_preferred(a);
     int bp = mode_is_preferred(b);
     if (ap != bp) {
         return ap > bp;
     }
 
-    int ahz = vrefresh(a), bhz = vrefresh(b);
-    if (ahz != bhz) {
-        return ahz > bhz;
-    }
-    long long aa = (long long)a->hdisplay * a->vdisplay;
-    long long bb = (long long)b->hdisplay * b->vdisplay;
-    if (aa != bb) {
-        return aa > bb;
-    }
     return a->clock > b->clock;
 }
 


### PR DESCRIPTION
## Summary
- adjust the DRM mode selection heuristic to compare refresh rate before preferred status
- keep resolution and clock as subsequent tie-breakers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6fb86fec832bb17ee7ecc7dd308d)