### PR TITLE
Reduce audio playback buffering latency

### DIFF
--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -58,6 +58,12 @@ device = plughw:CARD=rockchiphdmi0,DEV=0
 ;plughw:CARD=Audio,DEV=0
 ;speaker-test -D plughw:CARD=Audio,DEV=0 -c2 -r48000
 ;aplay  -l
+queue-start-buffers = 2
+queue-play-buffers = 2
+queue-sink-buffers = 2
+record-queue-buffers = 16
+sink-buffer-time-us = 12000
+sink-latency-time-us = 6000
 disable = false
 optional = true
 

--- a/include/config.h
+++ b/include/config.h
@@ -82,6 +82,12 @@ typedef struct {
     int udpsrc_pt97_filter;
     CustomSinkMode custom_sink;
     char aud_dev[128];
+    int audio_queue_start_buffers;
+    int audio_queue_play_buffers;
+    int audio_queue_sink_buffers;
+    int audio_record_queue_buffers;
+    unsigned int audio_sink_buffer_time_us;
+    unsigned int audio_sink_latency_time_us;
 
     int no_audio;
     int audio_optional;

--- a/src/config.c
+++ b/src/config.c
@@ -146,6 +146,12 @@ void cfg_defaults(AppCfg *c) {
     c->udpsrc_pt97_filter = 1;
     c->custom_sink = CUSTOM_SINK_RECEIVER;
     strcpy(c->aud_dev, "plughw:CARD=rockchiphdmi0,DEV=0");
+    c->audio_queue_start_buffers = 2;
+    c->audio_queue_play_buffers = 2;
+    c->audio_queue_sink_buffers = 2;
+    c->audio_record_queue_buffers = 16;
+    c->audio_sink_buffer_time_us = 12000;
+    c->audio_sink_latency_time_us = 6000;
 
     c->no_audio = 0;
     c->audio_optional = 1;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1048,6 +1048,54 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             ini_copy_string(cfg->aud_dev, sizeof(cfg->aud_dev), value);
             return 0;
         }
+        if (strcasecmp(key, "queue-start-buffers") == 0) {
+            cfg->audio_queue_start_buffers = atoi(value);
+            if (cfg->audio_queue_start_buffers <= 0) {
+                LOGE("config: audio.queue-start-buffers '%s' must be positive", value);
+                cfg->audio_queue_start_buffers = 1;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "queue-play-buffers") == 0) {
+            cfg->audio_queue_play_buffers = atoi(value);
+            if (cfg->audio_queue_play_buffers <= 0) {
+                LOGE("config: audio.queue-play-buffers '%s' must be positive", value);
+                cfg->audio_queue_play_buffers = 1;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "queue-sink-buffers") == 0) {
+            cfg->audio_queue_sink_buffers = atoi(value);
+            if (cfg->audio_queue_sink_buffers <= 0) {
+                LOGE("config: audio.queue-sink-buffers '%s' must be positive", value);
+                cfg->audio_queue_sink_buffers = 1;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "record-queue-buffers") == 0) {
+            cfg->audio_record_queue_buffers = atoi(value);
+            if (cfg->audio_record_queue_buffers <= 0) {
+                LOGE("config: audio.record-queue-buffers '%s' must be positive", value);
+                cfg->audio_record_queue_buffers = 1;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "sink-buffer-time-us") == 0) {
+            cfg->audio_sink_buffer_time_us = (unsigned int)strtoul(value, NULL, 10);
+            if (cfg->audio_sink_buffer_time_us == 0) {
+                LOGE("config: audio.sink-buffer-time-us '%s' must be positive", value);
+                cfg->audio_sink_buffer_time_us = 1;
+            }
+            return 0;
+        }
+        if (strcasecmp(key, "sink-latency-time-us") == 0) {
+            cfg->audio_sink_latency_time_us = (unsigned int)strtoul(value, NULL, 10);
+            if (cfg->audio_sink_latency_time_us == 0) {
+                LOGE("config: audio.sink-latency-time-us '%s' must be positive", value);
+                cfg->audio_sink_latency_time_us = 1;
+            }
+            return 0;
+        }
         if (strcasecmp(key, "disable") == 0) {
             int v = 0;
             if (parse_bool(value, &v) != 0) {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -722,15 +722,16 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
         audio_caps = NULL;
 
         g_object_set(audio_queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 2, NULL);
+                     "max-size-buffers", cfg->audio_queue_start_buffers, NULL);
         g_object_set(audio_queue_play, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 2, NULL);
+                     "max-size-buffers", cfg->audio_queue_play_buffers, NULL);
         g_object_set(audio_queue_sink, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 2, NULL);
+                     "max-size-buffers", cfg->audio_queue_sink_buffers, NULL);
         g_object_set(audio_record_queue, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 16, NULL);
