### PR TITLE
Add animated outline OSD widget and clamp refresh interval

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -127,7 +127,7 @@ line = {record.indicator}
 
 [osd.element.signal_outline]
 ; Animated alpha-blended frame that follows ext.value1. When the value drops
-; below the threshold the outline animates around the screen border.
+; below the threshold the outline pulses in and out along the screen border.
 type = outline
 metric = ext.value1
 threshold = 30

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -71,6 +71,7 @@ affinity = 1,2,3
 
 [osd]
 enable = true
+; The refresh interval is clamped to a minimum of 50ms to avoid busy loops.
 refresh-ms = 100
 plane-id = 0
 ; Order of elements rendered each update
@@ -123,6 +124,20 @@ background = transparent-grey
 border = transparent-white
 foreground = red
 line = {record.indicator}
+
+[osd.element.signal_outline]
+; Animated alpha-blended frame that follows ext.value1. When the value drops
+; below the threshold the outline animates around the screen border.
+type = outline
+metric = ext.value1
+threshold = 30
+trigger = below
+color = 0x90FF4500
+inactive-color = 0x00000000
+thickness = 8
+pattern-length = 48
+pattern-active = 18
+speed = 2
 
 ; To create additional text blocks duplicate the section with a new element
 ; name and adjust the anchor/offset. Each `line =` entry appends to that block.

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -76,14 +76,13 @@ refresh-ms = 100
 plane-id = 0
 ; Order of elements rendered each update
 ; The names reference [osd.element.NAME] sections below.
-elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
+elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot, signal_outline
 
 [osd.external]
 ; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
-; tokens/metrics into the OSD. Leave disabled by default so the socket is
-; only created when explicitly requested.
-enable = false
-socket = /run/pixelpilot/osd.sock
+; tokens/metrics into the OSD. Enabled here so the pulsing outline sample
+; can react to the external metric feed immediately.
+enable = true
 
 ; -----------------------------------------------------------------------------
 ; Element placement quick reference
@@ -134,10 +133,11 @@ threshold = 30
 trigger = below
 color = 0x90FF4500
 inactive-color = 0x00000000
-thickness = 8
-pattern-length = 48
-pattern-active = 18
-speed = 2
+base-thickness = 8
+pulse-period = 48
+pulse-amplitude = 4
+pulse-step = 2
+show-when-missing = false
 
 ; To create additional text blocks duplicate the section with a new element
 ; name and adjust the anchor/offset. Each `line =` entry appends to that block.

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -131,6 +131,30 @@ unknown, configuration files created on older builds keep working: users only
 see `{ext.text1}` until they update the binary to a release containing the
 bridge.
 
+### Animated outline widget
+
+The OSD includes an `outline` element type that renders an alpha-blended frame
+around the screen. The widget listens to any metric (for example
+`ext.value1`) and animates whenever the sampled value crosses a configured
+threshold. A representative INI snippet looks like:
+
+```ini
+[osd.element.signal_outline]
+type = outline
+metric = ext.value1
+threshold = 30
+trigger = below
+color = 0x90FF4500
+pattern-length = 48
+pattern-active = 18
+speed = 2
+```
+
+With the example above the outline begins moving when `ext.value1 < 30`. The
+color accepts any ARGB value, so using a partially transparent colour ensures
+the animation blends with the video underneath. Setting `inactive-color` keeps
+a static border visible even when the trigger is not met.
+
 ## Error handling and observability
 
 * Socket creation failures should log a warning and keep the rest of the

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -145,18 +145,24 @@ metric = ext.value1
 threshold = 30
 trigger = below
 color = 0x90FF4500
-pattern-length = 48
-pattern-active = 18
-speed = 2
+base-thickness = 8
+pulse-period = 48
+pulse-amplitude = 4
+pulse-step = 2
+show-when-missing = false
 ```
 
 With the example above the outline begins pulsing when `ext.value1 < 30`. The
 color accepts any ARGB value, so using a partially transparent colour ensures
-the animation blends with the video underneath. The `pattern-length` value
-controls the full in/out pulse cycle (higher numbers slow the animation),
-while `pattern-active` sets how far the outline expands beyond its base
-thickness. Setting `inactive-color` keeps a static border visible even when
-the trigger is not met.
+the animation blends with the video underneath. `base-thickness` establishes
+the baseline border width, `pulse-period` controls the full in/out pulse cycle
+(higher numbers slow the animation), and `pulse-amplitude` defines how far the
+border expands beyond the baseline. `pulse-step` advances the animation phase on
+each refresh, so larger steps make the pulse travel faster. Setting
+`inactive-color` keeps a static border visible even when the trigger is not met,
+while `show-when-missing` toggles whether the outline should be rendered at all
+when the metric source has not yet published a value (for example immediately
+after a TTL expires).
 
 ## Error handling and observability
 

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -150,10 +150,13 @@ pattern-active = 18
 speed = 2
 ```
 
