### PR TITLE
feat: add PiP stream (second UDP) with default port 5601 and configurable plane/viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
 | `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
-| `[pip].format` | PiP plane format target (`nv12` or `yuv420_8bit`; default `yuv420_8bit`). Current code only renders NV12; `yuv420_8bit` is recognized and currently disabled with a clear startup error until AFBC/modifier support lands. |
+| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `yuv420_8bit`). Current code only renders NV12; `yuv420_8bit` is recognized and currently disabled with a clear startup error until AFBC/modifier support lands. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ to the defaults listed in `src/config.c` when omitted.
 | `[drm].osd-plane-id` | Optional explicit plane for the OSD overlay (0 keeps the auto-selection). |
 | `[udp].port` | UDP port that the RTP stream arrives on. |
 | `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
+| `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
+| `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
+| `[pip].video-plane-id` | DRM plane used by PiP (default `96`). |
+| `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
+| `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |
 | `[pipeline].custom-sink` | `receiver` to use the custom UDP receiver, or `udpsrc` for the bare GStreamer `udpsrc` pipeline. |
 | `[pipeline].pt97-filter` | `true` (default) keeps the RTP payload-type filter on `udpsrc`; set `false` to accept all payload types when CPU headroom is limited. |
@@ -207,3 +212,8 @@ When 64 consecutive HTTP bursts fail to clear the decoder warnings, the requeste
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
 
+## PiP design note (second UDP stream / plane 96)
+
+For planned picture-in-picture support that reuses the same decoder path on a second UDP port and targets configurable DRM planes (including plane 96 `YUV420_8BIT` scenarios), see `docs/pip_yuv420_8bit_plan.md`.
+
+The short version: the current decoder path is linear `NV12`-centric, while plane 96 often advertises `YUV420_8BIT` through AFBC modifiers; supporting that path cleanly requires modifier-aware buffer allocation/import rather than a simple software color conversion.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
-| `[pip].video-plane-id` | DRM plane used by PiP (default `96`). |
+| `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
 | `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
+| `[pip].format` | PiP plane format target (`nv12` or `yuv420_8bit`; default `yuv420_8bit`). Current code only renders NV12; `yuv420_8bit` is recognized and currently disabled with a clear startup error until AFBC/modifier support lands. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
 | `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
-| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `yuv420_8bit`). Current code only renders NV12; `yuv420_8bit` is recognized and currently disabled with a clear startup error until AFBC/modifier support lands. |
+| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). Current code only renders NV12; `yuv420_8bit` is recognized and currently requires AFBC/modifier import support that is still in progress. In `auto` mode PiP currently falls back to `nv12` when the yuv path is unavailable. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
 | `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
-| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). Current allocator path supports only linear layouts. `auto` skips `yuv420_8bit` when the target plane only advertises non-linear modifiers (for example AFBC on plane 96) and selects `nv12` instead. If strict PiP plane selection still cannot satisfy the chosen format, PiP is disabled to avoid endless restart retries. Explicit `yuv420_8bit` still fails fast until non-linear buffer allocation/import is implemented. |
+| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). For non-linear modifier formats (for example AFBC on plane 96), decoder now switches to an internal-buffer import path and attempts modifier-backed `drmModeAddFB2WithModifiers` registration per decoded frame. `auto` still falls back to `nv12` if the requested strict plane cannot satisfy the selected format. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
 | `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
-| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). Current allocator path supports only linear layouts. `auto` now skips `yuv420_8bit` when the target plane only advertises non-linear modifiers (for example AFBC on plane 96) and selects `nv12` instead. Explicit `yuv420_8bit` still fails fast until non-linear buffer allocation/import is implemented. |
+| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). Current allocator path supports only linear layouts. `auto` skips `yuv420_8bit` when the target plane only advertises non-linear modifiers (for example AFBC on plane 96) and selects `nv12` instead. If strict PiP plane selection still cannot satisfy the chosen format, PiP is disabled to avoid endless restart retries. Explicit `yuv420_8bit` still fails fast until non-linear buffer allocation/import is implemented. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pip].enable` | `true` enables a second PiP video stream/decoder instance (audio disabled for PiP). |
 | `[pip].udp-port` | UDP port for the PiP stream (default `5601`). |
 | `[pip].video-plane-id` | DRM plane used by PiP (default `96`). PiP uses strict plane selection and will fail to start instead of falling back to the main video plane. |
-| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). Current code only renders NV12; `yuv420_8bit` is recognized and currently requires AFBC/modifier import support that is still in progress. In `auto` mode PiP currently falls back to `nv12` when the yuv path is unavailable. |
+| `[pip].format` | PiP plane format target (`auto`, `nv12` or `yuv420_8bit`; default `auto`). Current allocator path supports only linear layouts. `auto` now skips `yuv420_8bit` when the target plane only advertises non-linear modifiers (for example AFBC on plane 96) and selects `nv12` instead. Explicit `yuv420_8bit` still fails fast until non-linear buffer allocation/import is implemented. |
 | `[pip].size` | PiP destination rectangle size in `WIDTHxHEIGHT` format (default `640x480`). |
 | `[pip].x` / `[pip].y` | PiP destination rectangle top-left coordinates in pixels. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -22,8 +22,8 @@ audio-pt = 98
 enable = false
 udp-port = 5601
 video-plane-id = 96
-; auto|nv12|yuv420_8bit (yuv420_8bit path is planned; defaults to yuv420_8bit)
-format = yuv420_8bit
+; auto|nv12|yuv420_8bit (default: auto)
+format = auto
 size = 640x480
 x = 40
 y = 40

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -22,7 +22,7 @@ audio-pt = 98
 enable = false
 udp-port = 5601
 video-plane-id = 96
-; nv12|yuv420_8bit (yuv420_8bit path is planned; defaults to yuv420_8bit)
+; auto|nv12|yuv420_8bit (yuv420_8bit path is planned; defaults to yuv420_8bit)
 format = yuv420_8bit
 size = 640x480
 x = 40

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -17,6 +17,15 @@ port = 5600
 video-pt = 97
 audio-pt = 98
 
+[pip]
+; Optional picture-in-picture second stream.
+enable = false
+udp-port = 5601
+video-plane-id = 96
+size = 640x480
+x = 40
+y = 40
+
 [pipeline]
 appsink-max-buffers = 8
 custom-sink = receiver

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -22,6 +22,8 @@ audio-pt = 98
 enable = false
 udp-port = 5601
 video-plane-id = 96
+; nv12|yuv420_8bit (yuv420_8bit path is planned; defaults to yuv420_8bit)
+format = yuv420_8bit
 size = 640x480
 x = 40
 y = 40

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -67,7 +67,8 @@ If hardware/driver constraints force format conversion, then an explicit convers
 
 - PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
 - PiP format configuration plumbing is in place (`auto`/`nv12`/`yuv420_8bit`).
-- `yuv420_8bit` path is partially wired (format/plane/modifier selection), while AFBC/modifier-backed framebuffer correctness remains under implementation; `auto` currently falls back to `nv12` when needed.
+- `yuv420_8bit` path is partially wired (format/plane/modifier selection), while AFBC/modifier-backed framebuffer correctness remains under implementation. Decoder init now probes a test framebuffer for the selected format/modifier and fails fast (returning the permanent-unsupported signal) when the current buffer allocator cannot import it.
+- `pip.format=auto` uses that permanent-unsupported signal to downgrade to `nv12` before entering repeated runtime failure loops.
 
 ## Practical rollout plan
 

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -67,8 +67,9 @@ If hardware/driver constraints force format conversion, then an explicit convers
 
 - PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
 - PiP format configuration plumbing is in place (`auto`/`nv12`/`yuv420_8bit`).
-- `yuv420_8bit` path is partially wired (format/plane/modifier selection), while AFBC/modifier-backed framebuffer correctness remains under implementation. Decoder init now probes a test framebuffer for the selected format/modifier and fails fast (returning the permanent-unsupported signal) when the current buffer allocator cannot import it.
-- `pip.format=auto` now skips `yuv420_8bit` on planes that only advertise non-linear modifiers and chooses `nv12` immediately. If strict plane selection still cannot satisfy the selected format, PiP is now disabled (instead of retrying forever). Explicit `yuv420_8bit` requests still fail fast with a clear allocator/modifier error.
+- `yuv420_8bit` path now attempts modifier-backed rendering via an internal-buffer import path: decoder frames are imported with `DRM_IOCTL_PRIME_FD_TO_HANDLE` and registered through `drmModeAddFB2WithModifiers` for the selected plane modifier.
+- `pip.format=auto` still keeps strict-plane safety: if the selected strict plane cannot satisfy the chosen format, PiP is disabled (instead of retrying forever).
+- AFBC details are still hardware-sensitive and under validation; the code now logs modifier-backed registration failures explicitly so bring-up can iterate with real device traces.
 
 ## Practical rollout plan
 

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -67,7 +67,7 @@ If hardware/driver constraints force format conversion, then an explicit convers
 
 - PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
 - PiP format configuration plumbing is in place (`auto`/`nv12`/`yuv420_8bit`).
