### PR TITLE
Support texts/values keys for external OSD updates

### DIFF
--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -49,8 +49,10 @@ External producers only need to send fields they care about. A minimal update
 looks like:
 
 ```json
-{"text":["HELLO","WORLD"], "value":[12.5, 0.75]}
+{"texts":["HELLO","WORLD"], "values":[12.5, 0.75]}
 ```
+
+Use the `texts`/`values` keys to publish data.
 
 If fewer than eight entries are present, the remaining slots keep their prior
 contents. Including an empty array clears previously published data. Optional
@@ -59,7 +61,7 @@ linger. The receiver tracks TTL per text/value slot so independent publishers
 can multiplex the feed without clobbering each other:
 
 ```json
-{"value":[42.0], "ttl_ms": 5000}
+{"values":[42.0], "ttl_ms": 5000}
 ```
 
 When the helper thread observes that `clock_gettime(CLOCK_MONOTONIC)` exceeds
@@ -111,7 +113,7 @@ duration.
   to half size around the centre looks like:
 
   ```json
-  {"text":["","","","","","","","zoom=50,50,50,50"], "ttl_ms": 1000}
+  {"texts":["","","","","","","","zoom=50,50,50,50"], "ttl_ms": 1000}
   ```
 
 * Clearing the slot (empty string) or publishing `zoom=off` restores the full
@@ -177,7 +179,7 @@ each refresh, so larger steps make the pulse travel faster. Setting
    (arrays longer than eight entries, missing fields, TTL expiry).
 2. Run the binary with the feature enabled and pipe updates manually:
    ```sh
-   printf '%s' '{"text":["BATTERY 12.6V"]}' | socat - UDP-DATAGRAM:127.0.0.1:5005
+   printf '%s' '{"texts":["BATTERY 12.6V"]}' | socat - UDP-DATAGRAM:127.0.0.1:5005
    ```
    Confirm the OSD text widget renders the injected string and that a line plot
    bound to `ext.value1` responds to subsequent updates.

--- a/src/osd_ext_feed.c
+++ b/src/osd_ext_feed.c
@@ -447,8 +447,8 @@ int main(int argc, char **argv)
 
                 char parsed_texts[MAX_ENTRIES][64];
                 double parsed_values[MAX_ENTRIES];
-                size_t text_count = parse_string_array(udp_buf, "text", parsed_texts, MAX_ENTRIES);
-                size_t value_count = parse_number_array(udp_buf, "value", parsed_values, MAX_ENTRIES);
+                size_t text_count = parse_string_array(udp_buf, "texts", parsed_texts, MAX_ENTRIES);
+                size_t value_count = parse_number_array(udp_buf, "values", parsed_values, MAX_ENTRIES);
                 uint64_t ttl_ms_field = 0;
                 bool has_ttl_field = parse_uint_field(udp_buf, "ttl_ms", &ttl_ms_field);
 

--- a/src/osd_external.c
+++ b/src/osd_external.c
@@ -396,13 +396,13 @@ static int parse_message(const char *payload, OsdExternalMessage *msg) {
         }
         ++p;
         p = skip_ws(p);
-        if (strcmp(key, "text") == 0) {
+        if (strcmp(key, "texts") == 0) {
             msg->has_text = 1;
             p = parse_string_array(p, msg);
             if (!p) {
                 return -1;
             }
-        } else if (strcmp(key, "value") == 0) {
+        } else if (strcmp(key, "values") == 0) {
             msg->has_value = 1;
             p = parse_number_array(p, msg);
             if (!p) {

--- a/tests/osd_feed_test.c
+++ b/tests/osd_feed_test.c
@@ -3,6 +3,10 @@
 // - Text rows show TICK that increments by 1 each second.
 // - Values follow sine curves (0.5 Hz) with per-channel phase offsets.
 // Build:  gcc -O2 -Wall -std=c11 osd_feed_test.c -o osd_feed_test -lm
+//
+// Payload fields:
+//   texts[]  -> maps to ext.textN (null entries skipped, "" clears)
+//   values[] -> maps to ext.valueN (null entries skipped)
 
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -134,9 +138,9 @@ int main(int argc, char **argv)
 
         if (clear_flag) {
             if (ttl_ms > 0)
-                snprintf(buf, sizeof(buf), "{\"text\":[],\"value\":[],\"ttl_ms\":%d}\n", ttl_ms);
+                snprintf(buf, sizeof(buf), "{\"texts\":[],\"values\":[],\"ttl_ms\":%d}\n", ttl_ms);
             else
-                snprintf(buf, sizeof(buf), "{\"text\":[],\"value\":[]}\n");
+                snprintf(buf, sizeof(buf), "{\"texts\":[],\"values\":[]}\n");
         } else {
             char text_part[1024] = {0};
             char value_part[512] = {0};
@@ -161,11 +165,11 @@ int main(int argc, char **argv)
 
             if (ttl_ms > 0)
                 snprintf(buf, sizeof(buf),
-                         "{\"text\":%s,\"value\":%s,\"ttl_ms\":%d}\n",
+                         "{\"texts\":%s,\"values\":%s,\"ttl_ms\":%d}\n",
                          text_part, value_part, ttl_ms);
             else
                 snprintf(buf, sizeof(buf),
-                         "{\"text\":%s,\"value\":%s}\n",
+                         "{\"texts\":%s,\"values\":%s}\n",
                          text_part, value_part);
         }
 


### PR DESCRIPTION
## Summary
- require the new `texts`/`values` fields for external OSD payloads and drop the old singular aliases
- keep the UDP feed helper and docs aligned to the plural-only schema for publishes and examples

## Testing
- gcc -O2 -Wall -std=c11 tests/osd_feed_test.c -o /tmp/osd_feed_test -lm


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb80e2e68832ba1bfdcc8b5709254)