-With the example above the outline begins moving when `ext.value1 < 30`. The
+With the example above the outline begins pulsing when `ext.value1 < 30`. The
 color accepts any ARGB value, so using a partially transparent colour ensures
-the animation blends with the video underneath. Setting `inactive-color` keeps
-a static border visible even when the trigger is not met.
+the animation blends with the video underneath. The `pattern-length` value
+controls the full in/out pulse cycle (higher numbers slow the animation),
+while `pattern-active` sets how far the outline expands beyond its base
+thickness. Setting `inactive-color` keeps a static border visible even when
+the trigger is not met.
 
 ## Error handling and observability
 

--- a/include/config.h
+++ b/include/config.h
@@ -8,6 +8,10 @@
 
 #define SPLASH_MAX_SEQUENCES 32
 
+#ifndef OSD_REFRESH_MIN_MS
+#define OSD_REFRESH_MIN_MS 50
+#endif
+
 #ifndef CPU_SETSIZE
 #define CPU_SETSIZE ((int)(sizeof(cpu_set_t) * CHAR_BIT))
 #endif

--- a/include/osd.h
+++ b/include/osd.h
@@ -92,6 +92,12 @@ typedef struct {
     OSDRect footer_rect;
 } OsdBarState;
 
+typedef struct {
+    int phase;
+    int last_active;
+    int last_thickness;
+} OsdOutlineState;
+
 typedef struct OSD {
     int enabled;
     int active;
@@ -140,6 +146,7 @@ typedef struct OSD {
             OsdTextState text;
             OsdLineState line;
             OsdBarState bar;
+            OsdOutlineState outline;
         } data;
     } elements[OSD_MAX_ELEMENTS];
 } OSD;

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -27,6 +27,7 @@ typedef enum {
 typedef struct {
     char text[OSD_EXTERNAL_MAX_TEXT][OSD_EXTERNAL_TEXT_LEN];
     double value[OSD_EXTERNAL_MAX_VALUES];
+    uint8_t value_active[OSD_EXTERNAL_MAX_VALUES];
     uint64_t last_update_ns;
     uint64_t expiry_ns;
     OsdExternalStatus status;

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -11,7 +11,8 @@ extern "C" {
 typedef enum {
     OSD_WIDGET_TEXT = 0,
     OSD_WIDGET_LINE,
-    OSD_WIDGET_BAR
+    OSD_WIDGET_BAR,
+    OSD_WIDGET_OUTLINE
 } OsdElementType;
 
 typedef enum {
@@ -93,6 +94,18 @@ typedef struct {
 } OsdBarConfig;
 
 typedef struct {
+    char metric[64];
+    double threshold;
+    int activate_when_below;
+    uint32_t active_color;
+    uint32_t inactive_color;
+    int thickness_px;
+    int pattern_length_px;
+    int pattern_active_px;
+    int speed_px;
+} OsdOutlineConfig;
+
+typedef struct {
     OsdElementType type;
     char name[48];
     OsdPlacement placement;
@@ -100,6 +113,7 @@ typedef struct {
         OsdTextConfig text;
         OsdLineConfig line;
         OsdBarConfig bar;
+        OsdOutlineConfig outline;
     } data;
 } OsdElementConfig;
 

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -99,10 +99,11 @@ typedef struct {
     int activate_when_below;
     uint32_t active_color;
     uint32_t inactive_color;
-    int thickness_px;
-    int pattern_length_px;
-    int pattern_active_px;
-    int speed_px;
+    int base_thickness_px;
+    int pulse_period_ticks;
+    int pulse_amplitude_px;
+    int pulse_step_ticks;
+    int show_when_missing;
 } OsdOutlineConfig;
 
 typedef struct {

--- a/src/config.c
+++ b/src/config.c
@@ -363,6 +363,10 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             cfg->osd_plane_id = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--osd-refresh-ms") && i + 1 < argc) {
             cfg->osd_refresh_ms = atoi(argv[++i]);
+            if (cfg->osd_refresh_ms < OSD_REFRESH_MIN_MS) {
+                LOGW("--osd-refresh-ms=%d clamped to minimum %d", cfg->osd_refresh_ms, OSD_REFRESH_MIN_MS);
+                cfg->osd_refresh_ms = OSD_REFRESH_MIN_MS;
+            }
         } else if (!strcmp(argv[i], "--osd-external")) {
             cfg->osd_external.enable = 1;
             cfg->osd_external.enable_set = 1;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -182,6 +182,19 @@ static void builder_reset_bar(OsdElementConfig *elem) {
     }
 }
 
+static void builder_reset_outline(OsdElementConfig *elem) {
+    elem->type = OSD_WIDGET_OUTLINE;
+    ini_copy_string(elem->data.outline.metric, sizeof(elem->data.outline.metric), "ext.value1");
+    elem->data.outline.threshold = 30.0;
+    elem->data.outline.activate_when_below = 1;
+    elem->data.outline.active_color = 0x90FF4500u;
+    elem->data.outline.inactive_color = 0x00000000u;
+    elem->data.outline.thickness_px = 8;
+    elem->data.outline.pattern_length_px = 48;
+    elem->data.outline.pattern_active_px = 18;
+    elem->data.outline.speed_px = 2;
+}
+
 static int builder_finalize(OsdLayoutBuilder *b, OsdLayout *out_layout) {
     if (!out_layout) {
         return -1;
@@ -790,6 +803,88 @@ static int parse_osd_element_bar(OsdElementConfig *elem, const char *key, const 
     return -1;
 }
 
+static int parse_osd_element_outline(OsdElementConfig *elem, const char *key, const char *value) {
+    if (strcasecmp(key, "metric") == 0) {
+        ini_copy_string(elem->data.outline.metric, sizeof(elem->data.outline.metric), value);
+        return 0;
+    }
+    if (strcasecmp(key, "threshold") == 0 || strcasecmp(key, "limit") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.outline.threshold = v;
+        return 0;
+    }
+    if (strcasecmp(key, "activate-below") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.outline.threshold = v;
+        elem->data.outline.activate_when_below = 1;
+        return 0;
+    }
+    if (strcasecmp(key, "activate-above") == 0) {
+        double v = 0.0;
+        if (parse_double(value, &v) != 0) {
+            return -1;
+        }
+        elem->data.outline.threshold = v;
+        elem->data.outline.activate_when_below = 0;
+        return 0;
+    }
+    if (strcasecmp(key, "trigger") == 0 || strcasecmp(key, "mode") == 0) {
+        if (strcasecmp(value, "below") == 0 || strcasecmp(value, "less") == 0) {
+            elem->data.outline.activate_when_below = 1;
+            return 0;
+        }
+        if (strcasecmp(value, "above") == 0 || strcasecmp(value, "greater") == 0) {
+            elem->data.outline.activate_when_below = 0;
+            return 0;
+        }
+        return -1;
+    }
+    if (strcasecmp(key, "color") == 0 || strcasecmp(key, "active-color") == 0 ||
+        strcasecmp(key, "active_colour") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.outline.active_color = color;
+        return 0;
+    }
+    if (strcasecmp(key, "inactive-color") == 0 || strcasecmp(key, "inactive_colour") == 0) {
+        uint32_t color = 0;
+        if (parse_color(value, &color) != 0) {
+            return -1;
+        }
+        elem->data.outline.inactive_color = color;
+        return 0;
+    }
+    if (strcasecmp(key, "thickness") == 0 || strcasecmp(key, "thickness-px") == 0) {
+        elem->data.outline.thickness_px = atoi(value);
+        return 0;
+    }
+    if (strcasecmp(key, "pattern-length") == 0 || strcasecmp(key, "pattern-length-px") == 0 ||
+        strcasecmp(key, "pattern_length") == 0 || strcasecmp(key, "pattern_length_px") == 0) {
+        elem->data.outline.pattern_length_px = atoi(value);
+        return 0;
+    }
+    if (strcasecmp(key, "pattern-active") == 0 || strcasecmp(key, "pattern-active-px") == 0 ||
+        strcasecmp(key, "pattern-on") == 0 || strcasecmp(key, "pattern_active") == 0 ||
+        strcasecmp(key, "pattern_active_px") == 0) {
+        elem->data.outline.pattern_active_px = atoi(value);
+        return 0;
+    }
+    if (strcasecmp(key, "speed") == 0 || strcasecmp(key, "scroll-speed") == 0 ||
+        strcasecmp(key, "speed-px") == 0 || strcasecmp(key, "speed_px") == 0) {
+        elem->data.outline.speed_px = atoi(value);
+        return 0;
+    }
+    return -1;
+}
+
 static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name, const char *key, const char *value) {
     const char *prefix = "osd.element.";
     size_t prefix_len = strlen(prefix);
@@ -816,6 +911,11 @@ static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name
         }
         if (strcasecmp(value, "bar") == 0) {
             builder_reset_bar(elem);
+            builder->type_set[idx] = 1;
+            return 0;
+        }
+        if (strcasecmp(value, "outline") == 0) {
+            builder_reset_outline(elem);
             builder->type_set[idx] = 1;
             return 0;
         }
@@ -847,6 +947,9 @@ static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name
     }
     if (elem->type == OSD_WIDGET_BAR) {
         return parse_osd_element_bar(elem, key, value);
+    }
+    if (elem->type == OSD_WIDGET_OUTLINE) {
+        return parse_osd_element_outline(elem, key, value);
     }
     return -1;
 }
@@ -1101,6 +1204,11 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         if (strcasecmp(key, "refresh-ms") == 0) {
             cfg->osd_refresh_ms = atoi(value);
+            if (cfg->osd_refresh_ms < OSD_REFRESH_MIN_MS) {
+                LOGW("config: osd refresh interval %dms below minimum; using %dms", cfg->osd_refresh_ms,
+                     OSD_REFRESH_MIN_MS);
+                cfg->osd_refresh_ms = OSD_REFRESH_MIN_MS;
+            }
             return 0;
         }
         if (strcasecmp(key, "plane-id") == 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -257,6 +257,23 @@ static int builder_finalize(OsdLayoutBuilder *b, OsdLayout *out_layout) {
             if (elem->data.bar.bar_width_px <= 0) {
                 elem->data.bar.bar_width_px = 8;
             }
+        } else if (elem->type == OSD_WIDGET_OUTLINE) {
+            if (elem->data.outline.thickness_px <= 0) {
+                elem->data.outline.thickness_px = 8;
+            }
+            if (elem->data.outline.pattern_length_px <= 0) {
+                elem->data.outline.pattern_length_px = 48;
+            }
+            if (elem->data.outline.pattern_active_px <= 0 ||
+                elem->data.outline.pattern_active_px > elem->data.outline.pattern_length_px) {
+                elem->data.outline.pattern_active_px = elem->data.outline.pattern_length_px / 2;
+                if (elem->data.outline.pattern_active_px <= 0) {
+                    elem->data.outline.pattern_active_px = elem->data.outline.pattern_length_px;
+                }
+            }
+            if (elem->data.outline.speed_px <= 0) {
+                elem->data.outline.speed_px = 2;
+            }
         } else {
             LOGE("config: osd element '%s' has unsupported type", elem->name);
             return -1;

--- a/src/osd.c
+++ b/src/osd.c
@@ -249,6 +249,8 @@ static int osd_outline_compute_thickness(const OSD *o, const OsdOutlineConfig *c
     return thickness;
 }
 
+static void osd_damage_add_rect(OSD *o, int x, int y, int w, int h);
+
 static void osd_outline_clear(OSD *o, int thickness) {
     if (!o || thickness <= 0 || o->w <= 0 || o->h <= 0) {
         return;

--- a/src/osd.c
+++ b/src/osd.c
@@ -921,7 +921,7 @@ static int osd_metric_sample(const OsdRenderContext *ctx, const char *key, doubl
 
     int ext_slot = osd_external_slot_from_key(metric, "ext.value", OSD_EXTERNAL_MAX_VALUES);
     if (ext_slot >= 0) {
-        if (ctx->external) {
+        if (ctx->external && ctx->external->value_active[ext_slot]) {
             *out_value = ctx->external->value[ext_slot];
             return 1;
         }


### PR DESCRIPTION
## Summary
- add an outline widget type that animates an alpha-blended border based on external metric thresholds
- extend configuration parsing, defaults, and samples/docs to cover the new element
- enforce a minimum OSD refresh interval when parsing CLI and INI settings

## Testing
- make *(fails: missing xf86drm.h on builder)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb53aa938832b90c79cb0dc6f761f)