-- `yuv420_8bit` currently fails fast with an explicit message because AFBC/modifier-aware framebuffer import is not implemented yet.
+- `yuv420_8bit` path is partially wired (format/plane/modifier selection), while AFBC/modifier-backed framebuffer correctness remains under implementation; `auto` currently falls back to `nv12` when needed.
 
 ## Practical rollout plan
 

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -68,7 +68,7 @@ If hardware/driver constraints force format conversion, then an explicit convers
 - PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
 - PiP format configuration plumbing is in place (`auto`/`nv12`/`yuv420_8bit`).
 - `yuv420_8bit` path is partially wired (format/plane/modifier selection), while AFBC/modifier-backed framebuffer correctness remains under implementation. Decoder init now probes a test framebuffer for the selected format/modifier and fails fast (returning the permanent-unsupported signal) when the current buffer allocator cannot import it.
-- `pip.format=auto` uses that permanent-unsupported signal to downgrade to `nv12` before entering repeated runtime failure loops.
+- `pip.format=auto` now skips `yuv420_8bit` on planes that only advertise non-linear modifiers and chooses `nv12` immediately. Explicit `yuv420_8bit` requests still fail fast with a clear allocator/modifier error.
 
 ## Practical rollout plan
 

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -34,7 +34,7 @@ By contrast, the current code uses `drmModeAddFB2(..., flags = 0)` with linear d
    - `pip.udp-port` (int)
    - `pip.video-plane-id` (int, default `96`)
    - `pip.x`, `pip.y`, `pip.width`, `pip.height`
-   - optional `pip.format` (`nv12|yuv420_8bit`)
+   - optional `pip.format` (`auto|nv12|yuv420_8bit`)
 
 3. **Refactor video decoder plane selection to be format-aware**
    - replace NV12-only probes with reusable helpers:
@@ -66,7 +66,7 @@ If hardware/driver constraints force format conversion, then an explicit convers
 ## Current implementation status
 
 - PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
-- PiP format configuration plumbing is in place (`nv12`/`yuv420_8bit`).
+- PiP format configuration plumbing is in place (`auto`/`nv12`/`yuv420_8bit`).
 - `yuv420_8bit` currently fails fast with an explicit message because AFBC/modifier-aware framebuffer import is not implemented yet.
 
 ## Practical rollout plan

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -1,0 +1,69 @@
+# Picture-in-picture (PiP) on a second DRM plane (YUV420_8BIT)
+
+This note captures what is required to add a second, independent video stream (PiP) that:
+
+- listens on a second UDP port,
+- reuses the same MPP-based decoder path as the main stream,
+- targets a configurable DRM plane (for example plane `96`), and
+- prefers `YUV420_8BIT` where possible.
+
+## Key finding from current implementation
+
+The current decoder path (`src/video_decoder.c`) allocates external DRM dumb buffers and registers framebuffers as `DRM_FORMAT_NV12` only. Plane selection is also hard-coded to look for linear `NV12` support.
+
+That means there is no generic "convert to YUV420_8BIT" stage today. The path is zero-copy NV12-oriented.
+
+## Why plane 96 is special on your dump
+
+On the provided `drm_info`, plane `96` advertises `YUV420_8BIT`, but via `IN_FORMATS` entries tied to `ARM_AFBC` modifiers (compressed surfaces), not plain linear buffers.
+
+By contrast, the current code uses `drmModeAddFB2(..., flags = 0)` with linear dumb buffers. So simply switching fourcc to `YUV420_8BIT` is not sufficient:
+
+1. framebuffer creation must carry AFBC modifiers (`drmModeAddFB2WithModifiers`),
+2. backing buffers must be allocated in a way compatible with AFBC layout,
+3. decoder output format/modifier must match what the plane accepts.
+
+## Recommended implementation strategy
+
+1. **Add a second pipeline instance (`PipelineState`)**
+   - `main`: existing stream (`udp.port`)
+   - `pip`: second stream (`pip.udp-port`)
+
+2. **Add PiP configuration keys** (INI + CLI)
+   - `pip.enable` (bool)
+   - `pip.udp-port` (int)
+   - `pip.video-plane-id` (int, default `96`)
+   - `pip.x`, `pip.y`, `pip.width`, `pip.height`
+   - optional `pip.format` (`auto|nv12|yuv420_8bit`)
+
+3. **Refactor video decoder plane selection to be format-aware**
+   - replace NV12-only probes with reusable helpers:
+     - `plane_accepts_format_with_modifiers(...)`
+     - `video_decoder_select_plane_for_format(...)`
+
+4. **Keep decoder path shared, instantiated twice**
+   - no architectural fork: same `VideoDecoder` API, two instances, different config/UDP source.
+   - each instance has independent `IdrRequester`, restart state, and stats labels.
+
+5. **Initial safe mode: PiP on NV12-capable plane**
+   - quickest route: enable PiP first with `NV12` on any plane that supports linear NV12.
+   - this gives feature value immediately and avoids AFBC complexities.
+
+6. **Optional advanced mode: YUV420_8BIT + AFBC**
+   - add modifier-aware FB import and atomic commit path.
+   - only enable when both decoder buffers and selected plane expose a matching AFBC modifier set.
+
+## Do we need conversion to YUV420_8BIT?
+
+Usually **not** as a software conversion step in this architecture.
+
+- If PiP runs in linear NV12 mode, continue using current zero-copy decode → plane flow.
+- If PiP must use plane 96 in `YUV420_8BIT`, this is primarily a **buffer layout/modifier compatibility** problem (AFBC), not a CPU colorspace-conversion problem.
+
+If hardware/driver constraints force format conversion, then an explicit conversion stage (RGA/GStreamer) may be needed, but that should be a fallback due to extra latency/CPU/GPU cost.
+
+## Practical rollout plan
+
+- **Phase 1:** dual UDP + dual decoder + configurable PiP rectangle using NV12-compatible plane.
+- **Phase 2:** add modifier negotiation and AFBC-capable path for plane 96/YUV420_8BIT.
+- **Phase 3:** auto-fallback logic (`requested format/plane -> best supported pair`) with clear logs.

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -70,6 +70,7 @@ If hardware/driver constraints force format conversion, then an explicit convers
 - `yuv420_8bit` path now attempts modifier-backed rendering via an internal-buffer import path: decoder frames are imported with `DRM_IOCTL_PRIME_FD_TO_HANDLE` and registered through `drmModeAddFB2WithModifiers` for the selected plane modifier.
 - `pip.format=auto` still keeps strict-plane safety: if the selected strict plane cannot satisfy the chosen format, PiP is disabled (instead of retrying forever).
 - AFBC details are still hardware-sensitive and under validation; the code now logs modifier-backed registration failures explicitly so bring-up can iterate with real device traces.