-        g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE, "buffer-time", (guint64)12000,
-                     "latency-time", (guint64)6000, NULL);
+                     "max-size-buffers", cfg->audio_record_queue_buffers, NULL);
+        g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE,
+                     "buffer-time", (guint64)cfg->audio_sink_buffer_time_us, "latency-time",
+                     (guint64)cfg->audio_sink_latency_time_us, NULL);
         gst_app_sink_set_max_buffers(GST_APP_SINK(audio_record_sink), 8);
         gst_app_sink_set_drop(GST_APP_SINK(audio_record_sink), TRUE);
         g_object_set(audio_record_sink, "emit-signals", TRUE, "sync", FALSE, "async", FALSE, NULL);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -722,13 +722,15 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
         audio_caps = NULL;
 
         g_object_set(audio_queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 16, NULL);
+                     "max-size-buffers", 4, NULL);
         g_object_set(audio_queue_play, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 16, NULL);
-        g_object_set(audio_queue_sink, "leaky", 2, NULL);
+                     "max-size-buffers", 4, NULL);
+        g_object_set(audio_queue_sink, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
+                     "max-size-buffers", 4, NULL);
         g_object_set(audio_record_queue, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
                      "max-size-buffers", 16, NULL);
-        g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE, NULL);
+        g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE, "buffer-time", (guint64)20000,
+                     "latency-time", (guint64)10000, NULL);
         gst_app_sink_set_max_buffers(GST_APP_SINK(audio_record_sink), 8);
         gst_app_sink_set_drop(GST_APP_SINK(audio_record_sink), TRUE);
         g_object_set(audio_record_sink, "emit-signals", TRUE, "sync", FALSE, "async", FALSE, NULL);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -722,15 +722,15 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
         audio_caps = NULL;
 
         g_object_set(audio_queue_start, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 4, NULL);
+                     "max-size-buffers", 2, NULL);
         g_object_set(audio_queue_play, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 4, NULL);
+                     "max-size-buffers", 2, NULL);
         g_object_set(audio_queue_sink, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
-                     "max-size-buffers", 4, NULL);
+                     "max-size-buffers", 2, NULL);
         g_object_set(audio_record_queue, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
                      "max-size-buffers", 16, NULL);
-        g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE, "buffer-time", (guint64)20000,
-                     "latency-time", (guint64)10000, NULL);
+        g_object_set(audio_sink, "device", cfg->aud_dev, "sync", FALSE, "async", FALSE, "buffer-time", (guint64)12000,
+                     "latency-time", (guint64)6000, NULL);
         gst_app_sink_set_max_buffers(GST_APP_SINK(audio_record_sink), 8);
         gst_app_sink_set_drop(GST_APP_SINK(audio_record_sink), TRUE);
         g_object_set(audio_record_sink, "emit-signals", TRUE, "sync", FALSE, "async", FALSE, NULL);


### PR DESCRIPTION
## Summary
- lower queue sizes for audio playback path and bound the sink queue to reduce accumulated latency
- set ALSA sink buffer and latency times for faster live opus audio output while leaving recording buffering unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9223ba88832b9475e87be7bbc30e)