### PR TITLE
Ensure OSD plane stays above video plane

### DIFF
--- a/include/osd.h
+++ b/include/osd.h
@@ -159,6 +159,7 @@ void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const 
 int osd_is_enabled(const OSD *osd);
 int osd_is_active(const OSD *osd);
 int osd_enable(int fd, OSD *osd);
+int osd_ensure_above_video(int fd, uint32_t video_plane_id, OSD *osd);
 void osd_disable(int fd, OSD *osd);
 void osd_teardown(int fd, OSD *osd);
 

--- a/src/main.c
+++ b/src/main.c
@@ -282,6 +282,10 @@ static void pipeline_restart_now(AppCfg *cfg,
         return;
     }
 
+    if (osd != NULL && osd_is_enabled(osd)) {
+        osd_ensure_above_video(fd, (uint32_t)cfg->plane_id, osd);
+    }
+
     stats_cache_invalidate(stats_enabled_cached);
     pipeline_maybe_set_stats(cfg, ps, stats_enabled_cached, stats_consumers_active(osd, sse_streamer));
     if (window_start != NULL) {
@@ -384,6 +388,9 @@ int main(int argc, char **argv) {
                 LOGE("Failed to start pipeline");
                 pipeline_maybe_set_stats(&cfg, &ps, &stats_enabled_cached, stats_consumers_active(&osd, &sse_streamer));
             } else {
+                if (osd_is_enabled(&osd)) {
+                    osd_ensure_above_video(fd, (uint32_t)cfg.plane_id, &osd);
+                }
                 pipeline_maybe_set_stats(&cfg, &ps, &stats_enabled_cached, stats_consumers_active(&osd, &sse_streamer));
             }
             clock_gettime(CLOCK_MONOTONIC, &window_start);
@@ -500,6 +507,9 @@ int main(int argc, char **argv) {
                                 LOGE("Failed to start pipeline after hotplug");
                                 pipeline_maybe_set_stats(&cfg, &ps, &stats_enabled_cached, FALSE);
                             } else {
+                                if (osd_is_enabled(&osd)) {
+                                    osd_ensure_above_video(fd, (uint32_t)cfg.plane_id, &osd);
+                                }
                                 pipeline_maybe_set_stats(&cfg, &ps, &stats_enabled_cached, osd_is_active(&osd) ? TRUE : FALSE);
                             }
                             clock_gettime(CLOCK_MONOTONIC, &window_start);

--- a/src/osd.c
+++ b/src/osd.c
@@ -3315,7 +3315,7 @@ int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plan
 }
 
 int osd_ensure_above_video(int fd, uint32_t video_plane_id, OSD *o) {
-    if (o == NULL || !o->enabled || !o->have_zpos || o->plane_id == 0) {
+    if (o == NULL || !o->enabled || !o->active || !o->have_zpos || o->plane_id == 0) {
         return 0;
     }
     if (video_plane_id == 0 || video_plane_id == o->plane_id) {
@@ -3328,6 +3328,7 @@ int osd_ensure_above_video(int fd, uint32_t video_plane_id, OSD *o) {
         return -1;
     }
 
+    /* Mirror the modeset ordering: keep OSD at its max zpos, nudge video below when possible. */
     uint64_t osd_z = clamp_u64(o->zmax, o->zmin, o->zmax);
     uint64_t video_z = video_props.zmin;
     if (osd_z > video_props.zmin) {

--- a/src/osd.c
+++ b/src/osd.c
@@ -2894,6 +2894,16 @@ static int plane_get_basic_props(int fd, uint32_t plane_id, PlaneProps *pp) {
     return 0;
 }
 
+static uint64_t clamp_u64(uint64_t value, uint64_t min, uint64_t max) {
+    if (value < min) {
+        return min;
+    }
+    if (value > max) {
+        return max;
+    }
+    return value;
+}
+
 static int plane_accepts_linear_argb(int fd, uint32_t plane_id, uint32_t crtc_id) {
     PlaneProps pp;
     if (plane_get_basic_props(fd, plane_id, &pp) != 0) {
@@ -3302,6 +3312,44 @@ int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plan
 
     o->active = 1;
     return 0;
+}
+
+int osd_ensure_above_video(int fd, uint32_t video_plane_id, OSD *o) {
+    if (o == NULL || !o->enabled || !o->have_zpos || o->plane_id == 0) {
+        return 0;
+    }
+    if (video_plane_id == 0 || video_plane_id == o->plane_id) {
+        return 0;
+    }
+
+    PlaneProps video_props;
+    if (plane_get_basic_props(fd, video_plane_id, &video_props) != 0 || !video_props.have_zpos) {
+        LOGW("OSD: video plane %u missing ZPOS; cannot enforce plane ordering", video_plane_id);
+        return -1;
+    }
+
+    uint64_t osd_z = clamp_u64(o->zmax, o->zmin, o->zmax);
+    uint64_t video_z = video_props.zmin;
+    if (osd_z > video_props.zmin) {
+        video_z = clamp_u64(osd_z - 1, video_props.zmin, video_props.zmax);
+    }
+
+    if (osd_z <= video_z) {
+        LOGW("OSD: unable to ensure ordering (OSD z=%" PRIu64 ", video z=%" PRIu64 ")", osd_z, video_z);
+    }
+
+    drmModeAtomicReq *req = drmModeAtomicAlloc();
+    if (!req) {
+        return -1;
+    }
+    drmModeAtomicAddProperty(req, o->plane_id, o->p_zpos, osd_z);
+    drmModeAtomicAddProperty(req, video_plane_id, video_props.p_zpos, video_z);
+    int ret = drmModeAtomicCommit(fd, req, 0, NULL);
+    drmModeAtomicFree(req);
+    if (ret != 0) {
+        LOGW("OSD: failed to update plane zpos ordering: %s", strerror(errno));
+    }
+    return ret;
 }
 
 void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const PipelineState *ps,


### PR DESCRIPTION
### Motivation
- Prevent the OSD overlay from being placed below the video plane when the video decoder auto-selects a different plane at runtime.
- Ensure consistent visual stacking by enforcing DRM `ZPOS` ordering so the OSD is always on top of the active video plane.

### Description
- Add a new API `osd_ensure_above_video` (declared in `include/osd.h`) that adjusts plane `ZPOS` atomically for both the OSD and the video plane. 
- Implement helper `clamp_u64` and ordering logic in `src/osd.c` that queries plane props, computes safe `zpos` values, and commits them with `drmModeAtomicCommit`.
- Call `osd_ensure_above_video` from `src/main.c` after pipeline start/restart and after hotplug-induced restarts so ordering is enforced whenever the active video plane may change.

### Testing
- No automated tests were executed for this change.
- Manual integration should verify that after decoder plane selection the OSD remains visible above video on devices with `ZPOS` support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946abc882a8832bbd6d9c7477b25a70)