### PR TITLE
Treat missing external metrics as absent

### DIFF
--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -27,6 +27,7 @@ typedef enum {
 typedef struct {
     char text[OSD_EXTERNAL_MAX_TEXT][OSD_EXTERNAL_TEXT_LEN];
     double value[OSD_EXTERNAL_MAX_VALUES];
+    uint8_t value_valid[OSD_EXTERNAL_MAX_VALUES];
     uint64_t last_update_ns;
     uint64_t expiry_ns;
     OsdExternalStatus status;

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -27,7 +27,6 @@ typedef enum {
 typedef struct {
     char text[OSD_EXTERNAL_MAX_TEXT][OSD_EXTERNAL_TEXT_LEN];
     double value[OSD_EXTERNAL_MAX_VALUES];
-    uint8_t value_valid[OSD_EXTERNAL_MAX_VALUES];
     uint64_t last_update_ns;
     uint64_t expiry_ns;
     OsdExternalStatus status;

--- a/src/osd.c
+++ b/src/osd.c
@@ -718,8 +718,14 @@ static int osd_token_format(const OsdRenderContext *ctx, const char *token, char
     }
     ext_slot = osd_external_slot_from_key(key, "ext.value", OSD_EXTERNAL_MAX_VALUES);
     if (ext_slot >= 0) {
-        double v = (ctx->external) ? ctx->external->value[ext_slot] : 0.0;
-        osd_format_metric_value(key, v, buf, buf_sz);
+        if (ctx->external && ctx->external->value_valid[ext_slot]) {
+            double v = ctx->external->value[ext_slot];
+            osd_format_metric_value(key, v, buf, buf_sz);
+        } else {
+            if (buf_sz > 0) {
+                buf[0] = '\0';
+            }
+        }
         return 0;
     }
 
@@ -921,7 +927,7 @@ static int osd_metric_sample(const OsdRenderContext *ctx, const char *key, doubl
 
     int ext_slot = osd_external_slot_from_key(metric, "ext.value", OSD_EXTERNAL_MAX_VALUES);
     if (ext_slot >= 0) {
-        if (ctx->external) {
+        if (ctx->external && ctx->external->value_valid[ext_slot]) {
             *out_value = ctx->external->value[ext_slot];
             return 1;
         }


### PR DESCRIPTION
## Summary
- track validity for external numeric slots and clear values when feeds send empty or invalid data
- require valid external values before sampling or rendering OSD outlines

## Testing
- make *(fails: missing xf86drm.h build dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910458a3f7c832b8f550695898cd439)