### PR TITLE
docs: align external OSD docs/config with UDP behavior

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -14,8 +14,8 @@ The payload is a JSON object. All fields are optional, but at least one should b
 
 ```json
 {
-  "text": ["string1", "string2", ...],
-  "value": [1.23, 4.56, ...],
+  "texts": ["string1", "string2", ...],
+  "values": [1.23, 4.56, ...],
   "zoom": "200,200,50,50",
   "ttl_ms": 1000
 }
@@ -25,21 +25,21 @@ The payload is a JSON object. All fields are optional, but at least one should b
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `text` | Array of Strings | Updates the text slots. Max 8 items. Strings are mapped to slots 0-7 by index. |
-| `value` | Array of Numbers | Updates the value slots. Max 8 items. Values are mapped to slots 0-7 by index. |
+| `texts` | Array of Strings | Updates the text slots. Max 8 items. Strings are mapped to slots 0-7 by index. |
+| `values` | Array of Numbers | Updates the value slots. Max 8 items. Values are mapped to slots 0-7 by index. |
 | `zoom` | String | Sets the zoom level and center point. See "Zoom Control" below. |
 | `ttl_ms` | Integer | Time-to-live in milliseconds. If present, the updated slots will expire and clear after this duration. If omitted, updates are persistent until overwritten or cleared. |
 
 ## Slot Mapping
 
 The OSD engine maintains 8 text slots and 8 value slots (indices 0-7).
-*   Sending `text` updates slots starting from index 0.
-*   Sending `value` updates slots starting from index 0.
-*   Sending an empty array `[]` for `text` or `value` clears all respective slots.
+*   Sending `texts` updates slots starting from index 0.
+*   Sending `values` updates slots starting from index 0.
+*   Sending an empty array `[]` for `texts` or `values` clears all respective slots.
 *   Sending an empty string `""` for a specific text slot clears that slot.
 *   Sending `null` for a specific slot skips the update for that slot, preserving its current value. This allows multiple senders to update different indices without interference.
 
-To reference these slots in your `osd.ini` configuration, use tokens like `{external.text0}`, `{external.value0}`, etc.
+To reference these slots in your `osd.ini` configuration, use tokens like `{ext.text1}`, `{ext.value1}`, etc.
 
 ## Zoom Control
 
@@ -63,7 +63,7 @@ This sets 2x zoom centered on the middle of the screen.
 **1. Display a message for 5 seconds:**
 ```json
 {
-  "text": ["Hello World"],
+  "texts": ["Hello World"],
   "ttl_ms": 5000
 }
 ```
@@ -71,15 +71,15 @@ This sets 2x zoom centered on the middle of the screen.
 **2. Update battery voltage and status:**
 ```json
 {
-  "text": ["Battery OK"],
-  "value": [12.4]
+  "texts": ["Battery OK"],
+  "values": [12.4]
 }
 ```
 
 **3. Clear all external text and values:**
 ```json
 {
-  "text": [],
-  "value": []
+  "texts": [],
+  "values": []
 }
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The application supports an external OSD control feed that allows third-party to
 *   **Default Port:** 5005
 *   **Protocol:** JSON over UDP
 
-Enable it with `--osd-external` (or `[osd].external = true`). See [CONTRACT.md](CONTRACT.md) for the full protocol specification and payload examples.
+Enable it with `--osd-external` (or `[osd.external] enable = true`). See [CONTRACT.md](CONTRACT.md) for the full protocol specification and payload examples.
 
 ## CPU affinity control
 
@@ -206,4 +206,3 @@ Tune the behaviour through `[idr]` in the INI (or the matching `--idr-*` CLI fla
 When 64 consecutive HTTP bursts fail to clear the decoder warnings, the requester now gives up on further IDR spam and tells the main loop to rebuild the entire pipeline. This mirrors a manual restart: the pipeline tears down the UDP receiver, decoder, and sinks before bringing them back up with the existing configuration. The strategy avoids endless HTTP loops when the camera ignores triggers or the stream never delivers a usable key frame.
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
-

--- a/config/config_advanced.conf
+++ b/config/config_advanced.conf
@@ -88,7 +88,7 @@ plane-id = 0
 elements = recording_indicator, jitter_plot, stats, external_bridge_text, bar_plot
 
 [osd.external]
-; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
+; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
 ; tokens/metrics into the OSD. Leave disabled by default so the socket is
 ; only created when explicitly requested.
 enable = true

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -60,8 +60,8 @@ plane-id = 0
 elements = recording_indicator, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
 
 [osd.external]
-; Enable the UNIX socket bridge explicitly so running this config immediately
-; binds the socket for test publishers.
+; Enable the UDP external feed explicitly so running this config immediately
+; binds the UDP listener for test publishers.
 enable = true
 
 [osd.element.recording_indicator]

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -70,7 +70,7 @@ plane-id = 0
 elements = stats, recording_indicator, station_logo, framesize_plot, bitrate_plot, jitter_plot, signal_outline
 
 [osd.external]
-; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
+; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
 ; tokens/metrics into the OSD. Enabled here so the pulsing outline sample
 ; can react to the external metric feed immediately.
 enable = true

--- a/config/osd_external.conf
+++ b/config/osd_external.conf
@@ -60,8 +60,8 @@ plane-id = 0
 elements = recording_indicator, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
 
 [osd.external]
-; Enable the UNIX socket bridge explicitly so running this config immediately
-; binds the socket for test publishers.
+; Enable the UDP external feed explicitly so running this config immediately
+; binds the UDP listener for test publishers.
 enable = true
 
 [osd.element.recording_indicator]

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -91,7 +91,7 @@ elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
 elements = recording_indicator, bar_plot
 
 [osd.external]
-; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
+; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
 ; tokens/metrics into the OSD. Leave disabled by default so the socket is
 ; only created when explicitly requested.
 enable = true

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -85,7 +85,7 @@ elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
 elements = recording_indicator
 
 [osd.external]
-; Enable the UNIX socket bridge that feeds {ext.textN} and {ext.valueN}
+; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
 ; tokens/metrics into the OSD. Leave disabled by default so the socket is
 ; only created when explicitly requested.
 enable = true


### PR DESCRIPTION
### Motivation

- The external OSD code uses a UDP JSON feed and the payload keys `texts`/`values` and token names `{ext.textN}`/`{ext.valueN}`, but documentation and example INI comments still referred to a UNIX socket bridge and older keys; this change updates docs/config comments to match the implemented behavior.

### Description

- Updated `CONTRACT.md` to use `texts` and `values` (including examples and field descriptions) and to reference `{ext.textN}` / `{ext.valueN}` tokens in INI templates.
- Corrected the README enablement example to the actual INI syntax ` [osd.external] enable = true` and clarified the external feed is over UDP/JSON on the default port 5005.
- Replaced stale "UNIX socket bridge" wording with "UDP external feed"/"UDP listener" in sample and reference INI/CONF files (`config/*.ini`, `config/osd_external.conf`, `config/config_advanced.conf`).
- Committed the changes across 8 files to keep docs and config comments consistent with the implementation.

### Testing

- Ran a repository search (`rg`) to confirm the old keys and "UNIX socket bridge" wording were removed, which succeeded and showed the updated strings only.
- Ran `make test`, which failed because the repository has no `test` target (`No rule to make target 'test'`).
- Ran `make`, which failed in this environment due to missing system headers/libraries (e.g. `xf86drm.h`, `glib.h`).
- Committed changes and created the PR after verification steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9e211898832bb5087652cd82ad86)