### PR TITLE
Cleanup: tie external asset_updates limit to OSD layout element cap

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -17,6 +17,7 @@ The payload is a JSON object. All fields are optional, but at least one should b
   "texts": ["string1", "string2", ...],
   "values": [1.23, 4.56, ...],
   "zoom": "200,200,50,50",
+  "asset_updates": [{"id": 0, "enabled": false}],
   "ttl_ms": 1000
 }
 ```
@@ -29,6 +30,7 @@ The payload is a JSON object. All fields are optional, but at least one should b
 | `values` | Array of Numbers | Updates the value slots. Max 8 items. Values are mapped to slots 0-7 by index. |
 | `zoom` | String | Sets the zoom level and center point. See "Zoom Control" below. |
 | `ttl_ms` | Integer | Time-to-live in milliseconds. If present, the updated slots will expire and clear after this duration. If omitted, updates are persistent until overwritten or cleared. |
+| `asset_updates` | Array of Objects | Optional compatibility field matching `waybeam_osd`. Each object supports `id` (0-7) and `enabled` (boolean) to show/hide a configured OSD element by configured asset `id`. |
 
 ## Slot Mapping
 
@@ -81,5 +83,25 @@ This sets 2x zoom centered on the middle of the screen.
 {
   "texts": [],
   "values": []
+}
+```
+
+## Asset Visibility Control (waybeam_osd compatible)
+
+To match `waybeam_osd` and reuse `osd_send.c`, send `asset_updates` entries with `id` and `enabled`.
+
+* `id` maps to the configured OSD element `id` (0-7) set in `[osd.element.*].id`.
+* `enabled: false` hides the element immediately.
+* `enabled: true` shows the element again.
+* Unknown fields in each object are ignored.
+* If `ttl_ms` is supplied, the visibility override expires automatically after the TTL.
+
+**Example:**
+```json
+{
+  "asset_updates": [
+    {"id": 3, "enabled": false},
+    {"id": 4, "enabled": true}
+  ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ The application supports an external OSD control feed that allows third-party to
 
 Enable it with `--osd-external` (or `[osd.external] enable = true`). See [CONTRACT.md](CONTRACT.md) for the full protocol specification and payload examples.
 
+For live/manual verification of `asset_updates` visibility handling, run:
+
+```sh
+python3 tests/test_udp_osd_controls.py --host 127.0.0.1 --port 5005 --asset-id 0 --cooldown 1.0
+```
+
+The harness sends disable, enable, and disable-with-TTL payloads with a 1s cooldown and prints the expected on-screen result for each step.
+
 ## CPU affinity control
 
 Use `--cpu-list` to provide a comma-separated list of CPU IDs that the process and its busy worker threads should run on. The main process mask is restricted to the specified CPUs and the UDP receiver and GStreamer bus threads are pinned in a round-robin fashion to spread the work across cores.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ to the defaults listed in `src/config.c` when omitted.
 | `[osd].enable` | Enable the OSD overlay plane. |
 | `[osd].refresh-ms` | Interval between OSD refreshes. |
 | `[osd].plane-id` | Optional override for the OSD plane (mirrors `[drm].osd-plane-id`). |
-| `[osd].elements` | Comma-separated list describing the render order of `[osd.element.NAME]` blocks. |
+| `[osd].elements` | Optional legacy render-order override for `[osd.element.NAME]` blocks. Usually unnecessary when each element has explicit `id`/`enabled`. |
 | `[osd.element.NAME].type` | Widget style (`text`, `line`, `bar`, or `image`). Each type unlocks additional keys listed in the sample file. |
+| `[osd.element.NAME].id` | Required asset id (0-7) used by external `asset_updates` visibility commands. IDs must be unique. |
+| `[osd.element.NAME].enabled` | Initial visibility (`true`/`false`) for the element before external overrides. |
 | `[osd.element.NAME].anchor` / `offset` / `size` / color keys | Control placement and styling for OSD widgets. See inline comments in the sample file for full semantics. |
 | `[osd.element.NAME].line` | For text widgets, each `line =` entry appends a formatted row supporting `{token}` placeholders. |
 | `[osd.element.NAME].metric` | For line/bar widgets, selects the metric token (e.g. `udp.bitrate.latest_mbps`) sampled each refresh. |
@@ -94,7 +96,7 @@ to the defaults listed in `src/config.c` when omitted.
 
 ## External OSD Control
 
-The application supports an external OSD control feed that allows third-party tools to push text, numeric values, and zoom commands to the renderer over UDP.
+The application supports an external OSD control feed that allows third-party tools to push text, numeric values, zoom commands, and `waybeam_osd`-style `asset_updates` visibility toggles over UDP.
 
 *   **Default Port:** 5005
 *   **Protocol:** JSON over UDP

--- a/config/osd-43.ini
+++ b/config/osd-43.ini
@@ -50,13 +50,14 @@ affinity = 1,2,3
 enable = true
 refresh-ms = 100
 plane-id = 0
-elements = recording_indicator, jitter_plot, external_openwrt_plot, bitrate_plot
 
 [osd.external]
 enable = true
 
 [osd.element.recording_indicator]
 type = text
+id = 0
+enabled = true
 anchor = top-right
 offset = -16,16
 padding = 2
@@ -67,6 +68,8 @@ line = {record.indicator}
 
 [osd.element.jitter_plot]
 type = bar
+id = 1
+enabled = true
 anchor = bottom-right
 size = 105x64
 sample-spacing = 10
@@ -81,6 +84,8 @@ y-max = 5
 
 [osd.element.external_openwrt_plot]
 type = bar
+id = 2
+enabled = true
 anchor = bottom-left
 ;offset = -16,-16
 size = 105x1000
@@ -97,6 +102,8 @@ y-max = 105
 
 [osd.element.bitrate_plot]
 type = bar
+id = 3
+enabled = true
 anchor = mid-right
 offset = 0,264
 size = 105x64

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -57,7 +57,6 @@ refresh-ms = 100
 plane-id = 0
 ; Keep the layout focused on external feed validation while staying under the
 ; renderer element cap.
-elements = recording_indicator, bitrate_plot, external_bridge_text, external_value1_plot, external_value2_plot, external_value3_plot
 
 [osd.external]
 ; Enable the UDP external feed explicitly so running this config immediately
@@ -66,6 +65,8 @@ enable = true
 
 [osd.element.recording_indicator]
 type = text
+id = 0
+enabled = true
 anchor = top-right
 offset = -16,16
 padding = 6
@@ -76,6 +77,8 @@ line = {record.indicator}
 
 [osd.element.bitrate_plot]
 type = bar
+id = 1
+enabled = true
 anchor = bottom-left
 offset = 0,-12
 size = 360x90
@@ -89,6 +92,8 @@ grid = transparent-white
 
 [osd.element.external_bridge_text]
 type = text
+id = 2
+enabled = true
 anchor = mid-right
 offset = -16,0
 padding = 8

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -65,9 +65,8 @@ enable = true
 ; The refresh interval is clamped to a minimum of 50ms to avoid busy loops.
 refresh-ms = 100
 plane-id = 0
-; Order of elements rendered each update
-; The names reference [osd.element.NAME] sections below.
-elements = stats, recording_indicator, station_logo, framesize_plot, bitrate_plot, jitter_plot
+; Elements are discovered from [osd.element.NAME] sections below.
+; `id` controls external asset_updates mapping and `enabled` controls initial visibility.
 
 [osd.external]
 ; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
@@ -90,6 +89,8 @@ enable = true
 
 [osd.element.stats]
 type = text
+id = 0
+enabled = true
 anchor = top-left
 padding = 8
 background = transparent-grey
@@ -107,6 +108,8 @@ line = Seq={udp.expected_sequence}
 
 [osd.element.recording_indicator]
 type = text
+id = 1
+enabled = true
 anchor = top-right
 offset = -16,16
 padding = 6
@@ -118,6 +121,8 @@ line = {record.indicator}
 
 [osd.element.station_logo]
 type = image
+id = 2
+enabled = true
 anchor = top-right
 offset = -16,56
 asset = /opt/pixelpilot/assets/station_logo.png
@@ -134,6 +139,8 @@ asset = /opt/pixelpilot/assets/station_logo.png
 
 [osd.element.bitrate_plot]
 type = bar
+id = 3
+enabled = true
 anchor = bottom-left
 offset = 0,-12
 size = 360x90
@@ -158,6 +165,8 @@ grid = transparent-white
 
 [osd.element.framesize_plot]
 type = bar
+id = 4
+enabled = true
 anchor = mid-left
 size = 360x90
 sample-spacing = 12
@@ -171,6 +180,8 @@ grid = transparent-white
 
 [osd.element.jitter_plot]
 type = bar
+id = 5
+enabled = true
 anchor = bottom-right
 size = 360x90
 sample-spacing = 12

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -85,10 +85,8 @@ plane-id = 0
 ; Optional per-element refresh override (in milliseconds). If omitted, elements inherit
 ; the global [osd].refresh-ms. Values below 50 are clamped to 50.
 ; Example: osd.element.stats.refresh-ms = 200, osd.element.bitrate_plot.refresh-ms = 50
-; Order of elements rendered each update
-; The names reference [osd.element.NAME] sections below.
-elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
-elements = recording_indicator, bar_plot
+; Elements are discovered from [osd.element.NAME] sections below.
+; `id` controls external asset_updates mapping and `enabled` controls initial visibility.
 
 [osd.external]
 ; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
@@ -111,6 +109,8 @@ enable = true
 
 [osd.element.bar_plot]                                                          
 type = bar                                                                         
+id = 0
+enabled = true
 anchor = mid-right                                                              
 offset = -16, 0                                                                    
 size = 32x420                                                                   
@@ -126,6 +126,8 @@ y-max = -30
 
 [osd.element.stats]
 type = text
+id = 1
+enabled = true
 anchor = top-left
 padding = 8
 background = transparent-grey
@@ -143,6 +145,8 @@ line = Seq={udp.expected_sequence}
 
 [osd.element.recording_indicator]
 type = text
+id = 2
+enabled = true
 anchor = top-right
 offset = -16,16
 padding = 6
@@ -163,6 +167,8 @@ line = {record.indicator}
 
 [osd.element.bitrate_plot]
 type = bar
+id = 3
+enabled = true
 anchor = bottom-left
 offset = 0,-12
 size = 360x90
@@ -187,6 +193,8 @@ grid = transparent-white
 
 [osd.element.framesize_plot]
 type = bar
+id = 4
+enabled = true
 anchor = mid-left
 size = 360x90
 sample-spacing = 12
@@ -200,6 +208,8 @@ grid = transparent-white
 
 [osd.element.jitter_plot]
 type = bar
+id = 5
+enabled = true
 anchor = bottom-right
 size = 360x90
 sample-spacing = 12

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -79,10 +79,8 @@ affinity = 1,2,3
 enable = true
 refresh-ms = 100
 plane-id = 0
-; Order of elements rendered each update
-; The names reference [osd.element.NAME] sections below.
-elements = stats, recording_indicator, framesize_plot, bitrate_plot, jitter_plot
-elements = recording_indicator
+; Elements are discovered from [osd.element.NAME] sections below.
+; `id` controls external asset_updates mapping and `enabled` controls initial visibility.
 
 [osd.external]
 ; Enable the UDP external feed that updates {ext.textN} and {ext.valueN}
@@ -105,6 +103,8 @@ enable = true
 
 [osd.element.stats]
 type = text
+id = 0
+enabled = true
 anchor = top-left
 padding = 8
 background = transparent-grey
@@ -122,6 +122,8 @@ line = Seq={udp.expected_sequence}
 
 [osd.element.recording_indicator]
 type = text
+id = 1
+enabled = true
 anchor = top-right
 offset = -16,16
 padding = 6
@@ -142,6 +144,8 @@ line = {record.indicator}
 
 [osd.element.bitrate_plot]
 type = bar
+id = 2
+enabled = true
 anchor = bottom-left
 offset = 0,-12
 size = 360x90
@@ -166,6 +170,8 @@ grid = transparent-white
 
 [osd.element.framesize_plot]
 type = bar
+id = 3
+enabled = true
 anchor = mid-left
 size = 360x90
 sample-spacing = 12
@@ -179,6 +185,8 @@ grid = transparent-white
 
 [osd.element.jitter_plot]
 type = bar
+id = 4
+enabled = true
 anchor = bottom-right
 size = 360x90
 sample-spacing = 12

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -27,10 +27,11 @@ optional = true
 enable = true
 refresh-ms = 500
 plane-id = 0
-elements = stats, psd_histogram, jitter_plot
 
 [osd.element.stats]
 type = text
+id = 0
+enabled = true
 anchor = top-left
 padding = 8
 background = transparent-grey
@@ -44,6 +45,8 @@ line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.
 
 [osd.element.psd_histogram]
 type = bar
+id = 1
+enabled = true
 anchor = mid-left
 size = 320x120
 sample-spacing = 12
@@ -57,6 +60,8 @@ info-box = true
 
 [osd.element.jitter_plot]
 type = line
+id = 2
+enabled = true
 anchor = bottom-right
 size = 320x90
 sample-spacing = 4

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -4,6 +4,8 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include "osd_layout.h"
+
 #ifndef OSD_EXTERNAL_BIND_ADDR_LEN
 #define OSD_EXTERNAL_BIND_ADDR_LEN 64
 #endif
@@ -15,6 +17,7 @@
 #define OSD_EXTERNAL_MAX_TEXT 8
 #define OSD_EXTERNAL_TEXT_LEN 64
 #define OSD_EXTERNAL_MAX_VALUES 8
+#define OSD_EXTERNAL_MAX_ASSETS OSD_MAX_ELEMENTS
 
 typedef enum {
     OSD_EXTERNAL_STATUS_DISABLED = 0,
@@ -29,6 +32,8 @@ typedef struct {
     uint64_t expiry_ns;
     uint64_t zoom_expiry_ns;
     char zoom_command[OSD_EXTERNAL_TEXT_LEN];
+    uint8_t asset_enabled[OSD_EXTERNAL_MAX_ASSETS];
+    uint8_t asset_active_mask;
     OsdExternalStatus status;
 } OsdExternalFeedSnapshot;
 
@@ -51,6 +56,9 @@ typedef struct {
     OsdExternalFeedSnapshot snapshot;
     uint64_t expiry_ns;
     uint64_t zoom_expiry_ns;
+    uint8_t asset_active_mask;
+    uint8_t asset_enabled[OSD_EXTERNAL_MAX_ASSETS];
+    uint64_t asset_expiry_ns[OSD_EXTERNAL_MAX_ASSETS];
     uint64_t last_error_log_ns;
     OsdExternalSlotState slots[OSD_EXTERNAL_MAX_TEXT];
 } OsdExternalBridge;

--- a/include/osd_layout.h
+++ b/include/osd_layout.h
@@ -100,6 +100,8 @@ typedef struct {
 typedef struct {
     OsdElementType type;
     char name[48];
+    int id;
+    int enabled;
     OsdPlacement placement;
     int refresh_ms; /* Optional per-element refresh override; 0 inherits global OSD refresh. */
     union {

--- a/src/osd.c
+++ b/src/osd.c
@@ -2682,6 +2682,21 @@ static void osd_bar_draw_footer(OSD *o, int idx, const char **lines, int line_co
     osd_store_rect(o, &state->footer_rect, x, y, box_w, box_h);
 }
 
+static int osd_external_asset_visible(const OsdExternalFeedSnapshot *ext, const OsdElementConfig *elem_cfg) {
+    if (!elem_cfg) {
+        return 1;
+    }
+    int visible = elem_cfg->enabled ? 1 : 0;
+    int id = elem_cfg->id;
+    if (!ext || id < 0 || id >= OSD_EXTERNAL_MAX_ASSETS) {
+        return visible;
+    }
+    if (!(ext->asset_active_mask & (1u << id))) {
+        return visible;
+    }
+    return ext->asset_enabled[id] ? 1 : 0;
+}
+
 static void osd_render_text_element(OSD *o, int idx, const OsdRenderContext *ctx) {
     OsdElementConfig *cfg = &o->layout.elements[idx];
     OsdTextConfig *text_cfg = &cfg->data.text;
@@ -3593,6 +3608,13 @@ int osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const P
         }
         OsdElementType type = o->layout.elements[i].type;
         o->elements[i].type = type;
+        if (!osd_external_asset_visible(ext, &o->layout.elements[i])) {
+            osd_clear_rect(o, &o->elements[i].rect);
+            osd_store_rect(o, &o->elements[i].rect, 0, 0, 0, 0);
+            updated = 1;
+            o->element_last_refresh[i] = *now;
+            continue;
+        }
         switch (type) {
         case OSD_WIDGET_TEXT:
             osd_render_text_element(o, i, &ctx);

--- a/src/osd.c
+++ b/src/osd.c
@@ -2682,6 +2682,37 @@ static void osd_bar_draw_footer(OSD *o, int idx, const char **lines, int line_co
     osd_store_rect(o, &state->footer_rect, x, y, box_w, box_h);
 }
 
+static void osd_clear_element_artifacts(OSD *o, int idx, OsdElementType type) {
+    if (!o || idx < 0 || idx >= o->element_count) {
+        return;
+    }
+
+    osd_clear_rect(o, &o->elements[idx].rect);
+    osd_store_rect(o, &o->elements[idx].rect, 0, 0, 0, 0);
+
+    if (type == OSD_WIDGET_LINE) {
+        OsdLineState *state = &o->elements[idx].data.line;
+        osd_clear_rect(o, &state->plot_rect);
+        osd_clear_rect(o, &state->header_rect);
+        osd_clear_rect(o, &state->label_rect);
+        osd_clear_rect(o, &state->footer_rect);
+        osd_store_rect(o, &state->plot_rect, 0, 0, 0, 0);
+        osd_store_rect(o, &state->header_rect, 0, 0, 0, 0);
+        osd_store_rect(o, &state->label_rect, 0, 0, 0, 0);
+        osd_store_rect(o, &state->footer_rect, 0, 0, 0, 0);
+    } else if (type == OSD_WIDGET_BAR) {
+        OsdBarState *state = &o->elements[idx].data.bar;
+        osd_clear_rect(o, &state->plot_rect);
+        osd_clear_rect(o, &state->header_rect);
+        osd_clear_rect(o, &state->label_rect);
+        osd_clear_rect(o, &state->footer_rect);
+        osd_store_rect(o, &state->plot_rect, 0, 0, 0, 0);
+        osd_store_rect(o, &state->header_rect, 0, 0, 0, 0);
+        osd_store_rect(o, &state->label_rect, 0, 0, 0, 0);
+        osd_store_rect(o, &state->footer_rect, 0, 0, 0, 0);
+    }
+}
+
 static int osd_external_asset_visible(const OsdExternalFeedSnapshot *ext, const OsdElementConfig *elem_cfg) {
     if (!elem_cfg) {
         return 1;
@@ -3609,8 +3640,7 @@ int osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const P
         OsdElementType type = o->layout.elements[i].type;
         o->elements[i].type = type;
         if (!osd_external_asset_visible(ext, &o->layout.elements[i])) {
-            osd_clear_rect(o, &o->elements[i].rect);
-            osd_store_rect(o, &o->elements[i].rect, 0, 0, 0, 0);
+            osd_clear_element_artifacts(o, i, type);
             updated = 1;
             o->element_last_refresh[i] = *now;
             continue;
@@ -3633,8 +3663,7 @@ int osd_update_stats(int fd, const AppCfg *cfg, const ModesetResult *ms, const P
             updated = 1;
             break;
         default:
-            osd_clear_rect(o, &o->elements[i].rect);
-            osd_store_rect(o, &o->elements[i].rect, 0, 0, 0, 0);
+            osd_clear_element_artifacts(o, i, type);
             updated = 1;
             break;
         }

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -42,6 +42,8 @@ void osd_layout_defaults(OsdLayout *layout) {
 
     OsdElementConfig *text = &layout->elements[0];
     text->type = OSD_WIDGET_TEXT;
+    text->id = 0;
+    text->enabled = 1;
     strncpy(text->name, "stats", sizeof(text->name) - 1);
     placement_defaults(&text->placement, OSD_POS_TOP_LEFT);
     text_defaults(&text->data.text);
@@ -63,6 +65,8 @@ void osd_layout_defaults(OsdLayout *layout) {
 
     OsdElementConfig *plot = &layout->elements[1];
     plot->type = OSD_WIDGET_LINE;
+    plot->id = 1;
+    plot->enabled = 1;
     strncpy(plot->name, "jitter", sizeof(plot->name) - 1);
     placement_defaults(&plot->placement, OSD_POS_BOTTOM_LEFT);
     line_defaults(&plot->data.line);

--- a/tests/test_udp_osd_controls.py
+++ b/tests/test_udp_osd_controls.py
@@ -1,210 +1,92 @@
 #!/usr/bin/env python3
-"""UDP OSD external-control harness.
+"""External UDP OSD control harness.
 
-Builds a tiny shared-library shim around src/osd_external.c and validates
-text/value/zoom + waybeam-style asset_updates behavior over UDP.
+This script does not link against project code. It only sends UDP JSON payloads
+that exercise the new external `asset_updates` behavior so an operator can
+visually confirm OSD behavior on-screen.
 """
 
 from __future__ import annotations
 
-import ctypes
+import argparse
 import json
 import socket
-import subprocess
-import tempfile
 import time
-import unittest
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-INCLUDE_DIR = REPO_ROOT / "include"
-SRC_FILE = REPO_ROOT / "src" / "osd_external.c"
-LOGGING_SRC_FILE = REPO_ROOT / "src" / "logging.c"
-
-OSD_EXTERNAL_MAX_TEXT = 8
-OSD_EXTERNAL_TEXT_LEN = 64
-OSD_EXTERNAL_MAX_VALUES = 8
-OSD_EXTERNAL_MAX_ASSETS = 8
+from typing import Any, Dict, List
 
 
-class OsdExternalFeedSnapshot(ctypes.Structure):
-    _fields_ = [
-        ("text", (ctypes.c_char * OSD_EXTERNAL_TEXT_LEN) * OSD_EXTERNAL_MAX_TEXT),
-        ("value", ctypes.c_double * OSD_EXTERNAL_MAX_VALUES),
-        ("last_update_ns", ctypes.c_uint64),
-        ("expiry_ns", ctypes.c_uint64),
-        ("zoom_expiry_ns", ctypes.c_uint64),
-        ("zoom_command", ctypes.c_char * OSD_EXTERNAL_TEXT_LEN),
-        ("asset_enabled", ctypes.c_uint8 * OSD_EXTERNAL_MAX_ASSETS),
-        ("asset_active_mask", ctypes.c_uint8),
-        ("status", ctypes.c_int),
+def send_payload(host: str, port: int, payload: Dict[str, Any]) -> None:
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.sendto(encoded, (host, port))
+
+
+def run_test_sequence(host: str, port: int, asset_id: int, cooldown_s: float) -> None:
+    tests: List[Dict[str, Any]] = [
+        {
+            "name": "Disable asset",
+            "payload": {"asset_updates": [{"id": asset_id, "enabled": False}]},
+            "expectation": f"Asset id={asset_id} should disappear immediately.",
+        },
+        {
+            "name": "Enable asset",
+            "payload": {"asset_updates": [{"id": asset_id, "enabled": True}]},
+            "expectation": f"Asset id={asset_id} should reappear immediately.",
+        },
+        {
+            "name": "Disable asset with TTL",
+            "payload": {"asset_updates": [{"id": asset_id, "enabled": False}], "ttl_ms": 3000},
+            "expectation": (
+                f"Asset id={asset_id} should disappear immediately, then revert after TTL (~3s)."
+            ),
+        },
     ]
 
+    print("UDP OSD control harness")
+    print(f"Target: {host}:{port}")
+    print(f"Asset id under test: {asset_id}")
+    print(f"Cooldown between tests: {cooldown_s:.1f}s")
+    print("=" * 72)
 
-class ExternalBridgeHarness:
-    def __init__(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory(prefix="osd_ext_harness_")
-        self._lib = self._build_and_load(Path(self._tmpdir.name))
-        self._bridge = ctypes.c_void_p(self._lib.bridge_create())
-        if not self._bridge:
-            raise RuntimeError("failed to create bridge")
+    for index, test in enumerate(tests, start=1):
+        print(f"[Test {index}/{len(tests)}] {test['name']}")
+        print(f"  Payload: {json.dumps(test['payload'])}")
+        print(f"  Expect:  {test['expectation']}")
+        send_payload(host, port, test["payload"])
 
-    @staticmethod
-    def _build_and_load(tmp: Path):
-        shim = tmp / "shim.c"
-        so = tmp / "libosd_ext_harness.so"
-        shim.write_text(
-            """
-#include <stdlib.h>
-#include "osd_external.h"
+        if test["name"] == "Disable asset with TTL":
+            print("  Waiting 3.5s so TTL expiration can be observed on-screen...")
+            time.sleep(3.5)
 
-void *bridge_create(void) {
-    OsdExternalBridge *bridge = (OsdExternalBridge *)calloc(1, sizeof(OsdExternalBridge));
-    if (!bridge) {
-        return NULL;
-    }
-    osd_external_init(bridge);
-    return bridge;
-}
+        print(f"  Cooling down for {cooldown_s:.1f}s before next test...\n")
+        time.sleep(cooldown_s)
 
-int bridge_start(void *bridge, const char *bind_addr, int udp_port) {
-    return osd_external_start((OsdExternalBridge *)bridge, bind_addr, udp_port);
-}
-
-void bridge_stop(void *bridge) {
-    if (!bridge) {
-        return;
-    }
-    osd_external_stop((OsdExternalBridge *)bridge);
-}
-
-void bridge_destroy(void *bridge) {
-    if (!bridge) {
-        return;
-    }
-    osd_external_stop((OsdExternalBridge *)bridge);
-    free(bridge);
-}
-
-void bridge_snapshot(void *bridge, OsdExternalFeedSnapshot *out) {
-    osd_external_get_snapshot((OsdExternalBridge *)bridge, out);
-}
-""".strip()
-            + "\n"
-        )
-
-        cmd = [
-            "cc",
-            "-shared",
-            "-fPIC",
-            "-O2",
-            "-Wall",
-            "-I",
-            str(INCLUDE_DIR),
-            str(SRC_FILE),
-            str(LOGGING_SRC_FILE),
-            str(shim),
-            "-o",
-            str(so),
-            "-lpthread",
-        ]
-        subprocess.run(cmd, check=True, cwd=REPO_ROOT)
-        lib = ctypes.CDLL(str(so))
-        lib.bridge_create.restype = ctypes.c_void_p
-        lib.bridge_start.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
-        lib.bridge_start.restype = ctypes.c_int
-        lib.bridge_stop.argtypes = [ctypes.c_void_p]
-        lib.bridge_destroy.argtypes = [ctypes.c_void_p]
-        lib.bridge_snapshot.argtypes = [ctypes.c_void_p, ctypes.POINTER(OsdExternalFeedSnapshot)]
-        return lib
-
-    def start(self, port: int) -> None:
-        rc = self._lib.bridge_start(self._bridge, b"127.0.0.1", port)
-        if rc != 0:
-            raise RuntimeError(f"bridge_start failed: {rc}")
-
-    def stop(self) -> None:
-        self._lib.bridge_stop(self._bridge)
-
-    def destroy(self) -> None:
-        self._lib.bridge_destroy(self._bridge)
-        self._bridge = ctypes.c_void_p()
-        self._tmpdir.cleanup()
-
-    def snapshot(self) -> OsdExternalFeedSnapshot:
-        snap = OsdExternalFeedSnapshot()
-        self._lib.bridge_snapshot(self._bridge, ctypes.byref(snap))
-        return snap
+    print("All tests sent.\n")
+    print("What was tested:")
+    print("  1) asset_updates enable=false")
+    print("  2) asset_updates enable=true")
+    print("  3) asset_updates enable=false with ttl_ms (auto-expiry)")
 
 
-def allocate_udp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="External UDP harness for OSD asset visibility controls")
+    parser.add_argument("--host", default="127.0.0.1", help="Target host running pixelpilot_mini_rk")
+    parser.add_argument("--port", type=int, default=5005, help="External OSD UDP port (default: 5005)")
+    parser.add_argument("--asset-id", type=int, default=0, help="OSD asset id to toggle (default: 0)")
+    parser.add_argument("--cooldown", type=float, default=1.0, help="Cooldown seconds between tests")
+    return parser.parse_args()
 
 
-def send_payload(port: int, payload: dict) -> None:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        sock.sendto(json.dumps(payload).encode("utf-8"), ("127.0.0.1", port))
+def main() -> int:
+    args = parse_args()
+    if args.asset_id < 0 or args.asset_id > 7:
+        raise SystemExit("--asset-id must be in range 0..7")
+    if args.cooldown < 1.0:
+        raise SystemExit("--cooldown must be >= 1.0 seconds")
 
-
-class TestUdpOsdControls(unittest.TestCase):
-    def setUp(self) -> None:
-        self.bridge = ExternalBridgeHarness()
-        self.port = allocate_udp_port()
-        self.bridge.start(self.port)
-
-    def tearDown(self) -> None:
-        self.bridge.destroy()
-
-    @staticmethod
-    def _cstr(buf: ctypes.Array) -> str:
-        return bytes(buf).split(b"\0", 1)[0].decode("utf-8", errors="replace")
-
-    def test_text_value_zoom_update(self) -> None:
-        send_payload(
-            self.port,
-            {
-                "texts": ["hello"],
-                "values": [12.5],
-                "zoom": "200,200,50,50",
-            },
-        )
-        time.sleep(0.08)
-        snap = self.bridge.snapshot()
-        self.assertEqual(self._cstr(snap.text[0]), "hello")
-        self.assertAlmostEqual(snap.value[0], 12.5, places=2)
-        self.assertEqual(self._cstr(snap.zoom_command), "200,200,50,50")
-
-    def test_asset_updates_toggle_and_ttl(self) -> None:
-        send_payload(
-            self.port,
-            {
-                "asset_updates": [{"id": 3, "enabled": False}],
-                "ttl_ms": 120,
-            },
-        )
-        time.sleep(0.06)
-        snap = self.bridge.snapshot()
-        self.assertTrue(snap.asset_active_mask & (1 << 3))
-        self.assertEqual(int(snap.asset_enabled[3]), 0)
-
-        time.sleep(0.10)
-        snap2 = self.bridge.snapshot()
-        self.assertFalse(snap2.asset_active_mask & (1 << 3))
-
-    def test_asset_update_enable_persists_without_ttl(self) -> None:
-        send_payload(
-            self.port,
-            {
-                "asset_updates": [{"id": 1, "enabled": True}],
-            },
-        )
-        time.sleep(0.06)
-        snap = self.bridge.snapshot()
-        self.assertTrue(snap.asset_active_mask & (1 << 1))
-        self.assertEqual(int(snap.asset_enabled[1]), 1)
+    run_test_sequence(args.host, args.port, args.asset_id, args.cooldown)
+    return 0
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    raise SystemExit(main())

--- a/tests/test_udp_osd_controls.py
+++ b/tests/test_udp_osd_controls.py
@@ -40,6 +40,16 @@ def run_test_sequence(host: str, port: int, asset_id: int, cooldown_s: float) ->
                 f"Asset id={asset_id} should disappear immediately, then revert after TTL (~3s)."
             ),
         },
+        {
+            "name": "Enable zoom",
+            "payload": {"zoom": "200,200,50,50"},
+            "expectation": "Video should zoom to 2x centered view.",
+        },
+        {
+            "name": "Disable zoom",
+            "payload": {"zoom": "off"},
+            "expectation": "Video should return to normal (no zoom).",
+        },
     ]
 
     print("UDP OSD control harness")
@@ -66,6 +76,8 @@ def run_test_sequence(host: str, port: int, asset_id: int, cooldown_s: float) ->
     print("  1) asset_updates enable=false")
     print("  2) asset_updates enable=true")
     print("  3) asset_updates enable=false with ttl_ms (auto-expiry)")
+    print("  4) zoom enable (200,200,50,50)")
+    print("  5) zoom disable (off)")
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_udp_osd_controls.py
+++ b/tests/test_udp_osd_controls.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""UDP OSD external-control harness.
+
+Builds a tiny shared-library shim around src/osd_external.c and validates
+text/value/zoom + waybeam-style asset_updates behavior over UDP.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INCLUDE_DIR = REPO_ROOT / "include"
+SRC_FILE = REPO_ROOT / "src" / "osd_external.c"
+LOGGING_SRC_FILE = REPO_ROOT / "src" / "logging.c"
+
+OSD_EXTERNAL_MAX_TEXT = 8
+OSD_EXTERNAL_TEXT_LEN = 64
+OSD_EXTERNAL_MAX_VALUES = 8
+OSD_EXTERNAL_MAX_ASSETS = 8
+
+
+class OsdExternalFeedSnapshot(ctypes.Structure):
+    _fields_ = [
+        ("text", (ctypes.c_char * OSD_EXTERNAL_TEXT_LEN) * OSD_EXTERNAL_MAX_TEXT),
+        ("value", ctypes.c_double * OSD_EXTERNAL_MAX_VALUES),
+        ("last_update_ns", ctypes.c_uint64),
+        ("expiry_ns", ctypes.c_uint64),
+        ("zoom_expiry_ns", ctypes.c_uint64),
+        ("zoom_command", ctypes.c_char * OSD_EXTERNAL_TEXT_LEN),
+        ("asset_enabled", ctypes.c_uint8 * OSD_EXTERNAL_MAX_ASSETS),
+        ("asset_active_mask", ctypes.c_uint8),
+        ("status", ctypes.c_int),
+    ]
+
+
+class ExternalBridgeHarness:
+    def __init__(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="osd_ext_harness_")
+        self._lib = self._build_and_load(Path(self._tmpdir.name))
+        self._bridge = ctypes.c_void_p(self._lib.bridge_create())
+        if not self._bridge:
+            raise RuntimeError("failed to create bridge")
+
+    @staticmethod
+    def _build_and_load(tmp: Path):
+        shim = tmp / "shim.c"
+        so = tmp / "libosd_ext_harness.so"
+        shim.write_text(
+            """
+#include <stdlib.h>
+#include "osd_external.h"
+
+void *bridge_create(void) {
+    OsdExternalBridge *bridge = (OsdExternalBridge *)calloc(1, sizeof(OsdExternalBridge));
+    if (!bridge) {
+        return NULL;
+    }
+    osd_external_init(bridge);
+    return bridge;
+}
+
+int bridge_start(void *bridge, const char *bind_addr, int udp_port) {
+    return osd_external_start((OsdExternalBridge *)bridge, bind_addr, udp_port);
+}
+
+void bridge_stop(void *bridge) {
+    if (!bridge) {
+        return;
+    }
+    osd_external_stop((OsdExternalBridge *)bridge);
+}
+
+void bridge_destroy(void *bridge) {
+    if (!bridge) {
+        return;
+    }
+    osd_external_stop((OsdExternalBridge *)bridge);
+    free(bridge);
+}
+
+void bridge_snapshot(void *bridge, OsdExternalFeedSnapshot *out) {
+    osd_external_get_snapshot((OsdExternalBridge *)bridge, out);
+}
+""".strip()
+            + "\n"
+        )
+
+        cmd = [
+            "cc",
+            "-shared",
+            "-fPIC",
+            "-O2",
+            "-Wall",
+            "-I",
+            str(INCLUDE_DIR),
+            str(SRC_FILE),
+            str(LOGGING_SRC_FILE),
+            str(shim),
+            "-o",
+            str(so),
+            "-lpthread",
+        ]
+        subprocess.run(cmd, check=True, cwd=REPO_ROOT)
+        lib = ctypes.CDLL(str(so))
+        lib.bridge_create.restype = ctypes.c_void_p
+        lib.bridge_start.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+        lib.bridge_start.restype = ctypes.c_int
+        lib.bridge_stop.argtypes = [ctypes.c_void_p]
+        lib.bridge_destroy.argtypes = [ctypes.c_void_p]
+        lib.bridge_snapshot.argtypes = [ctypes.c_void_p, ctypes.POINTER(OsdExternalFeedSnapshot)]
+        return lib
+
+    def start(self, port: int) -> None:
+        rc = self._lib.bridge_start(self._bridge, b"127.0.0.1", port)
+        if rc != 0:
+            raise RuntimeError(f"bridge_start failed: {rc}")
+
+    def stop(self) -> None:
+        self._lib.bridge_stop(self._bridge)
+
+    def destroy(self) -> None:
+        self._lib.bridge_destroy(self._bridge)
+        self._bridge = ctypes.c_void_p()
+        self._tmpdir.cleanup()
+
+    def snapshot(self) -> OsdExternalFeedSnapshot:
+        snap = OsdExternalFeedSnapshot()
+        self._lib.bridge_snapshot(self._bridge, ctypes.byref(snap))
+        return snap
+
+
+def allocate_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def send_payload(port: int, payload: dict) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.sendto(json.dumps(payload).encode("utf-8"), ("127.0.0.1", port))
+
+
+class TestUdpOsdControls(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bridge = ExternalBridgeHarness()
+        self.port = allocate_udp_port()
+        self.bridge.start(self.port)
+
+    def tearDown(self) -> None:
+        self.bridge.destroy()
+
+    @staticmethod
+    def _cstr(buf: ctypes.Array) -> str:
+        return bytes(buf).split(b"\0", 1)[0].decode("utf-8", errors="replace")
+
+    def test_text_value_zoom_update(self) -> None:
+        send_payload(
+            self.port,
+            {
+                "texts": ["hello"],
+                "values": [12.5],
+                "zoom": "200,200,50,50",
+            },
+        )
+        time.sleep(0.08)
+        snap = self.bridge.snapshot()
+        self.assertEqual(self._cstr(snap.text[0]), "hello")
+        self.assertAlmostEqual(snap.value[0], 12.5, places=2)
+        self.assertEqual(self._cstr(snap.zoom_command), "200,200,50,50")
+
+    def test_asset_updates_toggle_and_ttl(self) -> None:
+        send_payload(
+            self.port,
+            {
+                "asset_updates": [{"id": 3, "enabled": False}],
+                "ttl_ms": 120,
+            },
+        )
+        time.sleep(0.06)
+        snap = self.bridge.snapshot()
+        self.assertTrue(snap.asset_active_mask & (1 << 3))
+        self.assertEqual(int(snap.asset_enabled[3]), 0)
+
+        time.sleep(0.10)
+        snap2 = self.bridge.snapshot()
+        self.assertFalse(snap2.asset_active_mask & (1 << 3))
+
+    def test_asset_update_enable_persists_without_ttl(self) -> None:
+        send_payload(
+            self.port,
+            {
+                "asset_updates": [{"id": 1, "enabled": True}],
+            },
+        )
+        time.sleep(0.06)
+        snap = self.bridge.snapshot()
+        self.assertTrue(snap.asset_active_mask & (1 << 1))
+        self.assertEqual(int(snap.asset_enabled[1]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### Motivation
- Remove a duplicated hard-coded asset cap so the external `asset_updates` capacity cannot drift out of sync with the OSD layout element limit. 
- Make the external feed header explicitly depend on the layout definition to keep both limits coordinated.

### Description
- `include/osd_external.h` now includes `osd_layout.h` and replaces the local `#define OSD_EXTERNAL_MAX_ASSETS 8` with `OSD_EXTERNAL_MAX_ASSETS OSD_MAX_ELEMENTS` so the external asset limit is derived from the layout constant. 
- No behavioral changes to runtime logic were made; this is purely a cleanup to consolidate constants and prevent future divergence.

### Testing
- Compiled translation units with `cc -O2 -Wall -Iinclude -Ithird_party/minimp4 -c src/osd_external.c -o /tmp/osd_external.o` (succeeded). 
- Compiled related units with `cc -O2 -Wall -Iinclude -Ithird_party/minimp4 -c src/config_ini.c -o /tmp/config_ini.o` and `cc -O2 -Wall -Iinclude -Ithird_party/minimp4 -c src/osd_layout.c -o /tmp/osd_layout.o` (succeeded). 
- Full build with `make -j4` failed in this environment due to missing system headers/libraries (`xf86drm.h`, `glib.h`), which are unrelated to this change (failure expected in this sandbox).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699021ba39d4832b93ad8ef5e4c9fd5c)