### PR TITLE
Add configurable DRM modes and avoid unnecessary hotplug reinitialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ to the defaults listed in `src/config.c` when omitted.
 | --- | --- |
 | `[drm].card` | DRM card node to open (default `/dev/dri/card0`). |
 | `[drm].connector` | Preferred connector name (e.g. `HDMI-A-1`). Leave blank to auto-pick the first connected head. |
+| `[drm].mode` | Optional forced mode in `WIDTHxHEIGHT[@Hz]` form (e.g. `1920x1080@120`). Omit or set `auto` to use the preferred/best mode. |
 | `[drm].video-plane-id` | Numeric plane ID used for the decoded video plane. |
 | `[drm].use-udev` | `true` to enable the hotplug listener that reapplies modes when connectors change. |
 | `[drm].osd-plane-id` | Optional explicit plane for the OSD overlay (0 keeps the auto-selection). |

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -5,6 +5,9 @@
 ; Card/connector selection for the video plane
 card = /dev/dri/card0
 connector = HDMI-A-1
+; Optional: force a specific display mode (e.g. 1920x1080@120). Leave empty or
+; set to "auto" to use the preferred/best mode.
+;mode = auto
 video-plane-id = 76
 use-udev = true
 osd-plane-id = 0

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -5,6 +5,9 @@
 ; Card/connector selection for the video plane
 card = /dev/dri/card0
 connector = HDMI-A-1
+; Optional: force a specific display mode (e.g. 1920x1080@120). Leave empty or
+; set to "auto" to use the preferred/best mode.
+;mode = auto
 video-plane-id = 76
 use-udev = false
 osd-plane-id = 0

--- a/include/config.h
+++ b/include/config.h
@@ -82,6 +82,9 @@ typedef struct {
     char config_path[PATH_MAX];
     int plane_id;
     int use_udev;
+    int mode_w;
+    int mode_h;
+    int mode_hz;
 
     int udp_port;
     int vid_pt;
@@ -141,5 +144,6 @@ const char *cfg_custom_sink_mode_name(CustomSinkMode mode);
 int cfg_parse_record_mode(const char *value, RecordMode *mode_out);
 const char *cfg_record_mode_name(RecordMode mode);
 int cfg_parse_host_and_port(const char *value, char *host_out, size_t host_len, int *port_out);
+int cfg_set_drm_mode_from_string(const char *value, AppCfg *cfg);
 
 #endif // CONFIG_H

--- a/include/drm_modeset.h
+++ b/include/drm_modeset.h
@@ -14,6 +14,7 @@ typedef struct {
 } ModesetResult;
 
 int atomic_modeset_maxhz(int fd, const AppCfg *cfg, int osd_enabled, ModesetResult *out);
+int probe_maxhz_mode(int fd, const AppCfg *cfg, ModesetResult *out);
 int is_any_connected(int fd, const AppCfg *cfg);
 
 #endif // DRM_MODESET_H

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -973,6 +973,12 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         ini_copy_string(cfg->connector_name, sizeof(cfg->connector_name), value);
             return 0;
         }
+        if (strcasecmp(key, "mode") == 0) {
+            if (cfg_set_drm_mode_from_string(value, cfg) != 0) {
+                LOGW("config: invalid drm.mode '%s'; falling back to auto", value);
+            }
+            return 0;
+        }
         if (strcasecmp(key, "video-plane-id") == 0) {
             cfg->plane_id = atoi(value);
             return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -469,11 +469,12 @@ int main(int argc, char **argv) {
                             osd_disable(fd, &osd);
                         }
                         connected = 0;
+                        memset(&ms, 0, sizeof(ms));
                     } else {
                         ModesetResult probed = {0};
                         gboolean probe_ok = (probe_maxhz_mode(fd, &cfg, &probed) == 0);
                         gboolean needs_modeset = TRUE;
-                        if (probe_ok && modeset_result_equals(&ms, &probed)) {
+                        if (probe_ok && modeset_result_equals(&ms, &probed) && ps.state == PIPELINE_RUNNING) {
                             LOGI("Hotplug: display unchanged; skipping reinitialization");
                             connected = 1;
                             needs_modeset = FALSE;


### PR DESCRIPTION
## Summary
- add a configurable `[drm].mode`/`--mode` option to force a specific display mode, falling back to auto when the request is invalid or unavailable
- reuse the shared DRM connector/mode selector for both probing and atomic commits to prevent unnecessary reinitialization on unchanged hotplug events
- update documentation and sample INI files to describe the optional fixed-mode setting

## Testing
- make *(fails: missing libdrm and glib development headers in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944413ff5a4832baea3548956966a71)