### PR TITLE
Avoid reinitializing pipeline on unchanged hotplug events

### DIFF
--- a/include/drm_modeset.h
+++ b/include/drm_modeset.h
@@ -14,6 +14,7 @@ typedef struct {
 } ModesetResult;
 
 int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResult *out);
+int probe_maxhz_mode(int fd, const AppCfg *cfg, ModesetResult *out);
 int is_any_connected(int fd, const AppCfg *cfg);
 
 #endif // DRM_MODESET_H

--- a/src/main.c
+++ b/src/main.c
@@ -469,11 +469,13 @@ int main(int argc, char **argv) {
                             osd_disable(fd, &osd);
                         }
                         connected = 0;
+                        ms = (ModesetResult){0};
                     } else {
                         ModesetResult probed = {0};
                         gboolean probe_ok = (probe_maxhz_mode(fd, &cfg, &probed) == 0);
                         gboolean needs_modeset = TRUE;
-                        if (probe_ok && modeset_result_equals(&ms, &probed)) {
+                        gboolean pipeline_ready = (connected && ps.state == PIPELINE_RUNNING);
+                        if (pipeline_ready && probe_ok && modeset_result_equals(&ms, &probed)) {
                             LOGI("Hotplug: display unchanged; skipping reinitialization");
                             connected = 1;
                             needs_modeset = FALSE;


### PR DESCRIPTION
## Summary
- add a helper to probe the preferred DRM connector/mode without committing a modeset
- reuse the selector in the atomic modeset path to reduce duplicate logic
- ignore hotplug events when the display and mode are unchanged to avoid unnecessary pipeline restarts and flicker

## Testing
- make *(fails: missing libdrm headers in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944413ff5a4832baea3548956966a71)