### PR TITLE
Remove OSD outline widget support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[osd].refresh-ms` | Interval between OSD refreshes. |
 | `[osd].plane-id` | Optional override for the OSD plane (mirrors `[drm].osd-plane-id`). |
 | `[osd].elements` | Comma-separated list describing the render order of `[osd.element.NAME]` blocks. |
-| `[osd.element.NAME].type` | Widget style (`text`, `line`, `bar`, `outline`, or `image`). Each type unlocks additional keys listed in the sample file. |
+| `[osd.element.NAME].type` | Widget style (`text`, `line`, `bar`, or `image`). Each type unlocks additional keys listed in the sample file. |
 | `[osd.element.NAME].anchor` / `offset` / `size` / color keys | Control placement and styling for OSD widgets. See inline comments in the sample file for full semantics. |
 | `[osd.element.NAME].line` | For text widgets, each `line =` entry appends a formatted row supporting `{token}` placeholders. |
 | `[osd.element.NAME].metric` | For line/bar widgets, selects the metric token (e.g. `udp.bitrate.latest_mbps`) sampled each refresh. |

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -67,12 +67,11 @@ refresh-ms = 100
 plane-id = 0
 ; Order of elements rendered each update
 ; The names reference [osd.element.NAME] sections below.
-elements = stats, recording_indicator, station_logo, framesize_plot, bitrate_plot, jitter_plot, signal_outline
+elements = stats, recording_indicator, station_logo, framesize_plot, bitrate_plot, jitter_plot
 
 [osd.external]
 ; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
-; tokens/metrics into the OSD. Enabled here so the pulsing outline sample
-; can react to the external metric feed immediately.
+; tokens/metrics into the OSD.
 enable = true
 
 ; -----------------------------------------------------------------------------
@@ -121,20 +120,6 @@ type = image
 anchor = top-right
 offset = -16,56
 asset = /opt/pixelpilot/assets/station_logo.png
-
-[osd.element.signal_outline]
-; Animated alpha-blended frame that follows ext.value1. When the value drops
-; below the threshold the outline pulses in and out along the screen border.
-type = outline
-metric = ext.value1
-threshold = 30
-trigger = below
-color = 0x90FF4500
-inactive-color = 0x00000000
-base-thickness = 8
-pulse-period = 48
-pulse-amplitude = 4
-pulse-step = 2
 
 ; To create additional text blocks duplicate the section with a new element
 ; name and adjust the anchor/offset. Each `line =` entry appends to that block.

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -84,7 +84,7 @@ refresh-ms = 100
 plane-id = 0
 ; Optional per-element refresh override (in milliseconds). If omitted, elements inherit
 ; the global [osd].refresh-ms. Values below 50 are clamped to 50.
-; Example: osd.element.stats.refresh-ms = 200, osd.element.signal_outline.refresh-ms = 50
+; Example: osd.element.stats.refresh-ms = 200, osd.element.bitrate_plot.refresh-ms = 50
 ; Order of elements rendered each update
 ; The names reference [osd.element.NAME] sections below.
 elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot

--- a/docs/osd-external-data.md
+++ b/docs/osd-external-data.md
@@ -133,35 +133,6 @@ unknown, configuration files created on older builds keep working: users only
 see `{ext.text1}` until they update the binary to a release containing the
 bridge.
 
-### Animated outline widget
-
-The OSD includes an `outline` element type that renders an alpha-blended frame
-around the screen. The widget listens to any metric (for example
-`ext.value1`) and animates whenever the sampled value crosses a configured
-threshold. A representative INI snippet looks like:
-
-```ini
-[osd.element.signal_outline]
-type = outline
-metric = ext.value1
-threshold = 30
-trigger = below
-color = 0x90FF4500
-base-thickness = 8
-pulse-period = 48
-pulse-amplitude = 4
-pulse-step = 2
-```
-
-With the example above the outline begins pulsing when `ext.value1 < 30`. The
-color accepts any ARGB value, so using a partially transparent colour ensures
-the animation blends with the video underneath. `base-thickness` establishes
-the baseline border width, `pulse-period` controls the full in/out pulse cycle
-(higher numbers slow the animation), and `pulse-amplitude` defines how far the
-border expands beyond the baseline. `pulse-step` advances the animation phase on
-each refresh, so larger steps make the pulse travel faster. Setting
-`inactive-color` keeps a static border visible even when the trigger is not met.
-
 ## Error handling and observability
 
 * Socket creation failures should log a warning and keep the rest of the

--- a/include/osd.h
+++ b/include/osd.h
@@ -94,12 +94,6 @@ typedef struct {
 } OsdBarState;
 
 typedef struct {
-    int phase;
-    int last_active;
-    int last_thickness;
-} OsdOutlineState;
-
-typedef struct {
     uint8_t *pixels;
     int width;
     int height;
@@ -154,7 +148,6 @@ typedef struct OSD {
             OsdTextState text;
             OsdLineState line;
             OsdBarState bar;
-            OsdOutlineState outline;
             OsdImageState image;
         } data;
     } elements[OSD_MAX_ELEMENTS];

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -12,7 +12,6 @@ typedef enum {
     OSD_WIDGET_TEXT = 0,
     OSD_WIDGET_LINE,
     OSD_WIDGET_BAR,
-    OSD_WIDGET_OUTLINE,
     OSD_WIDGET_IMAGE
 } OsdElementType;
 
@@ -95,18 +94,6 @@ typedef struct {
 } OsdBarConfig;
 
 typedef struct {
-    char metric[64];
-    double threshold;
-    int activate_when_below;
-    uint32_t active_color;
-    uint32_t inactive_color;
-    int base_thickness_px;
-    int pulse_period_ticks;
-    int pulse_amplitude_px;
-    int pulse_step_ticks;
-} OsdOutlineConfig;
-
-typedef struct {
     char asset[256];
 } OsdImageConfig;
 
@@ -119,7 +106,6 @@ typedef struct {
         OsdTextConfig text;
         OsdLineConfig line;
         OsdBarConfig bar;
-        OsdOutlineConfig outline;
         OsdImageConfig image;
     } data;
 } OsdElementConfig;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -173,19 +173,6 @@ static void builder_reset_bar(OsdElementConfig *elem) {
     }
 }
 
-static void builder_reset_outline(OsdElementConfig *elem) {
-    elem->type = OSD_WIDGET_OUTLINE;
-    elem->refresh_ms = 0;
-    ini_copy_string(elem->data.outline.metric, sizeof(elem->data.outline.metric), "ext.value1");
-    elem->data.outline.threshold = 30.0;
-    elem->data.outline.activate_when_below = 1;
-    elem->data.outline.active_color = 0x90FF4500u;
-    elem->data.outline.inactive_color = 0x00000000u;
-    elem->data.outline.base_thickness_px = 8;
-    elem->data.outline.pulse_period_ticks = 48;
-    elem->data.outline.pulse_amplitude_px = 4;
-    elem->data.outline.pulse_step_ticks = 2;
-}
 
 static void builder_reset_image(OsdElementConfig *elem) {
     elem->type = OSD_WIDGET_IMAGE;
@@ -254,22 +241,6 @@ static int builder_finalize(OsdLayoutBuilder *b, OsdLayout *out_layout) {
             }
             if (elem->data.bar.bar_width_px <= 0) {
                 elem->data.bar.bar_width_px = 8;
-            }
-        } else if (elem->type == OSD_WIDGET_OUTLINE) {
-            if (elem->data.outline.base_thickness_px <= 0) {
-                elem->data.outline.base_thickness_px = 8;
-            }
-            if (elem->data.outline.pulse_period_ticks <= 0) {
-                elem->data.outline.pulse_period_ticks = 48;
-            }
-            if (elem->data.outline.pulse_amplitude_px < 0) {
-                elem->data.outline.pulse_amplitude_px = 0;
-            }
-            if (elem->data.outline.pulse_amplitude_px > elem->data.outline.base_thickness_px) {
-                elem->data.outline.pulse_amplitude_px = elem->data.outline.base_thickness_px;
-            }
-            if (elem->data.outline.pulse_step_ticks <= 0) {
-                elem->data.outline.pulse_step_ticks = 2;
             }
         } else if (elem->type == OSD_WIDGET_IMAGE) {
             if (elem->data.image.asset[0] == '\0') {
@@ -733,95 +704,6 @@ static int parse_osd_element_bar(OsdElementConfig *elem, const char *key, const 
     return -1;
 }
 
-static int parse_osd_element_outline(OsdElementConfig *elem, const char *key, const char *value) {
-    if (strcasecmp(key, "metric") == 0) {
-        ini_copy_string(elem->data.outline.metric, sizeof(elem->data.outline.metric), value);
-        return 0;
-    }
-    if (strcasecmp(key, "threshold") == 0 || strcasecmp(key, "limit") == 0) {
-        double v = 0.0;
-        if (parse_double(value, &v) != 0) {
-            return -1;
-        }
-        elem->data.outline.threshold = v;
-        return 0;
-    }
-    if (strcasecmp(key, "activate-below") == 0) {
-        double v = 0.0;
-        if (parse_double(value, &v) != 0) {
-            return -1;
-        }
-        elem->data.outline.threshold = v;
-        elem->data.outline.activate_when_below = 1;
-        return 0;
-    }
-    if (strcasecmp(key, "activate-above") == 0) {
-        double v = 0.0;
-        if (parse_double(value, &v) != 0) {
-            return -1;
-        }
-        elem->data.outline.threshold = v;
-        elem->data.outline.activate_when_below = 0;
-        return 0;
-    }
-    if (strcasecmp(key, "trigger") == 0 || strcasecmp(key, "mode") == 0) {
-        if (strcasecmp(value, "below") == 0 || strcasecmp(value, "less") == 0) {
-            elem->data.outline.activate_when_below = 1;
-            return 0;
-        }
-        if (strcasecmp(value, "above") == 0 || strcasecmp(value, "greater") == 0) {
-            elem->data.outline.activate_when_below = 0;
-            return 0;
-        }
-        return -1;
-    }
-    if (strcasecmp(key, "color") == 0 || strcasecmp(key, "active-color") == 0 ||
-        strcasecmp(key, "active_colour") == 0) {
-        uint32_t color = 0;
-        if (parse_color(value, &color) != 0) {
-            return -1;
-        }
-        elem->data.outline.active_color = color;
-        return 0;
-    }
-    if (strcasecmp(key, "inactive-color") == 0 || strcasecmp(key, "inactive_colour") == 0) {
-        uint32_t color = 0;
-        if (parse_color(value, &color) != 0) {
-            return -1;
-        }
-        elem->data.outline.inactive_color = color;
-        return 0;
-    }
-    if (strcasecmp(key, "base-thickness") == 0 || strcasecmp(key, "base-thickness-px") == 0 ||
-        strcasecmp(key, "base_thickness") == 0 || strcasecmp(key, "base_thickness_px") == 0 ||
-        strcasecmp(key, "thickness") == 0 || strcasecmp(key, "thickness-px") == 0) {
-        elem->data.outline.base_thickness_px = atoi(value);
-        return 0;
-    }
-    if (strcasecmp(key, "pulse-period") == 0 || strcasecmp(key, "pulse-period-ticks") == 0 ||
-        strcasecmp(key, "pulse_period") == 0 || strcasecmp(key, "pulse_period_ticks") == 0 ||
-        strcasecmp(key, "pattern-length") == 0 || strcasecmp(key, "pattern-length-px") == 0 ||
-        strcasecmp(key, "pattern_length") == 0 || strcasecmp(key, "pattern_length_px") == 0) {
-        elem->data.outline.pulse_period_ticks = atoi(value);
-        return 0;
-    }
-    if (strcasecmp(key, "pulse-amplitude") == 0 || strcasecmp(key, "pulse-amplitude-px") == 0 ||
-        strcasecmp(key, "pulse-on") == 0 || strcasecmp(key, "pulse_amplitude") == 0 ||
-        strcasecmp(key, "pulse_amplitude_px") == 0 || strcasecmp(key, "pattern-active") == 0 ||
-        strcasecmp(key, "pattern-active-px") == 0 || strcasecmp(key, "pattern-on") == 0 ||
-        strcasecmp(key, "pattern_active") == 0 || strcasecmp(key, "pattern_active_px") == 0) {
-        elem->data.outline.pulse_amplitude_px = atoi(value);
-        return 0;
-    }
-    if (strcasecmp(key, "pulse-step") == 0 || strcasecmp(key, "pulse-step-ticks") == 0 ||
-        strcasecmp(key, "pulse_step") == 0 || strcasecmp(key, "pulse_step_ticks") == 0 ||
-        strcasecmp(key, "speed") == 0 || strcasecmp(key, "scroll-speed") == 0 ||
-        strcasecmp(key, "speed-px") == 0 || strcasecmp(key, "speed_px") == 0) {
-        elem->data.outline.pulse_step_ticks = atoi(value);
-        return 0;
-    }
-    return -1;
-}
 
 static int parse_osd_element_image(OsdElementConfig *elem, const char *key, const char *value) {
     if (strcasecmp(key, "asset") == 0 || strcasecmp(key, "path") == 0 || strcasecmp(key, "png") == 0) {
@@ -857,11 +739,6 @@ static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name
         }
         if (strcasecmp(value, "bar") == 0) {
             builder_reset_bar(elem);
-            builder->type_set[idx] = 1;
-            return 0;
-        }
-        if (strcasecmp(value, "outline") == 0) {
-            builder_reset_outline(elem);
             builder->type_set[idx] = 1;
             return 0;
         }
@@ -907,9 +784,6 @@ static int parse_osd_element(OsdLayoutBuilder *builder, const char *section_name
     }
     if (elem->type == OSD_WIDGET_BAR) {
         return parse_osd_element_bar(elem, key, value);
-    }
-    if (elem->type == OSD_WIDGET_OUTLINE) {
-        return parse_osd_element_outline(elem, key, value);
     }
     if (elem->type == OSD_WIDGET_IMAGE) {
         return parse_osd_element_image(elem, key, value);

--- a/src/osd.c
+++ b/src/osd.c
@@ -313,57 +313,6 @@ static void osd_fill_rect(OSD *o, int x, int y, int w, int h, uint32_t argb) {
     }
 }
 
-static int osd_outline_compute_thickness(const OSD *o, const OsdOutlineConfig *cfg) {
-    if (!o) {
-        return 0;
-    }
-    int scale = (o->scale > 0) ? o->scale : 1;
-    int thickness = (cfg && cfg->base_thickness_px > 0) ? cfg->base_thickness_px : (6 * scale);
-    if (thickness < 2) {
-        thickness = 2;
-    }
-    if (thickness > o->h / 2) {
-        thickness = o->h / 2;
-    }
-    if (thickness > o->w / 2) {
-        thickness = o->w / 2;
-    }
-    if (thickness <= 0) {
-        thickness = 1;
-    }
-    return thickness;
-}
-
-static void osd_damage_add_rect(OSD *o, int x, int y, int w, int h);
-
-static void osd_outline_clear(OSD *o, int thickness) {
-    if (!o || thickness <= 0 || o->w <= 0 || o->h <= 0) {
-        return;
-    }
-    if (thickness > o->h) {
-        thickness = o->h;
-    }
-    if (thickness > o->w) {
-        thickness = o->w;
-    }
-    int bottom_y = o->h - thickness;
-    if (bottom_y < 0) {
-        bottom_y = 0;
-    }
-    int right_x = o->w - thickness;
-    if (right_x < 0) {
-        right_x = 0;
-    }
-
-    osd_fill_rect(o, 0, 0, o->w, thickness, 0x00000000u);
-    osd_damage_add_rect(o, 0, 0, o->w, thickness);
-    osd_fill_rect(o, 0, bottom_y, o->w, thickness, 0x00000000u);
-    osd_damage_add_rect(o, 0, bottom_y, o->w, thickness);
-    osd_fill_rect(o, 0, 0, thickness, o->h, 0x00000000u);
-    osd_damage_add_rect(o, 0, 0, thickness, o->h);
-    osd_fill_rect(o, right_x, 0, thickness, o->h, 0x00000000u);
-    osd_damage_add_rect(o, right_x, 0, thickness, o->h);
-}
 
 static void osd_damage_reset(OSD *o) {
     if (!o) {
@@ -2807,174 +2756,6 @@ static void osd_render_text_element(OSD *o, int idx, const OsdRenderContext *ctx
     o->elements[idx].data.text.last_line_count = actual_lines;
 }
 
-static void osd_render_outline_element(OSD *o, int idx, const OsdRenderContext *ctx) {
-    if (!o || idx < 0 || idx >= o->element_count) {
-        return;
-    }
-
-    const OsdElementConfig *elem_cfg = &o->layout.elements[idx];
-    const OsdOutlineConfig *cfg = &elem_cfg->data.outline;
-    OsdOutlineState *state = &o->elements[idx].data.outline;
-
-    int thickness = osd_outline_compute_thickness(o, cfg);
-    int clear_thickness = thickness;
-    if (state->last_thickness > clear_thickness) {
-        clear_thickness = state->last_thickness;
-    }
-    if (clear_thickness > 0) {
-        osd_outline_clear(o, clear_thickness);
-    }
-
-    const char *metric_key = NULL;
-    if (cfg && cfg->metric[0] != '\0') {
-        metric_key = cfg->metric;
-    }
-    if (!metric_key) {
-        metric_key = "ext.value1";
-    }
-
-    double value = 0.0;
-    int have_value = osd_metric_sample(ctx, metric_key, &value);
-    int should_render = have_value;
-    if (!should_render) {
-        state->last_active = 0;
-        state->phase = 0;
-        state->last_thickness = 0;
-        goto store_rect;
-    }
-    int active = 0;
-    if (have_value) {
-        if (cfg && cfg->activate_when_below) {
-            active = (value < cfg->threshold);
-        } else {
-            active = (value > cfg->threshold);
-        }
-    }
-
-    uint32_t active_color = (cfg && cfg->active_color != 0) ? cfg->active_color : 0x90FF4500u;
-    uint32_t inactive_color = cfg ? cfg->inactive_color : 0x00000000u;
-
-    if (active) {
-        int scale = (o->scale > 0) ? o->scale : 1;
-        int period = (cfg && cfg->pulse_period_ticks > 0) ? cfg->pulse_period_ticks : (48 * scale);
-        if (period <= 0) {
-            period = 1;
-        }
-        int step = (cfg && cfg->pulse_step_ticks != 0) ? cfg->pulse_step_ticks : scale;
-        if (step < 0) {
-            step = -step;
-        }
-        if (step <= 0) {
-            step = 1;
-        }
-
-        int amplitude = (cfg && cfg->pulse_amplitude_px > 0) ? cfg->pulse_amplitude_px : (thickness / 2);
-        if (amplitude < 0) {
-            amplitude = 0;
-        }
-
-        int min_thickness = thickness - amplitude;
-        if (min_thickness < 1) {
-            min_thickness = 1;
-        }
-        if (min_thickness > thickness) {
-            min_thickness = thickness;
-        }
-
-        int max_thickness = thickness + amplitude;
-        int max_allowed = o->h / 2;
-        if (max_allowed <= 0) {
-            max_allowed = 1;
-        }
-        if (max_thickness > max_allowed) {
-            max_thickness = max_allowed;
-        }
-        max_allowed = o->w / 2;
-        if (max_allowed <= 0) {
-            max_allowed = 1;
-        }
-        if (max_thickness > max_allowed) {
-            max_thickness = max_allowed;
-        }
-        if (max_thickness < min_thickness) {
-            max_thickness = min_thickness;
-        }
-
-        int range = max_thickness - min_thickness;
-        int double_period = period * 2;
-        if (double_period <= 0) {
-            double_period = 2;
-        }
-        int phase = state->phase % double_period;
-        if (phase < 0) {
-            phase += double_period;
-        }
-        int cycle = phase;
-        if (cycle >= period) {
-            cycle = double_period - cycle;
-            if (cycle > period) {
-                cycle = period;
-            }
-        }
-        int pulse_thickness = max_thickness;
-        if (period > 0 && range > 0) {
-            pulse_thickness = min_thickness + (range * cycle) / period;
-        }
-
-        int right_x = o->w - pulse_thickness;
-        if (right_x < 0) {
-            right_x = 0;
-        }
-        int bottom_y = o->h - pulse_thickness;
-        if (bottom_y < 0) {
-            bottom_y = 0;
-        }
-
-        osd_fill_rect(o, 0, 0, o->w, pulse_thickness, active_color);
-        osd_damage_add_rect(o, 0, 0, o->w, pulse_thickness);
-        osd_fill_rect(o, 0, bottom_y, o->w, pulse_thickness, active_color);
-        osd_damage_add_rect(o, 0, bottom_y, o->w, pulse_thickness);
-        osd_fill_rect(o, 0, 0, pulse_thickness, o->h, active_color);
-        osd_damage_add_rect(o, 0, 0, pulse_thickness, o->h);
-        osd_fill_rect(o, right_x, 0, pulse_thickness, o->h, active_color);
-        osd_damage_add_rect(o, right_x, 0, pulse_thickness, o->h);
-
-        int next_phase = (phase + step) % double_period;
-        if (next_phase < 0) {
-            next_phase += double_period;
-        }
-        state->phase = next_phase;
-        state->last_active = 1;
-        state->last_thickness = pulse_thickness;
-    } else if (inactive_color != 0) {
-        int right_x = o->w - thickness;
-        if (right_x < 0) {
-            right_x = 0;
-        }
-        int bottom_y = o->h - thickness;
-        if (bottom_y < 0) {
-            bottom_y = 0;
-        }
-        osd_fill_rect(o, 0, 0, o->w, thickness, inactive_color);
-        osd_damage_add_rect(o, 0, 0, o->w, thickness);
-        osd_fill_rect(o, 0, bottom_y, o->w, thickness, inactive_color);
-        osd_damage_add_rect(o, 0, bottom_y, o->w, thickness);
-        osd_fill_rect(o, 0, 0, thickness, o->h, inactive_color);
-        osd_damage_add_rect(o, 0, 0, thickness, o->h);
-        osd_fill_rect(o, right_x, 0, thickness, o->h, inactive_color);
-        osd_damage_add_rect(o, right_x, 0, thickness, o->h);
-        state->last_active = 0;
-        state->phase = 0;
-        state->last_thickness = thickness;
-    } else {
-        state->last_active = 0;
-        state->phase = 0;
-        state->last_thickness = thickness;
-    }
-
-store_rect:
-    osd_store_rect(o, &o->elements[idx].rect, 0, 0, 0, 0);
-}
 
 static void osd_bar_draw(OSD *o, int idx) {
     OsdBarState *state = &o->elements[idx].data.bar;
@@ -3643,10 +3424,6 @@ int osd_setup(int fd, const AppCfg *cfg, const ModesetResult *ms, int video_plan
             osd_bar_reset(o, cfg, i);
         } else if (o->elements[i].type == OSD_WIDGET_TEXT) {
             o->elements[i].data.text.last_line_count = 0;
-        } else if (o->elements[i].type == OSD_WIDGET_OUTLINE) {
-            o->elements[i].data.outline.phase = 0;
-            o->elements[i].data.outline.last_active = 0;
-            o->elements[i].data.outline.last_thickness = 0;
         } else if (o->elements[i].type == OSD_WIDGET_IMAGE) {
             o->elements[i].data.image.pixels = NULL;
             o->elements[i].data.image.width = 0;
@@ -3827,10 +3604,6 @@ int osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const P
             break;
         case OSD_WIDGET_BAR:
             osd_render_bar_element(o, i, &ctx);
-            updated = 1;
-            break;
-        case OSD_WIDGET_OUTLINE:
-            osd_render_outline_element(o, i, &ctx);
             updated = 1;
             break;
         case OSD_WIDGET_IMAGE:


### PR DESCRIPTION
### Motivation
- The outline widget feature is being removed to simplify the OSD subsystem and eliminate its parsing/rendering/runtime paths.
- Remove outline-specific data structures to avoid carrying unused config/state in the element model and unions.
- Update user-facing samples/docs to reflect the reduced set of supported widget types (`text`, `line`, `bar`, `image`).

### Description
- Deleted the `outline` element type from the layout enum and removed the `OsdOutlineConfig` member from `include/osd_layout.h` and its union usage in `OsdElementConfig`.
- Removed the outline runtime state (`OsdOutlineState`) and references from `include/osd.h` and removed all outline initialization, rendering and helper functions from `src/osd.c`.
- Removed outline parsing, the `builder_reset_outline` initializer and all outline-related parsing branches from `src/config_ini.c` so the INI parser no longer accepts `type = outline` or outline keys.
- Updated the sample configuration and docs (`config/osd-sample.ini`, `config/pixelpilot_mini.ini`, `README.md`, `docs/osd-external-data.md`) to remove the `signal_outline` example and any user-facing outline references.

### Testing
- Ran a repository-wide search with `rg -n "outline|OSD_WIDGET_OUTLINE|signal_outline|parse_osd_element_outline|builder_reset_outline" include src config README.md docs -S` which returned no matches after the change.
- Attempted a full build with `make -j$(nproc)` which was invoked but failed in the execution environment due to a missing system header (`xf86drm.h`), so a complete compile validation could not be performed here.
- Ran `make test`, which is not available in this project (no `test` target), so no automated test-suite executions were possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9d38a29c832bacd68047e39c97ba)