+- External linear NV12 path now maps 10-bit decoder frames to `NV15` framebuffer registration so 10-bit streams do not repeatedly fail `drmModeAddFB2` with an NV12 fourcc mismatch.
 
 ## Practical rollout plan
 

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -34,7 +34,7 @@ By contrast, the current code uses `drmModeAddFB2(..., flags = 0)` with linear d
    - `pip.udp-port` (int)
    - `pip.video-plane-id` (int, default `96`)
    - `pip.x`, `pip.y`, `pip.width`, `pip.height`
-   - optional `pip.format` (`auto|nv12|yuv420_8bit`)
+   - optional `pip.format` (`nv12|yuv420_8bit`)
 
 3. **Refactor video decoder plane selection to be format-aware**
    - replace NV12-only probes with reusable helpers:
@@ -61,6 +61,13 @@ Usually **not** as a software conversion step in this architecture.
 - If PiP must use plane 96 in `YUV420_8BIT`, this is primarily a **buffer layout/modifier compatibility** problem (AFBC), not a CPU colorspace-conversion problem.
 
 If hardware/driver constraints force format conversion, then an explicit conversion stage (RGA/GStreamer) may be needed, but that should be a fallback due to extra latency/CPU/GPU cost.
+
+
+## Current implementation status
+
+- PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
+- PiP format configuration plumbing is in place (`nv12`/`yuv420_8bit`).
+- `yuv420_8bit` currently fails fast with an explicit message because AFBC/modifier-aware framebuffer import is not implemented yet.
 
 ## Practical rollout plan
 

--- a/docs/pip_yuv420_8bit_plan.md
+++ b/docs/pip_yuv420_8bit_plan.md
@@ -68,7 +68,7 @@ If hardware/driver constraints force format conversion, then an explicit convers
 - PiP now supports strict requested-plane selection so it cannot silently steal the main NV12 plane.
 - PiP format configuration plumbing is in place (`auto`/`nv12`/`yuv420_8bit`).
 - `yuv420_8bit` path is partially wired (format/plane/modifier selection), while AFBC/modifier-backed framebuffer correctness remains under implementation. Decoder init now probes a test framebuffer for the selected format/modifier and fails fast (returning the permanent-unsupported signal) when the current buffer allocator cannot import it.
