### PR TITLE
Add per-element OSD refresh scheduling and honor zoom TTL

### DIFF
--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -76,6 +76,9 @@ affinity = 1,2,3
 enable = true
 ; The refresh interval is clamped to a minimum of 50ms to avoid busy loops.
 refresh-ms = 100
+; Optional per-element refresh override (in milliseconds). If omitted, elements inherit
+; the global [osd].refresh-ms. Values below 50 are clamped to 50.
+; Example: osd.element.stats.refresh-ms = 200, osd.element.signal_outline.refresh-ms = 50
 plane-id = 0
 ; Order of elements rendered each update
 ; The names reference [osd.element.NAME] sections below.

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -58,7 +58,9 @@ If fewer than eight entries are present, the remaining slots keep their prior
 contents. Including an empty array clears previously published data. Optional
 `ttl_ms` lets publishers request automatic expiry so stale telemetry does not
 linger. The receiver tracks TTL per text/value slot so independent publishers
-can multiplex the feed without clobbering each other:
+can multiplex the feed without clobbering each other. TTL also applies to
+`zoom` commands so a zoom request can naturally expire and revert when its TTL
+elapses:
 
 ```json
 {"values":[42.0], "ttl_ms": 5000}
@@ -109,8 +111,9 @@ duration.
 * Commands are debounced: the receiver only reprograms the plane when the text
   changes. Publish the same string again only when refreshing its TTL.
 * Include `ttl_ms` with every zoom update so the request naturally expires when
-  the publisher stops sending data. A typical one-second zoom command that crops
-  to half size around the centre looks like:
+  the publisher stops sending data. The receiver clears zoom commands when
+  their TTL elapses. A typical one-second zoom command that crops to half size
+  around the centre looks like:
 
   ```json
   {"texts":["","","","","","","","zoom=50,50,50,50"], "ttl_ms": 1000}

--- a/include/osd.h
+++ b/include/osd.h
@@ -2,6 +2,7 @@
 #define OSD_H
 
 #include <stdint.h>
+#include <time.h>
 
 #include "config.h"
 #include "drm_fb.h"
@@ -149,13 +150,16 @@ typedef struct OSD {
             OsdOutlineState outline;
         } data;
     } elements[OSD_MAX_ELEMENTS];
+    int element_refresh_ms[OSD_MAX_ELEMENTS];
+    struct timespec element_last_refresh[OSD_MAX_ELEMENTS];
 } OSD;
 
 void osd_init(OSD *osd);
 int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plane_id, OSD *osd);
-void osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const PipelineState *ps,
-                      int audio_disabled, int restart_count, const OsdExternalFeedSnapshot *ext,
-                      OSD *osd);
+int osd_refresh_hint_ms(const OSD *osd, int global_refresh_ms);
+int osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const PipelineState *ps,
+                     int audio_disabled, int restart_count, const OsdExternalFeedSnapshot *ext,
+                     const struct timespec *now, OSD *osd);
 int osd_is_enabled(const OSD *osd);
 int osd_is_active(const OSD *osd);
 int osd_enable(int fd, OSD *osd);

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -27,6 +27,7 @@ typedef struct {
     double value[OSD_EXTERNAL_MAX_VALUES];
     uint64_t last_update_ns;
     uint64_t expiry_ns;
+    uint64_t zoom_expiry_ns;
     char zoom_command[OSD_EXTERNAL_TEXT_LEN];
     OsdExternalStatus status;
 } OsdExternalFeedSnapshot;
@@ -49,6 +50,7 @@ typedef struct {
     pthread_mutex_t lock;
     OsdExternalFeedSnapshot snapshot;
     uint64_t expiry_ns;
+    uint64_t zoom_expiry_ns;
     uint64_t last_error_log_ns;
     OsdExternalSlotState slots[OSD_EXTERNAL_MAX_TEXT];
 } OsdExternalBridge;

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -109,6 +109,7 @@ typedef struct {
     OsdElementType type;
     char name[48];
     OsdPlacement placement;
+    int refresh_ms; /* Optional per-element refresh override; 0 inherits global OSD refresh. */
     union {
         OsdTextConfig text;
         OsdLineConfig line;


### PR DESCRIPTION
## Summary
- add per-element OSD refresh overrides and scheduling so the OSD loop can wake at the fastest required cadence
- keep slower loop work on the existing cadence while reducing poll timeouts when OSD is active
- honor external zoom commands’ ttl_ms by expiring zoom requests and clearing them when their TTL elapses
- document per-element refresh overrides in sample config and clarify zoom TTL handling in external OSD docs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eccbaac28832ba8478fc56e96bbfa)