-- `pip.format=auto` now skips `yuv420_8bit` on planes that only advertise non-linear modifiers and chooses `nv12` immediately. Explicit `yuv420_8bit` requests still fail fast with a clear allocator/modifier error.
+- `pip.format=auto` now skips `yuv420_8bit` on planes that only advertise non-linear modifiers and chooses `nv12` immediately. If strict plane selection still cannot satisfy the selected format, PiP is now disabled (instead of retrying forever). Explicit `yuv420_8bit` requests still fail fast with a clear allocator/modifier error.
 
 ## Practical rollout plan
 

--- a/include/config.h
+++ b/include/config.h
@@ -78,6 +78,7 @@ typedef struct {
     char config_path[PATH_MAX];
     int plane_id;
     VideoViewportCfg viewport;
+    int strict_plane_selection;
     int use_udev;
     int mode_w;
     int mode_h;

--- a/include/config.h
+++ b/include/config.h
@@ -37,7 +37,8 @@ typedef struct {
 } VideoCtmCfg;
 
 typedef enum {
-    DECODER_PLANE_FORMAT_NV12 = 0,
+    DECODER_PLANE_FORMAT_AUTO = 0,
+    DECODER_PLANE_FORMAT_NV12,
     DECODER_PLANE_FORMAT_YUV420_8BIT,
 } DecoderPlaneFormat;
 

--- a/include/config.h
+++ b/include/config.h
@@ -37,6 +37,20 @@ typedef struct {
 } VideoCtmCfg;
 
 typedef struct {
+    int x;
+    int y;
+    int width;
+    int height;
+} VideoViewportCfg;
+
+typedef struct {
+    int enable;
+    int udp_port;
+    int plane_id;
+    VideoViewportCfg viewport;
+} PipCfg;
+
+typedef struct {
     int enable;
     char bind_address[64];
     int port;
@@ -63,6 +77,7 @@ typedef struct {
     char connector_name[32];
     char config_path[PATH_MAX];
     int plane_id;
+    VideoViewportCfg viewport;
     int use_udev;
     int mode_w;
     int mode_h;
@@ -112,6 +127,7 @@ typedef struct {
     SseCfg sse;
     IdrCfg idr;
     VideoCtmCfg video_ctm;
+    PipCfg pip;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/config.h
+++ b/include/config.h
@@ -36,6 +36,11 @@ typedef struct {
     double matrix[9];
 } VideoCtmCfg;
 
+typedef enum {
+    DECODER_PLANE_FORMAT_NV12 = 0,
+    DECODER_PLANE_FORMAT_YUV420_8BIT,
+} DecoderPlaneFormat;
+
 typedef struct {
     int x;
     int y;
@@ -47,6 +52,7 @@ typedef struct {
     int enable;
     int udp_port;
     int plane_id;
+    DecoderPlaneFormat format;
     VideoViewportCfg viewport;
 } PipCfg;
 
@@ -77,6 +83,7 @@ typedef struct {
     char connector_name[32];
     char config_path[PATH_MAX];
     int plane_id;
+    DecoderPlaneFormat plane_format;
     VideoViewportCfg viewport;
     int strict_plane_selection;
     int use_udev;
@@ -142,6 +149,8 @@ int cfg_parse_custom_sink_mode(const char *value, CustomSinkMode *mode_out);
 const char *cfg_custom_sink_mode_name(CustomSinkMode mode);
 int cfg_parse_record_mode(const char *value, RecordMode *mode_out);
 const char *cfg_record_mode_name(RecordMode mode);
+int cfg_parse_decoder_plane_format(const char *value, DecoderPlaneFormat *format_out);
+const char *cfg_decoder_plane_format_name(DecoderPlaneFormat format);
 int cfg_parse_host_and_port(const char *value, char *host_out, size_t host_len, int *port_out);
 int cfg_set_drm_mode_from_string(const char *value, AppCfg *cfg);
 

--- a/src/config.c
+++ b/src/config.c
@@ -188,6 +188,7 @@ void cfg_defaults(AppCfg *c) {
     c->viewport.y = 0;
     c->viewport.width = 0;
     c->viewport.height = 0;
+    c->strict_plane_selection = 0;
     c->use_udev = 1;
     c->mode_w = 0;
     c->mode_h = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -24,7 +24,7 @@ static void usage(const char *prog) {
             "  --pip                        (enable PiP stream)\n"
             "  --pip-udp-port N            (PiP listen port; default: 5601)\n"
             "  --pip-plane-id N            (PiP video plane; default: 96)\n"
-            "  --pip-format FORMAT         (PiP format: nv12|yuv420_8bit; default: yuv420_8bit)\n"
+            "  --pip-format FORMAT         (PiP format: auto|nv12|yuv420_8bit; default: yuv420_8bit)\n"
             "  --pip-size WxH              (PiP destination size, e.g. 640x480)\n"
             "  --pip-pos X,Y               (PiP destination top-left position)\n"
             "  --vid-pt N                   (default: 97 H265)\n"
@@ -103,6 +103,7 @@ typedef struct {
 } DecoderPlaneFormatAlias;
 
 static const DecoderPlaneFormatAlias kDecoderPlaneFormatAliases[] = {
+    {"auto", DECODER_PLANE_FORMAT_AUTO},
     {"nv12", DECODER_PLANE_FORMAT_NV12},
     {"yuv420_8bit", DECODER_PLANE_FORMAT_YUV420_8BIT},
     {"yuv420-8bit", DECODER_PLANE_FORMAT_YUV420_8BIT},
@@ -174,6 +175,8 @@ int cfg_parse_decoder_plane_format(const char *value, DecoderPlaneFormat *format
 
 const char *cfg_decoder_plane_format_name(DecoderPlaneFormat format) {
     switch (format) {
+    case DECODER_PLANE_FORMAT_AUTO:
+        return "auto";
     case DECODER_PLANE_FORMAT_NV12:
         return "nv12";
     case DECODER_PLANE_FORMAT_YUV420_8BIT:
@@ -524,7 +527,7 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
         } else if (!strcmp(argv[i], "--pip-format") && i + 1 < argc) {
             DecoderPlaneFormat format;
             if (cfg_parse_decoder_plane_format(argv[++i], &format) != 0) {
-                LOGE("--pip-format requires one of: nv12, yuv420_8bit");
+                LOGE("--pip-format requires one of: auto, nv12, yuv420_8bit");
                 return -1;
             }
             cfg->pip.enable = 1;

--- a/src/config.c
+++ b/src/config.c
@@ -24,7 +24,7 @@ static void usage(const char *prog) {
             "  --pip                        (enable PiP stream)\n"
             "  --pip-udp-port N            (PiP listen port; default: 5601)\n"
             "  --pip-plane-id N            (PiP video plane; default: 96)\n"
-            "  --pip-format FORMAT         (PiP format: auto|nv12|yuv420_8bit; default: yuv420_8bit)\n"
+            "  --pip-format FORMAT         (PiP format: auto|nv12|yuv420_8bit; default: auto)\n"
             "  --pip-size WxH              (PiP destination size, e.g. 640x480)\n"
             "  --pip-pos X,Y               (PiP destination top-left position)\n"
             "  --vid-pt N                   (default: 97 H265)\n"
@@ -298,7 +298,7 @@ void cfg_defaults(AppCfg *c) {
     c->pip.enable = 0;
     c->pip.udp_port = 5601;
     c->pip.plane_id = 96;
-    c->pip.format = DECODER_PLANE_FORMAT_YUV420_8BIT;
+    c->pip.format = DECODER_PLANE_FORMAT_AUTO;
     c->pip.viewport.x = 0;
     c->pip.viewport.y = 0;
     c->pip.viewport.width = 640;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1204,6 +1204,16 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->pip.enable = 1;
             return 0;
         }
+        if (strcasecmp(key, "format") == 0) {
+            DecoderPlaneFormat format;
+            if (cfg_parse_decoder_plane_format(value, &format) != 0) {
+                LOGE("config: pip format '%s' is invalid (use nv12 or yuv420_8bit)", value);
+                return -1;
+            }
+            cfg->pip.format = format;
+            cfg->pip.enable = 1;
+            return 0;
+        }
         if (strcasecmp(key, "size") == 0) {
             int w = 0;
             int h = 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1180,6 +1180,61 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "pip") == 0) {
+        if (strcasecmp(key, "enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->pip.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "udp-port") == 0 || strcasecmp(key, "port") == 0) {
+            int port = atoi(value);
+            if (port <= 0 || port > 65535) {
+                LOGE("config: pip udp port '%s' out of range", value);
+                return -1;
+            }
+            cfg->pip.udp_port = port;
+            cfg->pip.enable = 1;
+            return 0;
+        }
+        if (strcasecmp(key, "video-plane-id") == 0 || strcasecmp(key, "plane-id") == 0) {
+            cfg->pip.plane_id = atoi(value);
+            cfg->pip.enable = 1;
+            return 0;
+        }
+        if (strcasecmp(key, "size") == 0) {
+            int w = 0;
+            int h = 0;
+            if (parse_size(value, &w, &h) != 0 || w <= 0 || h <= 0) {
+                return -1;
+            }
+            cfg->pip.viewport.width = w;
+            cfg->pip.viewport.height = h;
+            cfg->pip.enable = 1;
+            return 0;
+        }
+        if (strcasecmp(key, "x") == 0) {
+            int x = atoi(value);
+            if (x < 0) {
+                return -1;
+            }
+            cfg->pip.viewport.x = x;
+            cfg->pip.enable = 1;
+            return 0;
+        }
+        if (strcasecmp(key, "y") == 0) {
+            int y = atoi(value);
+            if (y < 0) {
+                return -1;
+            }
+            cfg->pip.viewport.y = y;
+            cfg->pip.enable = 1;
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "record") == 0) {
         if (strcasecmp(key, "enable") == 0) {
             int v = 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1207,7 +1207,7 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         if (strcasecmp(key, "format") == 0) {
             DecoderPlaneFormat format;
             if (cfg_parse_decoder_plane_format(value, &format) != 0) {
-                LOGE("config: pip format '%s' is invalid (use nv12 or yuv420_8bit)", value);
+                LOGE("config: pip format '%s' is invalid (use auto, nv12 or yuv420_8bit)", value);
                 return -1;
             }
             cfg->pip.format = format;

--- a/src/main.c
+++ b/src/main.c
@@ -338,6 +338,11 @@ static void start_pip_pipeline(AppCfg *cfg,
                 LOGW("PiP disabled: requested format '%s' is not implemented on this build",
                      cfg_decoder_plane_format_name(pip_cfg.plane_format));
             }
+        } else if (pip_start_rc == -3) {
+            cfg->pip.enable = 0;
+            LOGW("PiP disabled: strict plane %d does not support selected format '%s'",
+                 pip_cfg.plane_id,
+                 cfg_decoder_plane_format_name(pip_cfg.plane_format));
         }
         return;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -330,9 +330,14 @@ static void start_pip_pipeline(AppCfg *cfg,
     if (pip_start_rc != 0) {
         LOGE("Failed to start PiP pipeline");
         if (pip_start_rc == -2) {
-            cfg->pip.enable = 0;
-            LOGW("PiP disabled: requested format '%s' is not implemented on this build",
-                 cfg_decoder_plane_format_name(pip_cfg.plane_format));
+            if (cfg->pip.format == DECODER_PLANE_FORMAT_AUTO) {
+                cfg->pip.format = DECODER_PLANE_FORMAT_NV12;
+                LOGW("PiP fallback: auto format selected unsupported yuv420_8bit path; switching to nv12");
+            } else {
+                cfg->pip.enable = 0;
+                LOGW("PiP disabled: requested format '%s' is not implemented on this build",
+                     cfg_decoder_plane_format_name(pip_cfg.plane_format));
+            }
         }
         return;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -304,6 +304,7 @@ static void configure_pip_cfg(const AppCfg *base_cfg, AppCfg *pip_cfg) {
     pip_cfg->udp_port = base_cfg->pip.udp_port;
     pip_cfg->plane_id = base_cfg->pip.plane_id;
     pip_cfg->viewport = base_cfg->pip.viewport;
+    pip_cfg->strict_plane_selection = 1;
     pip_cfg->no_audio = 1;
     pip_cfg->record.enable = 0;
     pip_cfg->osd_enable = 0;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -961,13 +961,13 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
     int decoder_init_rc = video_decoder_init(ps->decoder, cfg, ms, drm_fd);
     if (decoder_init_rc != 0) {
         LOGE("Failed to initialise video decoder");
-        if (decoder_init_rc == -2) {
+        if (decoder_init_rc == -2 || decoder_init_rc == -3) {
             if (pipeline != NULL) {
                 gst_element_set_state(pipeline, GST_STATE_NULL);
             }
             cleanup_pipeline(ps);
             ps->state = PIPELINE_STOPPED;
-            return -2;
+            return decoder_init_rc;
         }
         goto fail;
     }

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -428,9 +428,9 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
 
     ps->pipeline = pipeline;
     ps->video_sink = appsink;
-    ps->video_depay = depay;
-    ps->video_parser = parser;
-    ps->video_capsfilter = capsfilter;
+    ps->video_depay = gst_object_ref(depay);
+    ps->video_parser = gst_object_ref(parser);
+    ps->video_capsfilter = gst_object_ref(capsfilter);
     ps->udp_receiver = receiver;
     return TRUE;
 

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -958,8 +958,17 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
         }
     }
 
-    if (video_decoder_init(ps->decoder, cfg, ms, drm_fd) != 0) {
+    int decoder_init_rc = video_decoder_init(ps->decoder, cfg, ms, drm_fd);
+    if (decoder_init_rc != 0) {
         LOGE("Failed to initialise video decoder");
+        if (decoder_init_rc == -2) {
+            if (pipeline != NULL) {
+                gst_element_set_state(pipeline, GST_STATE_NULL);
+            }
+            cleanup_pipeline(ps);
+            ps->state = PIPELINE_STOPPED;
+            return -2;
+        }
         goto fail;
     }
     ps->decoder_initialized = TRUE;

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -1510,7 +1510,16 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     vd->packet_buf_size = 0;
     vd->packet_buf = NULL;
 
-    if (cfg->plane_format == DECODER_PLANE_FORMAT_YUV420_8BIT) {
+    DecoderPlaneFormat requested_format = cfg->plane_format;
+    if (requested_format == DECODER_PLANE_FORMAT_AUTO) {
+        gboolean plane_lists_yuv = plane_lists_format(drm_fd, (uint32_t)cfg->plane_id, DRM_FORMAT_YUV420_8BIT);
+        requested_format = plane_lists_yuv ? DECODER_PLANE_FORMAT_YUV420_8BIT : DECODER_PLANE_FORMAT_NV12;
+        LOGI("Video decoder: auto-selected requested plane format '%s' for plane %u",
+             cfg_decoder_plane_format_name(requested_format),
+             (uint32_t)cfg->plane_id);
+    }
+
+    if (requested_format == DECODER_PLANE_FORMAT_YUV420_8BIT) {
         gboolean plane_lists_yuv = plane_lists_format(drm_fd, (uint32_t)cfg->plane_id, DRM_FORMAT_YUV420_8BIT);
         if (plane_lists_yuv) {
             LOGE("Video decoder: requested format yuv420_8bit on plane %u requires AFBC/modifier-aware framebuffer setup, which is not implemented yet",

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -1738,6 +1738,9 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     if (desired_fourcc == DRM_FORMAT_NV12) {
         if (!video_decoder_select_plane(drm_fd, vd->crtc_id, (uint32_t)cfg->plane_id, strict_requested, &chosen_plane)) {
             LOGE("Video decoder: unable to find NV12-capable plane for CRTC %u", vd->crtc_id);
+            if (strict_requested) {
+                return -3;
+            }
             return -1;
         }
     } else {
@@ -1746,7 +1749,7 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
             chosen_plane = (uint32_t)cfg->plane_id;
         } else if (strict_requested) {
             LOGE("Video decoder: requested plane %u does not advertise yuv420_8bit format", (uint32_t)cfg->plane_id);
-            return -1;
+            return -3;
         } else {
             LOGW("Video decoder: requested plane %u does not advertise yuv420_8bit format; searching for fallback plane",
                  (uint32_t)cfg->plane_id);


### PR DESCRIPTION
### Motivation
- Provide a picture-in-picture (PiP) runtime that reuses the existing decoder path on a second UDP port and can target a configurable DRM plane and destination rectangle. 
- Default the PiP listener to port `5601` and allow specifying the PiP destination size and position (e.g. `640x480` at `x,y`) for practical placement.
- Keep the main-stream behaviour unchanged when PiP is disabled and integrate PiP into startup/hotplug/restart/shutdown flows.

### Description
- Added PiP configuration types and fields to `AppCfg` (`PipCfg`, `VideoViewportCfg`) and default values (PiP disabled, `udp_port = 5601`, `plane_id = 96`, default viewport `640x480`).
- Implemented CLI flags `--pip`, `--pip-udp-port`, `--pip-plane-id`, `--pip-size WxH`, and `--pip-pos X,Y` plus corresponding INI keys under an added `[pip]` section (`enable`, `udp-port`, `video-plane-id`, `size`, `x`, `y`).
- Wired a second pipeline instance for PiP into the main lifecycle: `start_pip_pipeline()` / `configure_pip_cfg()` in `src/main.c`, ensuring PiP runs with audio disabled and is managed during startup, hotplug, restart, and shutdown.
- Extended `video_decoder` to support per-instance viewport metadata and modified `commit_plane()` to render into an arbitrary destination rectangle with aspect-fit behavior, enabling PiP placement/size while preserving the main fullscreen path.
- Updated documentation and samples: `README.md` INI key table, `config/osd-sample.ini` with a `[pip]` block, and added `docs/pip_yuv420_8bit_plan.md` describing AFBC/YUV420_8BIT implications and rollout strategy.

### Testing
- Performed syntax-only checks on modified parsers with `cc -fsyntax-only -Iinclude src/config.c` and `cc -fsyntax-only -Iinclude src/config_ini.c`, which succeeded.
- Attempted a full build with `make -j4`, which could not complete in this environment due to missing system development headers (`xf86drm.h`, `glib.h`), so the full binary was not built here.
- Performed local static checks and basic compile sanity for changed translation units where system headers were available; changes were committed after local verification of parser and ABI adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f8590e654832b86c303318d94a906)