### PR TITLE
pipeline: add optional RTP jitterbuffer element (`sstarrtpjitterbuffer`) for stability mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ to the defaults listed in `src/config.c` when omitted.
 | `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |
 | `[pipeline].stream-profile` | End-to-end recovery/latency preset: `low-latency` (120 fps, ~1-2 frame delay), `medium-latency` (60 fps), `high-latency` (30 fps, stability-first). |
-| `[pipeline].depay-emit-partial-au` | `true` (default) forwards damaged H.265 access units with `CORRUPTED`/`DISCONT` flags so display continuity is preserved; `false` drops damaged AUs before decode. |
-| `[pipeline].decoder-drop-error-frames` | `false` (default) keeps frames that the decoder marks with error metadata (still triggers IDR); set `true` to drop those frames for cleaner images at the cost of visible discontinuities. |
 | `[pipeline].custom-sink` | `receiver` to use the custom UDP receiver, or `udpsrc` for the bare GStreamer `udpsrc` pipeline. |
 | `[pipeline].pt97-filter` | `true` (default) keeps the RTP payload-type filter on `udpsrc`; set `false` to accept all payload types when CPU headroom is limited. |
 | `[idr].enable` | `true` enables the automatic IDR requester that fires HTTP recovery bursts when decode warnings appear. |
@@ -277,7 +275,7 @@ Prefer the preset instead of tuning many independent knobs:
 
 Each profile coordinates jitterbuffer behavior plus IDR stats-driven thresholds/hysteresis so transient burst recovery is faster and IDR storms settle quickly once clean frames return.
 
-User-facing per-stream overrides are kept intentionally small: `depay-emit-partial-au` and `decoder-drop-error-frames` remain explicit user choices, while jitterbuffer and IDR stats-trigger tuning are controlled by `stream-profile`.
+All corruption/recovery behavior knobs (including depay damaged-AU policy, decoder error-frame policy, jitterbuffer behavior, and IDR stats-trigger tuning) are coordinated by `stream-profile` to keep runtime configuration simple and unambiguous.
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
 

--- a/README.md
+++ b/README.md
@@ -305,3 +305,5 @@ python tests/rtp_fault_injector.py
 ```
 
 The ncurses menu lets you switch between pass-through, packet drop, burst loss, packet delay/jitter, whole-frame drop, and whole-frame delay modes in real time.
+
+If your terminal is very small, the UI may be truncated to avoid curses drawing errors; resize the terminal for full controls.

--- a/README.md
+++ b/README.md
@@ -304,10 +304,12 @@ Run:
 python tests/rtp_fault_injector.py
 ```
 
-The ncurses menu lets you switch between pass-through, packet drop, burst loss, packet delay/jitter, whole-frame drop, and whole-frame delay modes in real time.
+The ncurses menu lets you switch between pass-through, packet drop, burst loss, packet delay/jitter, bursty packet delay/jitter, whole-frame drop, and whole-frame delay modes in real time.
 
 If your terminal is very small, the UI may be truncated to avoid curses drawing errors; resize the terminal for full controls.
 
 In pass-through and non-delay drop modes, the injector now forwards packets immediately (without queuing) to avoid adding artificial latency. Queue depth is primarily expected in delay/jitter modes.
+
+Use `+` / `-` to adjust the active mode severity directly (instead of mode-specific increase/decrease key pairs).
 
 When using "drop every N frames", it is normal for H.265 decode to stall until the next IDR/CRA if a dropped frame was a reference frame; this often appears as repeated old output rather than green corruption on Rockchip MPP.

--- a/README.md
+++ b/README.md
@@ -288,3 +288,20 @@ For a stability-first profile (accepting extra delay to absorb reorder jitter), 
 - `pipeline.jitterbuffer-max-misorder = 128`
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
+
+## Manual fault-injection helper (packet/frame drop and delay)
+
+Use `tests/rtp_fault_injector.py` to proxy an RTP/UDP stream through interactive fault modes while watching output quality and recovery behavior.
+
+Default wiring is:
+
+- ingest on `0.0.0.0:5601`
+- forward to `127.0.0.1:5600`
+
+Run:
+
+```bash
+python tests/rtp_fault_injector.py
+```
+
+The ncurses menu lets you switch between pass-through, packet drop, burst loss, packet delay/jitter, whole-frame drop, and whole-frame delay modes in real time.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ to the defaults listed in `src/config.c` when omitted.
 | `[udp].port` | UDP port that the RTP stream arrives on. |
 | `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |
+| `[pipeline].depay-emit-partial-au` | `true` (default) forwards damaged H.265 access units with `CORRUPTED`/`DISCONT` flags so display continuity is preserved; `false` drops damaged AUs before decode. |
+| `[pipeline].decoder-drop-error-frames` | `false` (default) keeps frames that the decoder marks with error metadata (still triggers IDR); set `true` to drop those frames for cleaner images at the cost of visible discontinuities. |
+| `[pipeline].jitterbuffer-enable` | `false` (default) bypasses RTP reordering; set `true` to enable the in-process `sstarrtpjitterbuffer` for stability-first playback under packet reordering. |
+| `[pipeline].jitterbuffer-latency-ms` | Gap wait budget before the jitterbuffer skips missing RTP sequence numbers (default `8`). Increase to favor stability over latency. |
+| `[pipeline].jitterbuffer-max-misorder` | Maximum RTP sequence distance the jitterbuffer will hold for reordering (default `64`). |
 | `[pipeline].custom-sink` | `receiver` to use the custom UDP receiver, or `udpsrc` for the bare GStreamer `udpsrc` pipeline. |
 | `[pipeline].pt97-filter` | `true` (default) keeps the RTP payload-type filter on `udpsrc`; set `false` to accept all payload types when CPU headroom is limited. |
 | `[idr].enable` | `true` enables the automatic IDR requester that fires HTTP recovery bursts when decode warnings appear. |
@@ -263,5 +268,23 @@ Packet loss or corruption around an IDR frame leaves the decoder without valid r
 Tune the behaviour through `[idr]` in the INI (or the matching `--idr-*` CLI flags): disable it entirely with `idr.enable = false`, override the port or path to match the camera firmware, or extend the timeout when proxies or long RTT links sit between the devices. Every trigger is logged with the cumulative total, and the `udp.idr_requests` counter exposes the same total in OSD templates, SSE payloads, and other telemetry sinks.
 
 When 64 consecutive HTTP bursts fail to clear the decoder warnings, the requester now gives up on further IDR spam and tells the main loop to rebuild the entire pipeline. This mirrors a manual restart: the pipeline tears down the UDP receiver, decoder, and sinks before bringing them back up with the existing configuration. The strategy avoids endless HTTP loops when the camera ignores triggers or the stream never delivers a usable key frame.
+
+## Low-latency corruption handling profile (120 fps target)
+
+For streams where end-to-end delay should stay near a single frame, start with:
+
+- `pipeline.appsink-max-buffers = 1`
+- `pipeline.depay-emit-partial-au = true`
+- `pipeline.decoder-drop-error-frames = false`
+- `pipeline.jitterbuffer-enable = false`
+- keep `[idr].enable = true` and `[idr].stats-trigger = true`
+
+This profile prefers showing partially damaged frames over freezing on old frames while still forcing fast IDR-based recovery when corruption is detected.
+
+For a stability-first profile (accepting extra delay to absorb reorder jitter), set:
+
+- `pipeline.jitterbuffer-enable = true`
+- `pipeline.jitterbuffer-latency-ms = 20` (or approximately 2-3 frame times)
+- `pipeline.jitterbuffer-max-misorder = 128`
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ to the defaults listed in `src/config.c` when omitted.
 | `[udp].port` | UDP port that the RTP stream arrives on. |
 | `[udp].video-pt` / `[udp].audio-pt` | Payload types for the video (default 97/H.265) and audio (default 98/Opus) streams. |
 | `[pipeline].appsink-max-buffers` | Maximum number of buffers queued on the appsink before older frames are dropped. Exposed via the OSD token `{pipeline.appsink_max_buffers}`. |
+| `[pipeline].stream-profile` | End-to-end recovery/latency preset: `low-latency` (120 fps, ~1-2 frame delay), `medium-latency` (60 fps), `high-latency` (30 fps, stability-first). |
 | `[pipeline].depay-emit-partial-au` | `true` (default) forwards damaged H.265 access units with `CORRUPTED`/`DISCONT` flags so display continuity is preserved; `false` drops damaged AUs before decode. |
 | `[pipeline].decoder-drop-error-frames` | `false` (default) keeps frames that the decoder marks with error metadata (still triggers IDR); set `true` to drop those frames for cleaner images at the cost of visible discontinuities. |
 | `[pipeline].jitterbuffer-enable` | `false` (default) bypasses RTP reordering; set `true` to enable the in-process `sstarrtpjitterbuffer` for stability-first playback under packet reordering. |
@@ -269,23 +270,17 @@ Tune the behaviour through `[idr]` in the INI (or the matching `--idr-*` CLI fla
 
 When 64 consecutive HTTP bursts fail to clear the decoder warnings, the requester now gives up on further IDR spam and tells the main loop to rebuild the entire pipeline. This mirrors a manual restart: the pipeline tears down the UDP receiver, decoder, and sinks before bringing them back up with the existing configuration. The strategy avoids endless HTTP loops when the camera ignores triggers or the stream never delivers a usable key frame.
 
-## Low-latency corruption handling profile (120 fps target)
+## Stream profiles (recommended)
 
-For streams where end-to-end delay should stay near a single frame, start with:
+Prefer the preset instead of tuning many independent knobs:
 
-- `pipeline.appsink-max-buffers = 1`
-- `pipeline.depay-emit-partial-au = true`
-- `pipeline.decoder-drop-error-frames = false`
-- `pipeline.jitterbuffer-enable = false`
-- keep `[idr].enable = true` and `[idr].stats-trigger = true`
+- `pipeline.stream-profile = low-latency` for 120 fps links where max latency target is roughly 1-2 frames.
+- `pipeline.stream-profile = medium-latency` for 60 fps links with moderate jitter tolerance.
+- `pipeline.stream-profile = high-latency` for 30 fps links where stability is prioritized over immediacy.
 
-This profile prefers showing partially damaged frames over freezing on old frames while still forcing fast IDR-based recovery when corruption is detected.
+Each profile coordinates depay partial-frame behavior, decoder error-frame handling, jitterbuffer behavior, and IDR hysteresis controls so transient burst recovery is faster and IDR storms settle quickly once clean frames return.
 
-For a stability-first profile (accepting extra delay to absorb reorder jitter), set:
-
-- `pipeline.jitterbuffer-enable = true`
-- `pipeline.jitterbuffer-latency-ms = 20` (or approximately 2-3 frame times)
-- `pipeline.jitterbuffer-max-misorder = 128`
+Advanced keys (`depay-emit-partial-au`, `decoder-drop-error-frames`, `jitterbuffer-*`, and `[idr]` thresholds) are still available for expert overrides.
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
 
@@ -310,6 +305,6 @@ If your terminal is very small, the UI may be truncated to avoid curses drawing 
 
 In pass-through and non-delay drop modes, the injector now forwards packets immediately (without queuing) to avoid adding artificial latency. Queue depth is primarily expected in delay/jitter modes.
 
-Use `+` / `-` to adjust the active mode severity directly (instead of mode-specific increase/decrease key pairs).
+Use `+` / `-` to adjust the active mode severity directly, and `{` / `}` to adjust the secondary burst-period knob on burst modes.
 
 When using "drop every N frames", it is normal for H.265 decode to stall until the next IDR/CRA if a dropped frame was a reference frame; this often appears as repeated old output rather than green corruption on Rockchip MPP.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ to the defaults listed in `src/config.c` when omitted.
 | `[pipeline].stream-profile` | End-to-end recovery/latency preset: `low-latency` (120 fps, ~1-2 frame delay), `medium-latency` (60 fps), `high-latency` (30 fps, stability-first). |
 | `[pipeline].depay-emit-partial-au` | `true` (default) forwards damaged H.265 access units with `CORRUPTED`/`DISCONT` flags so display continuity is preserved; `false` drops damaged AUs before decode. |
 | `[pipeline].decoder-drop-error-frames` | `false` (default) keeps frames that the decoder marks with error metadata (still triggers IDR); set `true` to drop those frames for cleaner images at the cost of visible discontinuities. |
-| `[pipeline].jitterbuffer-enable` | `false` (default) bypasses RTP reordering; set `true` to enable the in-process `sstarrtpjitterbuffer` for stability-first playback under packet reordering. |
-| `[pipeline].jitterbuffer-latency-ms` | Gap wait budget before the jitterbuffer skips missing RTP sequence numbers (default `8`). Increase to favor stability over latency. |
-| `[pipeline].jitterbuffer-max-misorder` | Maximum RTP sequence distance the jitterbuffer will hold for reordering (default `64`). |
 | `[pipeline].custom-sink` | `receiver` to use the custom UDP receiver, or `udpsrc` for the bare GStreamer `udpsrc` pipeline. |
 | `[pipeline].pt97-filter` | `true` (default) keeps the RTP payload-type filter on `udpsrc`; set `false` to accept all payload types when CPU headroom is limited. |
 | `[idr].enable` | `true` enables the automatic IDR requester that fires HTTP recovery bursts when decode warnings appear. |
@@ -278,9 +275,9 @@ Prefer the preset instead of tuning many independent knobs:
 - `pipeline.stream-profile = medium-latency` for 60 fps links with moderate jitter tolerance.
 - `pipeline.stream-profile = high-latency` for 30 fps links where stability is prioritized over immediacy.
 
-Each profile coordinates depay partial-frame behavior, decoder error-frame handling, jitterbuffer behavior, and IDR hysteresis controls so transient burst recovery is faster and IDR storms settle quickly once clean frames return.
+Each profile coordinates jitterbuffer behavior plus IDR stats-driven thresholds/hysteresis so transient burst recovery is faster and IDR storms settle quickly once clean frames return.
 
-Advanced keys (`depay-emit-partial-au`, `decoder-drop-error-frames`, `jitterbuffer-*`, and `[idr]` thresholds) are still available for expert overrides.
+User-facing per-stream overrides are kept intentionally small: `depay-emit-partial-au` and `decoder-drop-error-frames` remain explicit user choices, while jitterbuffer and IDR stats-trigger tuning are controlled by `stream-profile`.
 
 Manual restarts follow the same path. Send the process a `SIGHUP` (for example `kill -HUP $(cat /tmp/pixelpilot_mini_rk.pid)`) to force an immediate teardown/restart cycle without dropping other runtime toggles such as audio fallbacks or active OSD overlays.
 

--- a/README.md
+++ b/README.md
@@ -307,3 +307,7 @@ python tests/rtp_fault_injector.py
 The ncurses menu lets you switch between pass-through, packet drop, burst loss, packet delay/jitter, whole-frame drop, and whole-frame delay modes in real time.
 
 If your terminal is very small, the UI may be truncated to avoid curses drawing errors; resize the terminal for full controls.
+
+In pass-through and non-delay drop modes, the injector now forwards packets immediately (without queuing) to avoid adding artificial latency. Queue depth is primarily expected in delay/jitter modes.
+
+When using "drop every N frames", it is normal for H.265 decode to stall until the next IDR/CRA if a dropped frame was a reference frame; this often appears as repeated old output rather than green corruption on Rockchip MPP.

--- a/config/config_advanced.conf
+++ b/config/config_advanced.conf
@@ -25,10 +25,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
@@ -41,12 +37,6 @@ path = /request/idr
 timeout-ms = 200
 ; Optional: force a fixed IDR request target instead of tracking the latest RTP sender
 ;endpoint = 192.168.2.203:80
-; Stats-driven triggers
-stats-trigger = true
-loss-window-ms = 200
-loss-threshold = 1
-jitter-threshold-ms = 25.0
-jitter-cooldown-ms = 750
 
 [sse]
 ; Optional Server-Sent Events streamer for UDP receiver counters.

--- a/config/config_advanced.conf
+++ b/config/config_advanced.conf
@@ -19,6 +19,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/config_advanced.conf
+++ b/config/config_advanced.conf
@@ -19,6 +19,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/config_advanced.conf
+++ b/config/config_advanced.conf
@@ -21,10 +21,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/minimal-udpsrc.ini
+++ b/config/minimal-udpsrc.ini
@@ -15,6 +15,14 @@ audio-pt = -1
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = udpsrc
 pt97-filter = false
 

--- a/config/minimal-udpsrc.ini
+++ b/config/minimal-udpsrc.ini
@@ -15,6 +15,8 @@ audio-pt = -1
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/minimal-udpsrc.ini
+++ b/config/minimal-udpsrc.ini
@@ -21,10 +21,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = udpsrc
 pt97-filter = false
 

--- a/config/minimal-udpsrc.ini
+++ b/config/minimal-udpsrc.ini
@@ -17,10 +17,6 @@ audio-pt = -1
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = udpsrc
 pt97-filter = false
 

--- a/config/osd-43.ini
+++ b/config/osd-43.ini
@@ -18,10 +18,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 
 [idr]

--- a/config/osd-43.ini
+++ b/config/osd-43.ini
@@ -12,6 +12,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/osd-43.ini
+++ b/config/osd-43.ini
@@ -12,6 +12,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 
 [idr]

--- a/config/osd-43.ini
+++ b/config/osd-43.ini
@@ -14,10 +14,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 
 [idr]

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -16,6 +16,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -18,10 +18,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 pt97-filter = true
 

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -22,10 +22,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 pt97-filter = true
 

--- a/config/osd-external-test.ini
+++ b/config/osd-external-test.ini
@@ -16,6 +16,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 pt97-filter = true
 

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -19,6 +19,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -19,6 +19,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -21,10 +21,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -25,10 +25,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/osd_external.conf
+++ b/config/osd_external.conf
@@ -16,6 +16,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/osd_external.conf
+++ b/config/osd_external.conf
@@ -18,10 +18,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 pt97-filter = true
 

--- a/config/osd_external.conf
+++ b/config/osd_external.conf
@@ -22,10 +22,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 pt97-filter = true
 

--- a/config/osd_external.conf
+++ b/config/osd_external.conf
@@ -16,6 +16,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 pt97-filter = true
 

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -25,10 +25,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
@@ -41,12 +37,6 @@ path = /request/idr
 timeout-ms = 200
 ; Optional: force a fixed IDR request target instead of tracking the latest RTP sender
 ;endpoint = 192.168.2.203:80
-; Stats-driven triggers
-stats-trigger = true
-loss-window-ms = 200
-loss-threshold = 1
-jitter-threshold-ms = 25.0
-jitter-cooldown-ms = 750
 
 [sse]
 ; Optional Server-Sent Events streamer for UDP receiver counters.

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -19,6 +19,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -19,6 +19,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -21,10 +21,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -16,6 +16,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -18,10 +18,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -16,6 +16,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -22,10 +22,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
@@ -38,12 +34,6 @@ path = /request/idr
 timeout-ms = 200
 ; Optional: force a fixed IDR request target instead of tracking the latest RTP sender
 ;endpoint = 192.168.2.203:80
-; Stats-driven triggers
-stats-trigger = true
-loss-window-ms = 200
-loss-threshold = 1
-jitter-threshold-ms = 25.0
-jitter-cooldown-ms = 750
 
 [sse]
 ; Optional Server-Sent Events streamer for UDP receiver counters.

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -14,6 +14,8 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
+stream-profile = low-latency
 ; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -16,10 +16,6 @@ audio-pt = 98
 appsink-max-buffers = 8
 ; Preset coordinating latency/recovery behaviour (low-latency|medium-latency|high-latency).
 stream-profile = low-latency
-; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
-depay-emit-partial-au = true
-; Keep decoder-marked error frames for continuity (set true to drop them).
-decoder-drop-error-frames = false
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -14,6 +14,14 @@ audio-pt = 98
 
 [pipeline]
 appsink-max-buffers = 8
+; Forward damaged AUs to minimize visible stalls; IDR recovery still triggers.
+depay-emit-partial-au = true
+; Keep decoder-marked error frames for continuity (set true to drop them).
+decoder-drop-error-frames = false
+; Enable to favor image stability over absolute minimum latency under packet reordering.
+jitterbuffer-enable = false
+jitterbuffer-latency-ms = 8
+jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/config/psd-sample.ini
+++ b/config/psd-sample.ini
@@ -20,10 +20,6 @@ stream-profile = low-latency
 depay-emit-partial-au = true
 ; Keep decoder-marked error frames for continuity (set true to drop them).
 decoder-drop-error-frames = false
-; Enable to favor image stability over absolute minimum latency under packet reordering.
-jitterbuffer-enable = false
-jitterbuffer-latency-ms = 8
-jitterbuffer-max-misorder = 64
 custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true

--- a/docs/h265-corruption-recovery-analysis.md
+++ b/docs/h265-corruption-recovery-analysis.md
@@ -1,0 +1,202 @@
+# H.265 corruption/recovery behavior analysis (Windows/Linux/Rockchip)
+
+## Executive findings (repo-specific)
+
+1. **In this repository, H.265 decode error behavior is primarily governed by the Rockchip MPP decoder path, not by GStreamer software/hardware decode elements** (`avdec_h265`, `d3d11h265dec`, `nvh265dec`, `v4l2*dec`, etc.). The pipeline terminates at `appsink`, and compressed H.265 AU payloads are fed into the project’s own decoder (`video_decoder_feed` -> MPP).【F:src/pipeline.c†L317-L326】【F:src/pipeline.c†L669-L688】【F:src/video_decoder.c†L1689-L1716】
+2. **Depayloading policy already biases toward "drop corrupted AU"**: `sstarh265depay` marks corruption on sequence gaps/FU issues and drops the AU unless `emit-partial-au=true`. Default is `false`.【F:src/h265_depay.c†L399-L408】【F:src/h265_depay.c†L226-L257】【F:src/h265_depay.c†L573-L582】【F:src/h265_depay.c†L618-L620】
+3. **`sstarh265parse` is effectively passthrough and does not implement recovery/concealment logic**; it mostly normalizes caps negotiation (`byte-stream`, alignment pass-through).【F:src/h265_parse.c†L44-L73】【F:src/h265_parse.c†L91-L96】【F:src/h265_parse.c†L136-L151】
+4. **Current receiver pipeline has no RTP jitterbuffer stage**, so loss/reorder handling is mostly from custom depay/statistics/decoder behavior rather than `rtpjitterbuffer` reordering/latency controls.【F:src/pipeline.c†L318-L326】【F:src/pipeline.c†L545-L548】
+
+### Implemented enhancement plan (this branch)
+
+- Added pipeline config control to explicitly choose damaged-AU forwarding: `[pipeline].depay-emit-partial-au`.
+- Added decoder config control to choose drop-vs-keep behavior for frames flagged by MPP: `[pipeline].decoder-drop-error-frames`.
+- Wired IDR warning triggers for `GST_BUFFER_FLAG_CORRUPTED` samples in the appsink pump so partial-frame mode still actively requests recovery.
+- Added a custom RTP reorder stage (`sstarrtpjitterbuffer`) that can be enabled in both receiver and `udpsrc` paths using `[pipeline].jitterbuffer-*` settings.
+- Kept low-latency guidance centered on one-frame buffering (`appsink-max-buffers=1`) and immediate IDR reaction.
+
+---
+
+## 1) Element(s) that govern corruption/recovery behavior
+
+### Primary control (in this repo)
+- **`video_decoder.c` (Rockchip MPP path)**:
+  - Frames flagged by MPP with `errinfo`/`discard` are explicitly dropped.
+  - Each drop triggers IDR requester warning flow.
+  - Decoder is configured with split-parse/immediate-out/fast-play controls that materially affect recovery timing and what is emitted under damage.
+  - Therefore this is the dominant determinant of green/garbled vs dropped/repeated output behavior on embedded RK builds.【F:src/video_decoder.c†L1306-L1329】【F:src/video_decoder.c†L1000-L1023】【F:src/video_decoder.c†L1540-L1560】
+
+### Secondary controls (in this repo)
+- **`sstarh265depay`**:
+  - Detects RTP gaps / malformed FU/AP / timestamp rollover conditions and marks AU corrupted.
+  - Default policy drops corrupted AU; optional policy emits partial AU with `CORRUPTED|DISCONT`.
+  - This influences whether decoder receives broken access units at all.【F:src/h265_depay.c†L399-L408】【F:src/h265_depay.c†L152-L199】【F:src/h265_depay.c†L226-L285】
+- **Queueing/appsink policy**:
+  - Video queue is leaky downstream (`leaky=2`) with `max-size-buffers=16`, so backlog drops are possible under pressure.
+  - `appsink` has `drop=true`, bounded buffers, `sync=false`; this minimizes latency but can increase sample loss under load.
+  - These affect what reaches decoder in time but do not implement concealment themselves.【F:src/pipeline.c†L292-L316】
+- **Custom UDP receiver + IDR requester**:
+  - Tracks loss/jitter and can request IDR bursts on loss/jitter and decoder warnings.
+  - This shortens corruption duration if transmitter honors IDR requests; otherwise corruption persists until natural keyframe.
+  - In `udpsrc` mode, receiver stats/learning are bypassed, reducing this adaptive behavior.【F:src/udp_receiver.c†L438-L490】【F:src/udp_receiver.c†L504-L511】【F:src/pipeline.c†L911-L926】【F:README.md†L177-L189】
+
+---
+
+## 2) Decoder-specific vs parser/depay/jitter/queue/sink influence
+
+## Decoder-specific (strongest)
+- Cross-platform differences (stale frame repeat vs green/garbled) are generally decoder implementation details:
+  - DPB/reference error handling
+  - Concealment strategy for missing references
+  - Whether damaged frames are output, dropped, or substituted
+  - Resync aggressiveness after IDR/CRA
+- In this repo’s runtime path, that behavior maps directly to **Rockchip MPP** decisions plus explicit drop-on-errinfo logic in `frame_thread_func`.【F:src/video_decoder.c†L1306-L1329】
+
+## Parser/depay and transport shaping (secondary)
+- `sstarh265depay` decides how much corruption reaches decoder (drop vs forward-partial).
+- `sstarh265parse` currently does not add robust recovery semantics.
+- No in-pipeline jitterbuffer currently means less controlled reorder/lateness handling.
+- Queue/appsink parameters are latency/backpressure knobs, not codec concealment controls.【F:src/h265_depay.c†L573-L582】【F:src/h265_parse.c†L91-L96】【F:src/pipeline.c†L292-L316】
+
+---
+
+## 3) Relevant properties/flags in the actual pipeline
+
+### Damaged frame output vs drop
+- `sstarh265depay emit-partial-au` (default `false`):
+  - `false` => drop corrupted AU before decoder.
+  - `true` => forward damaged AU with `GST_BUFFER_FLAG_CORRUPTED|DISCONT`.
+  - Current pipeline does not override it, so default drop behavior is active.【F:src/h265_depay.c†L573-L582】【F:src/h265_depay.c†L618-L620】【F:src/pipeline.c†L281-L326】
+- MPP output filtering in frame thread:
+  - `errinfo || discard` => frame dropped and IDR warning emitted.【F:src/video_decoder.c†L1318-L1329】
+
+### Concealment/recovery strategy
+- MPP controls set at init:
+  - `MPP_DEC_SET_DISABLE_ERROR`
+  - `MPP_DEC_SET_IMMEDIATE_OUT`
+  - `MPP_DEC_SET_ENABLE_FAST_PLAY`
+  - plus parser split mode.
+- IDR requester triggers on decode warnings and UDP stats thresholds (loss/jitter), reducing time-to-recovery when source supports on-demand IDR.【F:src/video_decoder.c†L1000-L1023】【F:src/video_decoder.c†L1540-L1560】【F:src/udp_receiver.c†L438-L490】
+
+### AU alignment / parameter-set handling
+- Source caps force H.265 byte-stream AU alignment at depay output and appsink caps:
+  - `video/x-h265, stream-format=byte-stream, alignment=au` in receiver mode.
+  - `udpsrc` mode also enforces byte-stream and appsink alignment AU via caps.
+- Parser preserves alignment field from incoming caps if present; defaults alignment to `au` when missing.【F:src/pipeline.c†L306-L313】【F:src/pipeline.c†L545-L548】【F:src/pipeline.c†L584-L587】【F:src/h265_parse.c†L59-L68】
+
+### Missing-reference behavior
+- Missing packets are detected at depay (sequence gap -> corrupted AU) and receiver stats.
+- Missing-reference decode failures are surfaced by MPP as `errinfo` and dropped in frame thread.
+- Recovery relies on keyframe arrival or successful IDR request path.【F:src/h265_depay.c†L399-L408】【F:src/video_decoder.c†L1318-L1329】【F:src/udp_receiver.c†L595-L601】【F:src/udp_receiver.c†L453-L458】
+
+---
+
+## 4) Platform matrix (actionable)
+
+> Note: only embedded RK path is implemented in this repo. Windows/Linux desktop decoder rows below are guidance for comparison test benches.
+
+| Platform | Decoder used | Typical loss/corruption behavior | Main knobs | Recommended “lowest visual corruption” | Recommended “lowest latency” |
+|---|---|---|---|---|---|
+| Embedded Linux (this repo) | **Rockchip MPP via `video_decoder.c`** | Corrupted references often dropped (`errinfo/discard`) and display can appear frozen/stale until IDR; garbled/green depends on MPP firmware/stream damage pattern | `sstarh265depay emit-partial-au`, MPP controls, IDR thresholds, queue/appsink depth | Keep `emit-partial-au=false`; keep IDR triggers enabled and aggressive (`loss-threshold=1`), ensure camera honors IDR endpoint | Keep leaky queue + small appsink buffers; optionally reduce buffering further but accept more drops |
+| Windows (comparison bench) | Usually `d3d11h265dec` / vendor HW / fallback `avdec_h265` | Vendor decoders may repeat prior frame or output damaged surfaces until IDR/CRA | Decoder-specific error handling, `h265parse` config-interval/alignment, jitterbuffer latency/drop-on-late | Prefer dropping damaged AUs before decode, enforce AU alignment, periodic VPS/SPS/PPS insertion, moderate jitterbuffer | Minimal jitterbuffer latency, leaky queues, `sync=false`; accept higher visual artifacts |
+| Linux desktop (comparison bench) | `va*`, `v4l2*`, `nvh265dec`, or `avdec_h265` | Behavior varies by backend; software decode often deterministic but slower; HW may conceal differently | Same as Windows + backend-specific properties | Use AU-aligned bytestream, drop corrupted AU upstream, periodic parameter-set insertion, request keyframe quickly | Short queues + low jitterbuffer latency + drop-on-late |
+
+---
+
+## 5) Proposed pipeline changes/snippets
+
+## A. Harden current repo pipeline for lowest corruption duration
+
+### Receiver mode (current architecture)
+```c
+/* after creating depay/parser/capsfilter/appsink */
+g_object_set(depay,
+             "payload-type", cfg->vid_pt,
+             "emit-partial-au", FALSE,   // explicit: drop damaged AU
+             NULL);
+
+/* keep AU alignment enforced */
+raw_caps = gst_caps_new_simple("video/x-h265",
+                               "stream-format", G_TYPE_STRING, "byte-stream",
+                               "alignment", G_TYPE_STRING, "au",
+                               NULL);
+```
+(Explicitly documents current preferred behavior and avoids accidental partial-AU forwarding.)
+
+## B. Optional latency/corruption tuning path (when using pure GStreamer decode benches)
+
+### “Lowest visual corruption” bench pattern
+```bash
+gst-launch-1.0 -v udpsrc ... ! rtpjitterbuffer latency=80 drop-on-late=true ! \
+  rtph265depay ! h265parse alignment=au config-interval=1 ! \
+  avdec_h265 output-corrupt=false ! videoconvert ! autovideosink sync=false qos=false
+```
+
+### “Lowest latency” bench pattern
+```bash
+gst-launch-1.0 -v udpsrc ... ! rtpjitterbuffer latency=10 drop-on-late=true ! \
+  rtph265depay ! h265parse alignment=au config-interval=-1 ! \
+  <platform_hw_decoder> ! queue leaky=downstream max-size-buffers=4 ! \
+  autovideosink sync=false qos=false
+```
+
+(Use platform-appropriate decoder substitution for matrix comparisons.)
+
+---
+
+## 6) Reproducible cross-platform test method
+
+## Controlled impairment injection
+1. **Network loss/reorder (Linux host):**
+   - `tc qdisc add dev <iface> root netem loss 2% 25% delay 20ms 5ms reorder 10% 50%`
+2. **Burst loss:**
+   - `tc qdisc change dev <iface> root netem loss gemodel 1% 50% 90% 1%`
+3. **Byte corruption/fuzz RTP payload:**
+   - Insert a small UDP proxy mutating random bytes in H.265 NAL payload region at configured rate.
+
+## Run matrix
+- Keep the same sender stream (GOP, bitrate, packetization mode) across all receivers.
+- Test at least:
+  - clean baseline
+  - 1% random loss
+  - burst loss
+  - corruption without loss
+- Capture:
+  - time from first corruption to first clean post-IDR frame
+  - count of stale-frame intervals
+  - count/duration of green/garbled output periods
+
+## GStreamer/debug logging to collect
+- `GST_DEBUG=2,*h265*:6,*rtp*:6,*jitterbuffer*:6,*basesink*:5`
+- Repo-specific categories:
+  - `sstarh265depay:6`
+  - `sstarh265parse:6`
+- App logs for:
+  - `MPP: dropping frame errinfo=...`
+  - `UDP receiver: ... requesting IDR`
+
+## Pass/fail criteria
+- **Pass (lowest corruption profile):**
+  - no partial damaged AU rendered
+  - recovery to clean output within target window (e.g. <= 1 GOP after loss)
+  - no sustained (>500 ms) green/garbled output under 1% random loss
+- **Pass (lowest latency profile):**
+  - end-to-end latency target met
+  - artifact bursts allowed but must self-recover within defined IDR window
+- **Fail:**
+  - repeated stale frame replay > target window
+  - persistent garble until manual restart
+  - IDR requester active but no keyframe recovery due to endpoint mismatch
+
+---
+
+## Root-cause conclusion
+
+For this codebase, the dominant root cause of differing corruption display is **decoder implementation behavior** (Rockchip MPP in-repo, different decoder backends in Windows/Linux benches), while depay/parser/queues mostly decide whether damaged access units are forwarded, delayed, or dropped before decode. The most practical corruption-minimizing strategy is:
+
+1. keep AU-aligned byte-stream,
+2. drop corrupted AUs before decode (`emit-partial-au=false`),
+3. trigger/validate fast IDR recovery path,
+4. add/retune jitter buffering in comparison pipelines where reorder/lateness dominates.
+
+This combination minimizes long green/garbled intervals and stale-reference artifacts without giving up full low-latency operation.

--- a/include/config.h
+++ b/include/config.h
@@ -72,6 +72,11 @@ typedef struct {
     int vid_pt;
     int aud_pt;
     int appsink_max_buffers;
+    int depay_emit_partial_au;
+    int decoder_drop_error_frames;
+    int jitterbuffer_enable;
+    unsigned int jitterbuffer_latency_ms;
+    unsigned int jitterbuffer_max_misorder;
     int udpsrc_pt97_filter;
     CustomSinkMode custom_sink;
     char aud_dev[128];

--- a/include/config.h
+++ b/include/config.h
@@ -20,6 +20,12 @@ typedef enum {
 } CustomSinkMode;
 
 typedef enum {
+    STREAM_PROFILE_LOW_LATENCY = 0,
+    STREAM_PROFILE_MEDIUM_LATENCY,
+    STREAM_PROFILE_HIGH_LATENCY,
+} StreamProfile;
+
+typedef enum {
     RECORD_MODE_STANDARD = 0,
     RECORD_MODE_SEQUENTIAL,
     RECORD_MODE_FRAGMENTED,
@@ -56,6 +62,8 @@ typedef struct {
     unsigned int loss_threshold;
     double jitter_threshold_ms;
     unsigned int jitter_cooldown_ms;
+    unsigned int recovery_holdoff_ms;
+    unsigned int clean_frames_for_recovery;
 } IdrCfg;
 
 typedef struct {
@@ -72,6 +80,7 @@ typedef struct {
     int vid_pt;
     int aud_pt;
     int appsink_max_buffers;
+    StreamProfile stream_profile;
     int depay_emit_partial_au;
     int decoder_drop_error_frames;
     int jitterbuffer_enable;
@@ -128,6 +137,9 @@ void cfg_get_process_affinity(const AppCfg *cfg, cpu_set_t *set_out);
 int cfg_get_thread_affinity(const AppCfg *cfg, int slot, cpu_set_t *set_out);
 int cfg_parse_custom_sink_mode(const char *value, CustomSinkMode *mode_out);
 const char *cfg_custom_sink_mode_name(CustomSinkMode mode);
+int cfg_parse_stream_profile(const char *value, StreamProfile *profile_out);
+const char *cfg_stream_profile_name(StreamProfile profile);
+void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile);
 int cfg_parse_record_mode(const char *value, RecordMode *mode_out);
 const char *cfg_record_mode_name(RecordMode mode);
 int cfg_parse_host_and_port(const char *value, char *host_out, size_t host_len, int *port_out);

--- a/include/config.h
+++ b/include/config.h
@@ -81,6 +81,7 @@ typedef struct {
     int aud_pt;
     int appsink_max_buffers;
     StreamProfile stream_profile;
+    int stream_profile_lock_controls;
     int depay_emit_partial_au;
     int decoder_drop_error_frames;
     int jitterbuffer_enable;

--- a/include/idr_requester.h
+++ b/include/idr_requester.h
@@ -18,6 +18,7 @@ void idr_requester_free(IdrRequester *req);
 void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len);
 void idr_requester_handle_warning(IdrRequester *req);
 void idr_requester_note_clean_frame(IdrRequester *req);
+void idr_requester_note_keyframe(IdrRequester *req);
 void idr_requester_set_enabled(IdrRequester *req, gboolean enabled);
 guint64 idr_requester_get_request_count(const IdrRequester *req);
 void idr_requester_set_reinit_callback(IdrRequester *req, IdrReinitCallback cb, gpointer user_data);

--- a/include/idr_requester.h
+++ b/include/idr_requester.h
@@ -17,6 +17,7 @@ IdrRequester *idr_requester_new(const IdrCfg *cfg);
 void idr_requester_free(IdrRequester *req);
 void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len);
 void idr_requester_handle_warning(IdrRequester *req);
+void idr_requester_note_clean_frame(IdrRequester *req);
 void idr_requester_set_enabled(IdrRequester *req, gboolean enabled);
 guint64 idr_requester_get_request_count(const IdrRequester *req);
 void idr_requester_set_reinit_callback(IdrRequester *req, IdrReinitCallback cb, gpointer user_data);

--- a/include/rtp_jitterbuffer.h
+++ b/include/rtp_jitterbuffer.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef RTP_JITTERBUFFER_H
+#define RTP_JITTERBUFFER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+GType sstar_rtp_jitterbuffer_get_type(void);
+
+#define SSTAR_TYPE_RTP_JITTERBUFFER (sstar_rtp_jitterbuffer_get_type())
+#define SSTAR_RTP_JITTERBUFFER(obj)                                                                    \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), SSTAR_TYPE_RTP_JITTERBUFFER, SstarRtpJitterBuffer))
+#define SSTAR_IS_RTP_JITTERBUFFER(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), SSTAR_TYPE_RTP_JITTERBUFFER))
+
+typedef struct _SstarRtpJitterBuffer SstarRtpJitterBuffer;
+typedef struct _SstarRtpJitterBufferClass SstarRtpJitterBufferClass;
+
+gboolean sstar_rtp_jitterbuffer_register(void);
+
+G_END_DECLS
+
+#endif // RTP_JITTERBUFFER_H

--- a/src/config.c
+++ b/src/config.c
@@ -201,7 +201,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
         cfg->jitterbuffer_latency_ms = 25;
         cfg->jitterbuffer_max_misorder = 128;
         cfg->idr.loss_window_ms = 400;
-        cfg->idr.loss_threshold = 2;
+        cfg->idr.loss_threshold = 1;
         cfg->idr.jitter_threshold_ms = 35.0;
         cfg->idr.jitter_cooldown_ms = 1000;
         cfg->idr.recovery_holdoff_ms = 1200;

--- a/src/config.c
+++ b/src/config.c
@@ -173,6 +173,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
     }
 
     cfg->stream_profile = profile;
+    cfg->stream_profile_lock_controls = 1;
 
     switch (profile) {
     case STREAM_PROFILE_LOW_LATENCY:
@@ -292,6 +293,7 @@ void cfg_defaults(AppCfg *c) {
     c->aud_pt = 98;
     c->appsink_max_buffers = 4;
     c->stream_profile = STREAM_PROFILE_LOW_LATENCY;
+    c->stream_profile_lock_controls = 1;
     c->udpsrc_pt97_filter = 1;
     c->custom_sink = CUSTOM_SINK_RECEIVER;
     strcpy(c->aud_dev, "plughw:CARD=rockchiphdmi0,DEV=0");
@@ -556,10 +558,23 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
         } else if (!strcmp(argv[i], "--decoder-keep-error-frames")) {
             cfg->decoder_drop_error_frames = 0;
         } else if (!strcmp(argv[i], "--jitterbuffer-enable")) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --jitterbuffer-enable because --stream-profile controls jitter/IDR tuning");
+                continue;
+            }
             cfg->jitterbuffer_enable = 1;
         } else if (!strcmp(argv[i], "--jitterbuffer-disable")) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --jitterbuffer-disable because --stream-profile controls jitter/IDR tuning");
+                continue;
+            }
             cfg->jitterbuffer_enable = 0;
         } else if (!strcmp(argv[i], "--jitterbuffer-latency-ms") && i + 1 < argc) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --jitterbuffer-latency-ms because --stream-profile controls jitter/IDR tuning");
+                ++i;
+                continue;
+            }
             int latency = atoi(argv[++i]);
             if (latency < 0) {
                 LOGW("--jitterbuffer-latency-ms must be >= 0; clamping to 0");
@@ -567,6 +582,11 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             }
             cfg->jitterbuffer_latency_ms = (unsigned int)latency;
         } else if (!strcmp(argv[i], "--jitterbuffer-max-misorder") && i + 1 < argc) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --jitterbuffer-max-misorder because --stream-profile controls jitter/IDR tuning");
+                ++i;
+                continue;
+            }
             int misorder = atoi(argv[++i]);
             if (misorder < 0) {
                 LOGW("--jitterbuffer-max-misorder must be >= 0; clamping to 0");
@@ -706,10 +726,23 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 cfg->idr.http_port = port;
             }
         } else if (!strcmp(argv[i], "--idr-stats-trigger")) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --idr-stats-trigger because --stream-profile controls jitter/IDR tuning");
+                continue;
+            }
             cfg->idr.stats_trigger = 1;
         } else if (!strcmp(argv[i], "--idr-no-stats-trigger")) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --idr-no-stats-trigger because --stream-profile controls jitter/IDR tuning");
+                continue;
+            }
             cfg->idr.stats_trigger = 0;
         } else if (!strcmp(argv[i], "--idr-loss-window-ms") && i + 1 < argc) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --idr-loss-window-ms because --stream-profile controls jitter/IDR tuning");
+                ++i;
+                continue;
+            }
             int win = atoi(argv[++i]);
             if (win < 0) {
                 LOGE("--idr-loss-window-ms requires a non-negative value");
@@ -717,6 +750,11 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             }
             cfg->idr.loss_window_ms = (unsigned int)win;
         } else if (!strcmp(argv[i], "--idr-loss-threshold") && i + 1 < argc) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --idr-loss-threshold because --stream-profile controls jitter/IDR tuning");
+                ++i;
+                continue;
+            }
             int threshold = atoi(argv[++i]);
             if (threshold <= 0) {
                 LOGE("--idr-loss-threshold requires a positive value");
@@ -724,6 +762,11 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             }
             cfg->idr.loss_threshold = (unsigned int)threshold;
         } else if (!strcmp(argv[i], "--idr-jitter-threshold-ms") && i + 1 < argc) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --idr-jitter-threshold-ms because --stream-profile controls jitter/IDR tuning");
+                ++i;
+                continue;
+            }
             double jitter = atof(argv[++i]);
             if (jitter <= 0.0) {
                 LOGE("--idr-jitter-threshold-ms requires a positive value");
@@ -731,6 +774,11 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
             }
             cfg->idr.jitter_threshold_ms = jitter;
         } else if (!strcmp(argv[i], "--idr-jitter-cooldown-ms") && i + 1 < argc) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("Ignoring --idr-jitter-cooldown-ms because --stream-profile controls jitter/IDR tuning");
+                ++i;
+                continue;
+            }
             int cooldown = atoi(argv[++i]);
             if (cooldown < 0) {
                 LOGE("--idr-jitter-cooldown-ms requires a non-negative value");

--- a/src/config.c
+++ b/src/config.c
@@ -24,6 +24,7 @@ static void usage(const char *prog) {
             "  --vid-pt N                   (default: 97 H265)\n"
             "  --aud-pt N                   (default: 98 Opus)\n"
             "  --appsink-max-buffers N      (default: 4)\n"
+            "  --stream-profile PROFILE     (low-latency|medium-latency|high-latency)\n"
             "  --depay-emit-partial-au      (forward corrupted access units to decoder; default on)\n"
             "  --depay-drop-corrupt-au      (drop corrupted access units before decoder)\n"
             "  --decoder-drop-error-frames  (drop frames flagged with decoder errors)\n"
@@ -74,6 +75,11 @@ typedef struct {
     CustomSinkMode mode;
 } CustomSinkAlias;
 
+typedef struct {
+    const char *name;
+    StreamProfile profile;
+} StreamProfileAlias;
+
 static const CustomSinkAlias kCustomSinkAliases[] = {
     {"receiver", CUSTOM_SINK_RECEIVER},
     {"udp-receiver", CUSTOM_SINK_RECEIVER},
@@ -81,6 +87,18 @@ static const CustomSinkAlias kCustomSinkAliases[] = {
     {"udpsrc", CUSTOM_SINK_UDPSRC},
     {"gst-udpsrc", CUSTOM_SINK_UDPSRC},
     {"gst", CUSTOM_SINK_UDPSRC},
+};
+
+static const StreamProfileAlias kStreamProfileAliases[] = {
+    {"low", STREAM_PROFILE_LOW_LATENCY},
+    {"low-latency", STREAM_PROFILE_LOW_LATENCY},
+    {"120fps", STREAM_PROFILE_LOW_LATENCY},
+    {"medium", STREAM_PROFILE_MEDIUM_LATENCY},
+    {"medium-latency", STREAM_PROFILE_MEDIUM_LATENCY},
+    {"60fps", STREAM_PROFILE_MEDIUM_LATENCY},
+    {"high", STREAM_PROFILE_HIGH_LATENCY},
+    {"high-latency", STREAM_PROFILE_HIGH_LATENCY},
+    {"30fps", STREAM_PROFILE_HIGH_LATENCY},
 };
 
 typedef struct {
@@ -120,6 +138,82 @@ const char *cfg_custom_sink_mode_name(CustomSinkMode mode) {
         return "udpsrc";
     default:
         return "unknown";
+    }
+}
+
+int cfg_parse_stream_profile(const char *value, StreamProfile *profile_out) {
+    if (value == NULL || profile_out == NULL) {
+        return -1;
+    }
+    for (size_t i = 0; i < sizeof(kStreamProfileAliases) / sizeof(kStreamProfileAliases[0]); ++i) {
+        if (strcasecmp(value, kStreamProfileAliases[i].name) == 0) {
+            *profile_out = kStreamProfileAliases[i].profile;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+const char *cfg_stream_profile_name(StreamProfile profile) {
+    switch (profile) {
+    case STREAM_PROFILE_LOW_LATENCY:
+        return "low-latency";
+    case STREAM_PROFILE_MEDIUM_LATENCY:
+        return "medium-latency";
+    case STREAM_PROFILE_HIGH_LATENCY:
+        return "high-latency";
+    default:
+        return "unknown";
+    }
+}
+
+void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
+    if (cfg == NULL) {
+        return;
+    }
+
+    cfg->stream_profile = profile;
+
+    switch (profile) {
+    case STREAM_PROFILE_LOW_LATENCY:
+        cfg->depay_emit_partial_au = 1;
+        cfg->decoder_drop_error_frames = 0;
+        cfg->jitterbuffer_enable = 0;
+        cfg->jitterbuffer_latency_ms = 4;
+        cfg->jitterbuffer_max_misorder = 16;
+        cfg->idr.loss_window_ms = 120;
+        cfg->idr.loss_threshold = 1;
+        cfg->idr.jitter_threshold_ms = 15.0;
+        cfg->idr.jitter_cooldown_ms = 300;
+        cfg->idr.recovery_holdoff_ms = 350;
+        cfg->idr.clean_frames_for_recovery = 12;
+        break;
+    case STREAM_PROFILE_MEDIUM_LATENCY:
+        cfg->depay_emit_partial_au = 1;
+        cfg->decoder_drop_error_frames = 0;
+        cfg->jitterbuffer_enable = 1;
+        cfg->jitterbuffer_latency_ms = 12;
+        cfg->jitterbuffer_max_misorder = 64;
+        cfg->idr.loss_window_ms = 200;
+        cfg->idr.loss_threshold = 1;
+        cfg->idr.jitter_threshold_ms = 25.0;
+        cfg->idr.jitter_cooldown_ms = 600;
+        cfg->idr.recovery_holdoff_ms = 700;
+        cfg->idr.clean_frames_for_recovery = 12;
+        break;
+    case STREAM_PROFILE_HIGH_LATENCY:
+        cfg->depay_emit_partial_au = 1;
+        cfg->decoder_drop_error_frames = 0;
+        cfg->jitterbuffer_enable = 1;
+        cfg->jitterbuffer_latency_ms = 25;
+        cfg->jitterbuffer_max_misorder = 128;
+        cfg->idr.loss_window_ms = 400;
+        cfg->idr.loss_threshold = 2;
+        cfg->idr.jitter_threshold_ms = 35.0;
+        cfg->idr.jitter_cooldown_ms = 1000;
+        cfg->idr.recovery_holdoff_ms = 1200;
+        cfg->idr.clean_frames_for_recovery = 8;
+        break;
     }
 }
 
@@ -197,11 +291,7 @@ void cfg_defaults(AppCfg *c) {
     c->vid_pt = 97;
     c->aud_pt = 98;
     c->appsink_max_buffers = 4;
-    c->depay_emit_partial_au = 1;
-    c->decoder_drop_error_frames = 0;
-    c->jitterbuffer_enable = 0;
-    c->jitterbuffer_latency_ms = 8;
-    c->jitterbuffer_max_misorder = 64;
+    c->stream_profile = STREAM_PROFILE_LOW_LATENCY;
     c->udpsrc_pt97_filter = 1;
     c->custom_sink = CUSTOM_SINK_RECEIVER;
     strcpy(c->aud_dev, "plughw:CARD=rockchiphdmi0,DEV=0");
@@ -252,15 +342,19 @@ void cfg_defaults(AppCfg *c) {
     c->idr.endpoint_host[0] = '\0';
     c->idr.endpoint_port = 0;
     c->idr.stats_trigger = 1;
-    c->idr.loss_window_ms = 200;
+    c->idr.loss_window_ms = 120;
     c->idr.loss_threshold = 1;
-    c->idr.jitter_threshold_ms = 25.0;
-    c->idr.jitter_cooldown_ms = 750;
+    c->idr.jitter_threshold_ms = 15.0;
+    c->idr.jitter_cooldown_ms = 300;
+    c->idr.recovery_holdoff_ms = 350;
+    c->idr.clean_frames_for_recovery = 12;
 
     c->video_ctm.enable = 0;
     for (int i = 0; i < 9; ++i) {
         c->video_ctm.matrix[i] = (i % 4 == 0) ? 1.0 : 0.0;
     }
+
+    cfg_apply_stream_profile(c, c->stream_profile);
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {
@@ -446,6 +540,13 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 LOGW("--appsink-max-buffers must be positive; clamping to 1");
                 cfg->appsink_max_buffers = 1;
             }
+        } else if (!strcmp(argv[i], "--stream-profile") && i + 1 < argc) {
+            StreamProfile profile;
+            if (cfg_parse_stream_profile(argv[++i], &profile) != 0) {
+                LOGE("Unknown stream profile '%s'", argv[i]);
+                return -1;
+            }
+            cfg_apply_stream_profile(cfg, profile);
         } else if (!strcmp(argv[i], "--depay-emit-partial-au")) {
             cfg->depay_emit_partial_au = 1;
         } else if (!strcmp(argv[i], "--depay-drop-corrupt-au")) {

--- a/src/config.c
+++ b/src/config.c
@@ -24,6 +24,14 @@ static void usage(const char *prog) {
             "  --vid-pt N                   (default: 97 H265)\n"
             "  --aud-pt N                   (default: 98 Opus)\n"
             "  --appsink-max-buffers N      (default: 4)\n"
+            "  --depay-emit-partial-au      (forward corrupted access units to decoder; default on)\n"
+            "  --depay-drop-corrupt-au      (drop corrupted access units before decoder)\n"
+            "  --decoder-drop-error-frames  (drop frames flagged with decoder errors)\n"
+            "  --decoder-keep-error-frames  (display frames flagged with decoder errors; default)\n"
+            "  --jitterbuffer-enable        (enable in-pipeline RTP reorder buffer)\n"
+            "  --jitterbuffer-disable       (disable in-pipeline RTP reorder buffer; default)\n"
+            "  --jitterbuffer-latency-ms N  (wait budget before skipping gaps; default: 8)\n"
+            "  --jitterbuffer-max-misorder N (max RTP sequence distance to reorder; default: 64)\n"
             "  --custom-sink MODE           (receiver|udpsrc; default: receiver)\n"
             "  --aud-dev STR                (default: plughw:CARD=rockchiphdmi0,DEV=0)\n"
             "  --no-audio                   (drop audio branch entirely)\n"
@@ -189,6 +197,11 @@ void cfg_defaults(AppCfg *c) {
     c->vid_pt = 97;
     c->aud_pt = 98;
     c->appsink_max_buffers = 4;
+    c->depay_emit_partial_au = 1;
+    c->decoder_drop_error_frames = 0;
+    c->jitterbuffer_enable = 0;
+    c->jitterbuffer_latency_ms = 8;
+    c->jitterbuffer_max_misorder = 64;
     c->udpsrc_pt97_filter = 1;
     c->custom_sink = CUSTOM_SINK_RECEIVER;
     strcpy(c->aud_dev, "plughw:CARD=rockchiphdmi0,DEV=0");
@@ -433,6 +446,32 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 LOGW("--appsink-max-buffers must be positive; clamping to 1");
                 cfg->appsink_max_buffers = 1;
             }
+        } else if (!strcmp(argv[i], "--depay-emit-partial-au")) {
+            cfg->depay_emit_partial_au = 1;
+        } else if (!strcmp(argv[i], "--depay-drop-corrupt-au")) {
+            cfg->depay_emit_partial_au = 0;
+        } else if (!strcmp(argv[i], "--decoder-drop-error-frames")) {
+            cfg->decoder_drop_error_frames = 1;
+        } else if (!strcmp(argv[i], "--decoder-keep-error-frames")) {
+            cfg->decoder_drop_error_frames = 0;
+        } else if (!strcmp(argv[i], "--jitterbuffer-enable")) {
+            cfg->jitterbuffer_enable = 1;
+        } else if (!strcmp(argv[i], "--jitterbuffer-disable")) {
+            cfg->jitterbuffer_enable = 0;
+        } else if (!strcmp(argv[i], "--jitterbuffer-latency-ms") && i + 1 < argc) {
+            int latency = atoi(argv[++i]);
+            if (latency < 0) {
+                LOGW("--jitterbuffer-latency-ms must be >= 0; clamping to 0");
+                latency = 0;
+            }
+            cfg->jitterbuffer_latency_ms = (unsigned int)latency;
+        } else if (!strcmp(argv[i], "--jitterbuffer-max-misorder") && i + 1 < argc) {
+            int misorder = atoi(argv[++i]);
+            if (misorder < 0) {
+                LOGW("--jitterbuffer-max-misorder must be >= 0; clamping to 0");
+                misorder = 0;
+            }
+            cfg->jitterbuffer_max_misorder = (unsigned int)misorder;
         } else if (!strcmp(argv[i], "--custom-sink") && i + 1 < argc) {
             const char *mode_str = argv[++i];
             CustomSinkMode mode;

--- a/src/config.c
+++ b/src/config.c
@@ -25,10 +25,6 @@ static void usage(const char *prog) {
             "  --aud-pt N                   (default: 98 Opus)\n"
             "  --appsink-max-buffers N      (default: 4)\n"
             "  --stream-profile PROFILE     (low-latency|medium-latency|high-latency)\n"
-            "  --jitterbuffer-enable        (enable in-pipeline RTP reorder buffer)\n"
-            "  --jitterbuffer-disable       (disable in-pipeline RTP reorder buffer; default)\n"
-            "  --jitterbuffer-latency-ms N  (wait budget before skipping gaps; default: 8)\n"
-            "  --jitterbuffer-max-misorder N (max RTP sequence distance to reorder; default: 64)\n"
             "  --custom-sink MODE           (receiver|udpsrc; default: receiver)\n"
             "  --aud-dev STR                (default: plughw:CARD=rockchiphdmi0,DEV=0)\n"
             "  --no-audio                   (drop audio branch entirely)\n"
@@ -173,7 +169,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
 
     switch (profile) {
     case STREAM_PROFILE_LOW_LATENCY:
-        cfg->depay_emit_partial_au = 1;
+        cfg->depay_emit_partial_au = 0;
         cfg->decoder_drop_error_frames = 0;
         cfg->jitterbuffer_enable = 0;
         cfg->jitterbuffer_latency_ms = 4;
@@ -186,7 +182,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
         cfg->idr.clean_frames_for_recovery = 12;
         break;
     case STREAM_PROFILE_MEDIUM_LATENCY:
-        cfg->depay_emit_partial_au = 1;
+        cfg->depay_emit_partial_au = 0;
         cfg->decoder_drop_error_frames = 0;
         cfg->jitterbuffer_enable = 1;
         cfg->jitterbuffer_latency_ms = 12;
@@ -199,7 +195,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
         cfg->idr.clean_frames_for_recovery = 12;
         break;
     case STREAM_PROFILE_HIGH_LATENCY:
-        cfg->depay_emit_partial_au = 1;
+        cfg->depay_emit_partial_au = 0;
         cfg->decoder_drop_error_frames = 0;
         cfg->jitterbuffer_enable = 1;
         cfg->jitterbuffer_latency_ms = 25;
@@ -545,42 +541,6 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 return -1;
             }
             cfg_apply_stream_profile(cfg, profile);
-        } else if (!strcmp(argv[i], "--jitterbuffer-enable")) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("Ignoring --jitterbuffer-enable because --stream-profile controls jitter/IDR tuning");
-                continue;
-            }
-            cfg->jitterbuffer_enable = 1;
-        } else if (!strcmp(argv[i], "--jitterbuffer-disable")) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("Ignoring --jitterbuffer-disable because --stream-profile controls jitter/IDR tuning");
-                continue;
-            }
-            cfg->jitterbuffer_enable = 0;
-        } else if (!strcmp(argv[i], "--jitterbuffer-latency-ms") && i + 1 < argc) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("Ignoring --jitterbuffer-latency-ms because --stream-profile controls jitter/IDR tuning");
-                ++i;
-                continue;
-            }
-            int latency = atoi(argv[++i]);
-            if (latency < 0) {
-                LOGW("--jitterbuffer-latency-ms must be >= 0; clamping to 0");
-                latency = 0;
-            }
-            cfg->jitterbuffer_latency_ms = (unsigned int)latency;
-        } else if (!strcmp(argv[i], "--jitterbuffer-max-misorder") && i + 1 < argc) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("Ignoring --jitterbuffer-max-misorder because --stream-profile controls jitter/IDR tuning");
-                ++i;
-                continue;
-            }
-            int misorder = atoi(argv[++i]);
-            if (misorder < 0) {
-                LOGW("--jitterbuffer-max-misorder must be >= 0; clamping to 0");
-                misorder = 0;
-            }
-            cfg->jitterbuffer_max_misorder = (unsigned int)misorder;
         } else if (!strcmp(argv[i], "--custom-sink") && i + 1 < argc) {
             const char *mode_str = argv[++i];
             CustomSinkMode mode;

--- a/src/config.c
+++ b/src/config.c
@@ -170,7 +170,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
     switch (profile) {
     case STREAM_PROFILE_LOW_LATENCY:
         cfg->depay_emit_partial_au = 0;
-        cfg->decoder_drop_error_frames = 0;
+        cfg->decoder_drop_error_frames = 1;
         cfg->jitterbuffer_enable = 0;
         cfg->jitterbuffer_latency_ms = 4;
         cfg->jitterbuffer_max_misorder = 16;
@@ -183,7 +183,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
         break;
     case STREAM_PROFILE_MEDIUM_LATENCY:
         cfg->depay_emit_partial_au = 0;
-        cfg->decoder_drop_error_frames = 0;
+        cfg->decoder_drop_error_frames = 1;
         cfg->jitterbuffer_enable = 1;
         cfg->jitterbuffer_latency_ms = 12;
         cfg->jitterbuffer_max_misorder = 64;
@@ -196,7 +196,7 @@ void cfg_apply_stream_profile(AppCfg *cfg, StreamProfile profile) {
         break;
     case STREAM_PROFILE_HIGH_LATENCY:
         cfg->depay_emit_partial_au = 0;
-        cfg->decoder_drop_error_frames = 0;
+        cfg->decoder_drop_error_frames = 1;
         cfg->jitterbuffer_enable = 1;
         cfg->jitterbuffer_latency_ms = 25;
         cfg->jitterbuffer_max_misorder = 128;

--- a/src/config.c
+++ b/src/config.c
@@ -25,10 +25,6 @@ static void usage(const char *prog) {
             "  --aud-pt N                   (default: 98 Opus)\n"
             "  --appsink-max-buffers N      (default: 4)\n"
             "  --stream-profile PROFILE     (low-latency|medium-latency|high-latency)\n"
-            "  --depay-emit-partial-au      (forward corrupted access units to decoder; default on)\n"
-            "  --depay-drop-corrupt-au      (drop corrupted access units before decoder)\n"
-            "  --decoder-drop-error-frames  (drop frames flagged with decoder errors)\n"
-            "  --decoder-keep-error-frames  (display frames flagged with decoder errors; default)\n"
             "  --jitterbuffer-enable        (enable in-pipeline RTP reorder buffer)\n"
             "  --jitterbuffer-disable       (disable in-pipeline RTP reorder buffer; default)\n"
             "  --jitterbuffer-latency-ms N  (wait budget before skipping gaps; default: 8)\n"
@@ -549,14 +545,6 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 return -1;
             }
             cfg_apply_stream_profile(cfg, profile);
-        } else if (!strcmp(argv[i], "--depay-emit-partial-au")) {
-            cfg->depay_emit_partial_au = 1;
-        } else if (!strcmp(argv[i], "--depay-drop-corrupt-au")) {
-            cfg->depay_emit_partial_au = 0;
-        } else if (!strcmp(argv[i], "--decoder-drop-error-frames")) {
-            cfg->decoder_drop_error_frames = 1;
-        } else if (!strcmp(argv[i], "--decoder-keep-error-frames")) {
-            cfg->decoder_drop_error_frames = 0;
         } else if (!strcmp(argv[i], "--jitterbuffer-enable")) {
             if (cfg->stream_profile_lock_controls) {
                 LOGW("Ignoring --jitterbuffer-enable because --stream-profile controls jitter/IDR tuning");

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -929,6 +929,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "jitterbuffer-enable") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring pipeline.jitterbuffer-enable because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = 0;
             if (parse_bool(value, &v) != 0) {
                 return -1;
@@ -937,6 +941,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "jitterbuffer-latency-ms") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring pipeline.jitterbuffer-latency-ms because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = atoi(value);
             if (v < 0) {
                 LOGE("config: pipeline.jitterbuffer-latency-ms '%s' must be >= 0", value);
@@ -946,6 +954,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "jitterbuffer-max-misorder") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring pipeline.jitterbuffer-max-misorder because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = atoi(value);
             if (v < 0) {
                 LOGE("config: pipeline.jitterbuffer-max-misorder '%s' must be >= 0", value);
@@ -1262,6 +1274,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "stats-trigger") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring idr.stats-trigger because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = 0;
             if (parse_bool(value, &v) != 0) {
                 return -1;
@@ -1270,6 +1286,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "loss-window-ms") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring idr.loss-window-ms because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = atoi(value);
             if (v < 0) {
                 v = 0;
@@ -1278,6 +1298,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "loss-threshold") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring idr.loss-threshold because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = atoi(value);
             if (v <= 0) {
                 LOGE("config: IDR loss-threshold '%s' must be positive", value);
@@ -1287,6 +1311,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "jitter-threshold-ms") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring idr.jitter-threshold-ms because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             double v = atof(value);
             if (v <= 0.0) {
                 LOGE("config: IDR jitter-threshold-ms '%s' must be positive", value);
@@ -1296,6 +1324,10 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "jitter-cooldown-ms") == 0) {
+            if (cfg->stream_profile_lock_controls) {
+                LOGW("config: ignoring idr.jitter-cooldown-ms because pipeline.stream-profile controls jitter/IDR tuning");
+                return 0;
+            }
             int v = atoi(value);
             if (v < 0) {
                 v = 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -903,6 +903,15 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             }
             return 0;
         }
+        if (strcasecmp(key, "stream-profile") == 0) {
+            StreamProfile profile;
+            if (cfg_parse_stream_profile(value, &profile) != 0) {
+                LOGE("config: invalid pipeline.stream-profile '%s'", value);
+                return -1;
+            }
+            cfg_apply_stream_profile(cfg, profile);
+            return 0;
+        }
         if (strcasecmp(key, "depay-emit-partial-au") == 0) {
             int v = 0;
             if (parse_bool(value, &v) != 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -912,44 +912,6 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg_apply_stream_profile(cfg, profile);
             return 0;
         }
-        if (strcasecmp(key, "jitterbuffer-enable") == 0) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("config: ignoring pipeline.jitterbuffer-enable because pipeline.stream-profile controls jitter/IDR tuning");
-                return 0;
-            }
-            int v = 0;
-            if (parse_bool(value, &v) != 0) {
-                return -1;
-            }
-            cfg->jitterbuffer_enable = v;
-            return 0;
-        }
-        if (strcasecmp(key, "jitterbuffer-latency-ms") == 0) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("config: ignoring pipeline.jitterbuffer-latency-ms because pipeline.stream-profile controls jitter/IDR tuning");
-                return 0;
-            }
-            int v = atoi(value);
-            if (v < 0) {
-                LOGE("config: pipeline.jitterbuffer-latency-ms '%s' must be >= 0", value);
-                v = 0;
-            }
-            cfg->jitterbuffer_latency_ms = (unsigned int)v;
-            return 0;
-        }
-        if (strcasecmp(key, "jitterbuffer-max-misorder") == 0) {
-            if (cfg->stream_profile_lock_controls) {
-                LOGW("config: ignoring pipeline.jitterbuffer-max-misorder because pipeline.stream-profile controls jitter/IDR tuning");
-                return 0;
-            }
-            int v = atoi(value);
-            if (v < 0) {
-                LOGE("config: pipeline.jitterbuffer-max-misorder '%s' must be >= 0", value);
-                v = 0;
-            }
-            cfg->jitterbuffer_max_misorder = (unsigned int)v;
-            return 0;
-        }
         if (strcasecmp(key, "custom-sink") == 0) {
             CustomSinkMode mode;
             if (cfg_parse_custom_sink_mode(value, &mode) != 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -903,6 +903,48 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             }
             return 0;
         }
+        if (strcasecmp(key, "depay-emit-partial-au") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->depay_emit_partial_au = v;
+            return 0;
+        }
+        if (strcasecmp(key, "decoder-drop-error-frames") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->decoder_drop_error_frames = v;
+            return 0;
+        }
+        if (strcasecmp(key, "jitterbuffer-enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->jitterbuffer_enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "jitterbuffer-latency-ms") == 0) {
+            int v = atoi(value);
+            if (v < 0) {
+                LOGE("config: pipeline.jitterbuffer-latency-ms '%s' must be >= 0", value);
+                v = 0;
+            }
+            cfg->jitterbuffer_latency_ms = (unsigned int)v;
+            return 0;
+        }
+        if (strcasecmp(key, "jitterbuffer-max-misorder") == 0) {
+            int v = atoi(value);
+            if (v < 0) {
+                LOGE("config: pipeline.jitterbuffer-max-misorder '%s' must be >= 0", value);
+                v = 0;
+            }
+            cfg->jitterbuffer_max_misorder = (unsigned int)v;
+            return 0;
+        }
         if (strcasecmp(key, "custom-sink") == 0) {
             CustomSinkMode mode;
             if (cfg_parse_custom_sink_mode(value, &mode) != 0) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -912,22 +912,6 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg_apply_stream_profile(cfg, profile);
             return 0;
         }
-        if (strcasecmp(key, "depay-emit-partial-au") == 0) {
-            int v = 0;
-            if (parse_bool(value, &v) != 0) {
-                return -1;
-            }
-            cfg->depay_emit_partial_au = v;
-            return 0;
-        }
-        if (strcasecmp(key, "decoder-drop-error-frames") == 0) {
-            int v = 0;
-            if (parse_bool(value, &v) != 0) {
-                return -1;
-            }
-            cfg->decoder_drop_error_frames = v;
-            return 0;
-        }
         if (strcasecmp(key, "jitterbuffer-enable") == 0) {
             if (cfg->stream_profile_lock_controls) {
                 LOGW("config: ignoring pipeline.jitterbuffer-enable because pipeline.stream-profile controls jitter/IDR tuning");

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -597,6 +597,28 @@ void idr_requester_note_clean_frame(IdrRequester *req) {
     g_mutex_unlock(&req->lock);
 }
 
+
+void idr_requester_note_keyframe(IdrRequester *req) {
+    if (req == NULL) {
+        return;
+    }
+
+    guint64 now_ms = monotonic_ms();
+    g_mutex_lock(&req->lock);
+    if (req->shutting_down || !req->enabled) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    req->active = FALSE;
+    req->attempt_count = 0;
+    req->next_interval_ms = 0;
+    req->last_request_ms = 0;
+    req->reinit_pending = FALSE;
+    req->clean_streak = 0;
+    req->recovery_suppress_until_ms = now_ms + req->recovery_holdoff_ms;
+    g_mutex_unlock(&req->lock);
+}
 guint64 idr_requester_get_request_count(const IdrRequester *req) {
     if (req == NULL) {
         return 0;

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -583,13 +583,16 @@ void idr_requester_note_clean_frame(IdrRequester *req) {
     }
 
     if (req->clean_streak >= threshold) {
+        gboolean had_active_recovery = req->active || req->attempt_count > 0 || req->last_request_ms != 0;
         req->active = FALSE;
         req->attempt_count = 0;
         req->next_interval_ms = 0;
         req->last_request_ms = 0;
         req->reinit_pending = FALSE;
         req->clean_streak = 0;
-        req->recovery_suppress_until_ms = now_ms + req->recovery_holdoff_ms;
+        if (had_active_recovery) {
+            req->recovery_suppress_until_ms = now_ms + req->recovery_holdoff_ms;
+        }
     }
     g_mutex_unlock(&req->lock);
 }

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -53,6 +53,11 @@ struct IdrRequester {
 
     guint64 total_requests;
 
+    guint recovery_holdoff_ms;
+    guint clean_frames_for_recovery;
+    guint clean_streak;
+    guint64 recovery_suppress_until_ms;
+
     IdrReinitCallback reinit_cb;
     gpointer reinit_user_data;
     gboolean reinit_pending;
@@ -274,6 +279,10 @@ IdrRequester *idr_requester_new(const IdrCfg *cfg) {
     req->request_in_flight = FALSE;
     req->shutting_down = FALSE;
     req->total_requests = 0;
+    req->recovery_holdoff_ms = (cfg != NULL) ? cfg->recovery_holdoff_ms : 0u;
+    req->clean_frames_for_recovery = (cfg != NULL) ? cfg->clean_frames_for_recovery : 0u;
+    req->clean_streak = 0;
+    req->recovery_suppress_until_ms = 0;
     req->reinit_cb = NULL;
     req->reinit_user_data = NULL;
     req->reinit_pending = FALSE;
@@ -384,6 +393,12 @@ void idr_requester_handle_warning(IdrRequester *req) {
 
     g_mutex_lock(&req->lock);
     if (req->shutting_down || !req->enabled || !req->have_source) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    req->clean_streak = 0;
+    if (req->recovery_suppress_until_ms != 0 && now_ms < req->recovery_suppress_until_ms) {
         g_mutex_unlock(&req->lock);
         return;
     }
@@ -546,6 +561,39 @@ void idr_requester_handle_warning(IdrRequester *req) {
     g_thread_unref(thread);
 }
 
+void idr_requester_note_clean_frame(IdrRequester *req) {
+    if (req == NULL) {
+        return;
+    }
+
+    guint64 now_ms = monotonic_ms();
+    g_mutex_lock(&req->lock);
+    if (req->shutting_down || !req->enabled) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    guint threshold = req->clean_frames_for_recovery;
+    if (threshold == 0) {
+        threshold = 10;
+    }
+
+    if (req->clean_streak < threshold) {
+        req->clean_streak++;
+    }
+
+    if (req->clean_streak >= threshold) {
+        req->active = FALSE;
+        req->attempt_count = 0;
+        req->next_interval_ms = 0;
+        req->last_request_ms = 0;
+        req->reinit_pending = FALSE;
+        req->clean_streak = 0;
+        req->recovery_suppress_until_ms = now_ms + req->recovery_holdoff_ms;
+    }
+    g_mutex_unlock(&req->lock);
+}
+
 guint64 idr_requester_get_request_count(const IdrRequester *req) {
     if (req == NULL) {
         return 0;
@@ -569,4 +617,3 @@ void idr_requester_set_reinit_callback(IdrRequester *req, IdrReinitCallback cb, 
     req->reinit_user_data = user_data;
     g_mutex_unlock(&req->lock);
 }
-

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -714,6 +714,9 @@ static gpointer appsink_thread_func(gpointer data) {
         max_packet = 1024 * 1024;
     }
 
+    const guint64 corrupt_idr_min_interval_ns = 1000ull * 1000ull * 1000ull;
+    guint64 last_corrupt_idr_ns = 0;
+
     while (TRUE) {
         g_mutex_lock(&ps->lock);
         gboolean stop_requested = ps->stop_requested;
@@ -742,8 +745,12 @@ static gpointer appsink_thread_func(gpointer data) {
 
                 if (corrupted) {
                     if (ps->idr_requester != NULL) {
-                        LOGW("Pipeline: corrupted H.265 access unit detected; requesting IDR");
-                        idr_requester_handle_warning(ps->idr_requester);
+                        guint64 now_ns = monotonic_time_ns();
+                        if (last_corrupt_idr_ns == 0 || now_ns - last_corrupt_idr_ns >= corrupt_idr_min_interval_ns) {
+                            LOGW("Pipeline: corrupted H.265 access unit detected; requesting IDR");
+                            idr_requester_handle_warning(ps->idr_requester);
+                            last_corrupt_idr_ns = now_ns;
+                        }
                     }
                 } else if (ps->idr_requester != NULL) {
                     idr_requester_note_clean_frame(ps->idr_requester);

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -4,6 +4,7 @@
 #include "h265_depay.h"
 #include "h265_parse.h"
 #include "logging.h"
+#include "rtp_jitterbuffer.h"
 #include "video_recorder.h"
 
 #ifndef GST_USE_UNSTABLE_API
@@ -146,6 +147,9 @@ static void ensure_gst_initialized(const AppCfg *cfg) {
         if (!sstar_h265_parse_register()) {
             LOGW("Failed to register sstarh265parse; falling back to system plugin if available");
         }
+        if (!sstar_rtp_jitterbuffer_register()) {
+            LOGW("Failed to register sstarrtpjitterbuffer; falling back to no reorder stage");
+        }
         g_once_init_leave(&inited, 1);
     }
 }
@@ -245,6 +249,7 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     GstElement *pipeline = NULL;
     GstElement *appsrc = NULL;
     GstElement *depay = NULL;
+    GstElement *jitterbuffer = NULL;
     GstElement *udp_queue = NULL;
     GstElement *parser = NULL;
     GstElement *capsfilter = NULL;
@@ -280,6 +285,8 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
 
     depay = gst_element_factory_make("sstarh265depay", "video_depay");
     CHECK_ELEM(depay, "sstarh265depay");
+    jitterbuffer = gst_element_factory_make("sstarrtpjitterbuffer", "video_jitterbuffer");
+    CHECK_ELEM(jitterbuffer, "sstarrtpjitterbuffer");
     udp_queue = gst_element_factory_make("queue", "udp_queue");
     CHECK_ELEM(udp_queue, "queue");
     parser = gst_element_factory_make("sstarh265parse", "video_parser");
@@ -295,7 +302,15 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     g_object_set(appsink, "sync", FALSE, NULL);
 
     if (cfg != NULL) {
-        g_object_set(depay, "payload-type", cfg->vid_pt, NULL);
+        g_object_set(depay,
+                     "payload-type", cfg->vid_pt,
+                     "emit-partial-au", cfg->depay_emit_partial_au ? TRUE : FALSE,
+                     NULL);
+        g_object_set(jitterbuffer,
+                     "enabled", cfg->jitterbuffer_enable ? TRUE : FALSE,
+                     "latency-ms", cfg->jitterbuffer_latency_ms,
+                     "max-misorder", cfg->jitterbuffer_max_misorder,
+                     NULL);
     }
 
     raw_caps = gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "byte-stream",
@@ -312,8 +327,8 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
     g_object_set(udp_queue, "leaky", 2, "max-size-time", (guint64)0, "max-size-bytes", (guint64)0,
                  "max-size-buffers", 16, NULL);
 
-    gst_bin_add_many(GST_BIN(pipeline), appsrc, depay, udp_queue, parser, capsfilter, appsink, NULL);
-    if (!gst_element_link_many(appsrc, depay, udp_queue, NULL)) {
+    gst_bin_add_many(GST_BIN(pipeline), appsrc, jitterbuffer, depay, udp_queue, parser, capsfilter, appsink, NULL);
+    if (!gst_element_link_many(appsrc, jitterbuffer, depay, udp_queue, NULL)) {
         LOGE("Failed to link UDP receiver passthrough source chain");
         goto fail;
     }
@@ -504,6 +519,9 @@ fail:
     if (parser != NULL && GST_OBJECT_PARENT(parser) == NULL) {
         gst_object_unref(parser);
     }
+    if (jitterbuffer != NULL && GST_OBJECT_PARENT(jitterbuffer) == NULL) {
+        gst_object_unref(jitterbuffer);
+    }
     if (udp_queue != NULL && GST_OBJECT_PARENT(udp_queue) == NULL) {
         gst_object_unref(udp_queue);
     }
@@ -542,11 +560,17 @@ static gboolean setup_gst_udpsrc_pipeline(PipelineState *ps, const AppCfg *cfg) 
 
     gchar *desc = g_strdup_printf(
         "udpsrc name=udp_source port=%d caps=\"%s\" ! "
+        "sstarrtpjitterbuffer name=video_jitterbuffer enabled=%s latency-ms=%u max-misorder=%u ! "
         "sstarh265depay name=video_depay payload-type=%d ! "
         "sstarh265parse name=video_parser ! "
         "capsfilter name=video_capsfilter caps=\"video/x-h265, stream-format=(string)byte-stream\" ! "
         "appsink drop=true name=out_appsink",
-        cfg->udp_port, caps_desc, cfg->vid_pt);
+        cfg->udp_port,
+        caps_desc,
+        cfg->jitterbuffer_enable ? "true" : "false",
+        cfg->jitterbuffer_latency_ms,
+        cfg->jitterbuffer_max_misorder,
+        cfg->vid_pt);
     g_free(caps_desc);
 
     if (desc == NULL) {
@@ -575,6 +599,12 @@ static gboolean setup_gst_udpsrc_pipeline(PipelineState *ps, const AppCfg *cfg) 
         LOGE("Failed to find appsink in udpsrc pipeline");
         gst_object_unref(pipeline);
         return FALSE;
+    }
+
+    GstElement *depay = gst_bin_get_by_name(GST_BIN(pipeline), "video_depay");
+    if (depay != NULL) {
+        g_object_set(depay, "emit-partial-au", cfg->depay_emit_partial_au ? TRUE : FALSE, NULL);
+        gst_object_unref(depay);
     }
 
     guint max_buffers = (cfg && cfg->appsink_max_buffers > 0) ? (guint)cfg->appsink_max_buffers : 4u;
@@ -673,6 +703,14 @@ static gpointer appsink_thread_func(gpointer data) {
 
         GstBuffer *buffer = gst_sample_get_buffer(sample);
         if (buffer != NULL) {
+            GstBufferFlags flags = GST_BUFFER_FLAGS(buffer);
+            if ((flags & GST_BUFFER_FLAG_CORRUPTED) != 0) {
+                if (ps->idr_requester != NULL) {
+                    LOGW("Pipeline: corrupted H.265 access unit detected; requesting IDR");
+                    idr_requester_handle_warning(ps->idr_requester);
+                }
+            }
+
             GstMapInfo map;
             if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
                 if (map.size > 0 && map.size <= max_packet) {

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -709,6 +709,8 @@ static gpointer appsink_thread_func(gpointer data) {
                     LOGW("Pipeline: corrupted H.265 access unit detected; requesting IDR");
                     idr_requester_handle_warning(ps->idr_requester);
                 }
+            } else if (ps->idr_requester != NULL) {
+                idr_requester_note_clean_frame(ps->idr_requester);
             }
 
             GstMapInfo map;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -77,6 +77,35 @@ static guint64 monotonic_time_ns(void) {
     return (guint64)g_get_monotonic_time() * 1000ull;
 }
 
+static gboolean h265_au_has_irap(const guint8 *data, gsize size) {
+    if (data == NULL || size < 5) {
+        return FALSE;
+    }
+
+    for (gsize i = 0; i + 4 < size; ++i) {
+        gsize nal_start = 0;
+        if (i + 3 < size && data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x01) {
+            nal_start = i + 3;
+        } else if (i + 4 < size && data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x00 &&
+                   data[i + 3] == 0x01) {
+            nal_start = i + 4;
+        } else {
+            continue;
+        }
+
+        if (nal_start + 1 >= size) {
+            continue;
+        }
+
+        guint8 nal_type = (data[nal_start] >> 1) & 0x3f;
+        if (nal_type >= 16 && nal_type <= 21) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
 /* Request an IDR frame on key recovery events (startup, recording start, warnings). */
 static void pipeline_request_idr(PipelineState *ps) {
     if (ps == NULL || ps->idr_requester == NULL) {
@@ -703,17 +732,23 @@ static gpointer appsink_thread_func(gpointer data) {
         GstBuffer *buffer = gst_sample_get_buffer(sample);
         if (buffer != NULL) {
             GstBufferFlags flags = GST_BUFFER_FLAGS(buffer);
-            if ((flags & GST_BUFFER_FLAG_CORRUPTED) != 0) {
-                if (ps->idr_requester != NULL) {
-                    LOGW("Pipeline: corrupted H.265 access unit detected; requesting IDR");
-                    idr_requester_handle_warning(ps->idr_requester);
-                }
-            } else if (ps->idr_requester != NULL) {
-                idr_requester_note_clean_frame(ps->idr_requester);
-            }
+            gboolean corrupted = (flags & GST_BUFFER_FLAG_CORRUPTED) != 0;
 
             GstMapInfo map;
             if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+                if (ps->idr_requester != NULL && h265_au_has_irap(map.data, map.size)) {
+                    idr_requester_note_keyframe(ps->idr_requester);
+                }
+
+                if (corrupted) {
+                    if (ps->idr_requester != NULL) {
+                        LOGW("Pipeline: corrupted H.265 access unit detected; requesting IDR");
+                        idr_requester_handle_warning(ps->idr_requester);
+                    }
+                } else if (ps->idr_requester != NULL) {
+                    idr_requester_note_clean_frame(ps->idr_requester);
+                }
+
                 if (map.size > 0 && map.size <= max_packet) {
                     g_mutex_lock(&ps->recorder_lock);
                     VideoRecorder *recorder = ps->recorder;

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -77,8 +77,7 @@ static guint64 monotonic_time_ns(void) {
     return (guint64)g_get_monotonic_time() * 1000ull;
 }
 
-/* Request an IDR frame when we are about to begin recording so files start
- * with a keyframe. */
+/* Request an IDR frame on key recovery events (startup, recording start, warnings). */
 static void pipeline_request_idr(PipelineState *ps) {
     if (ps == NULL || ps->idr_requester == NULL) {
         return;
@@ -1056,9 +1055,8 @@ int pipeline_start(const AppCfg *cfg, const ModesetResult *ms, int drm_fd, int a
 
     ps->state = PIPELINE_RUNNING;
 
-    if (pipeline_is_recording(ps)) {
-        pipeline_request_idr(ps);
-    }
+    pipeline_request_idr(ps);
+
     return 0;
 
 fail:

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -443,9 +443,9 @@ static gboolean setup_udp_receiver_passthrough(PipelineState *ps, const AppCfg *
 
     ps->pipeline = pipeline;
     ps->video_sink = appsink;
-    ps->video_depay = depay;
-    ps->video_parser = parser;
-    ps->video_capsfilter = capsfilter;
+    ps->video_depay = gst_object_ref(depay);
+    ps->video_parser = gst_object_ref(parser);
+    ps->video_capsfilter = gst_object_ref(capsfilter);
     ps->udp_receiver = receiver;
     return TRUE;
 

--- a/src/rtp_jitterbuffer.c
+++ b/src/rtp_jitterbuffer.c
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: MIT
+
+#include "rtp_jitterbuffer.h"
+
+#include <gst/gst.h>
+
+GST_DEBUG_CATEGORY_STATIC(sstar_rtp_jitterbuffer_debug);
+#define GST_CAT_DEFAULT sstar_rtp_jitterbuffer_debug
+
+#define RTP_MIN_HEADER 12
+
+typedef struct {
+    guint16 sequence;
+    GstBuffer *buffer;
+} RtpQueuedPacket;
+
+struct _SstarRtpJitterBuffer {
+    GstElement parent;
+
+    GstPad *sinkpad;
+    GstPad *srcpad;
+
+    gboolean enabled;
+    guint latency_ms;
+    guint max_misorder;
+
+    gboolean have_expected_seq;
+    guint16 expected_seq;
+    gboolean gap_active;
+    guint64 gap_started_ns;
+
+    GQueue *queued;
+};
+
+struct _SstarRtpJitterBufferClass {
+    GstElementClass parent_class;
+};
+
+G_DEFINE_TYPE(SstarRtpJitterBuffer, sstar_rtp_jitterbuffer, GST_TYPE_ELEMENT)
+
+enum {
+    PROP_0,
+    PROP_ENABLED,
+    PROP_LATENCY_MS,
+    PROP_MAX_MISORDER,
+};
+
+static inline guint64 monotonic_ns(void) {
+    return (guint64)g_get_monotonic_time() * 1000ull;
+}
+
+static inline gboolean parse_rtp_sequence(const GstMapInfo *map, guint16 *sequence_out) {
+    if (map == NULL || sequence_out == NULL || map->size < RTP_MIN_HEADER) {
+        return FALSE;
+    }
+
+    const guint8 *data = map->data;
+    guint8 version = data[0] >> 6;
+    if (version != 2) {
+        return FALSE;
+    }
+
+    *sequence_out = ((guint16)data[2] << 8) | (guint16)data[3];
+    return TRUE;
+}
+
+static inline gint16 seq_delta(guint16 a, guint16 b) {
+    return (gint16)(a - b);
+}
+
+static void queued_packet_free(RtpQueuedPacket *packet) {
+    if (packet == NULL) {
+        return;
+    }
+    if (packet->buffer != NULL) {
+        gst_buffer_unref(packet->buffer);
+    }
+    g_free(packet);
+}
+
+static void clear_queue(SstarRtpJitterBuffer *self) {
+    if (self == NULL || self->queued == NULL) {
+        return;
+    }
+
+    while (!g_queue_is_empty(self->queued)) {
+        RtpQueuedPacket *packet = g_queue_pop_head(self->queued);
+        queued_packet_free(packet);
+    }
+}
+
+static void reset_state(SstarRtpJitterBuffer *self) {
+    if (self == NULL) {
+        return;
+    }
+
+    clear_queue(self);
+    self->have_expected_seq = FALSE;
+    self->expected_seq = 0;
+    self->gap_active = FALSE;
+    self->gap_started_ns = 0;
+}
+
+static void queue_insert_sorted(SstarRtpJitterBuffer *self, RtpQueuedPacket *packet) {
+    if (self == NULL || self->queued == NULL || packet == NULL) {
+        return;
+    }
+
+    GList *iter = self->queued->head;
+    while (iter != NULL) {
+        RtpQueuedPacket *current = (RtpQueuedPacket *)iter->data;
+        if (current != NULL) {
+            gint16 delta = seq_delta(packet->sequence, current->sequence);
+            if (delta < 0) {
+                g_queue_insert_before(self->queued, iter, packet);
+                return;
+            }
+            if (delta == 0) {
+                queued_packet_free(packet);
+                return;
+            }
+        }
+        iter = iter->next;
+    }
+
+    g_queue_push_tail(self->queued, packet);
+}
+
+static RtpQueuedPacket *queue_find_by_sequence(SstarRtpJitterBuffer *self, guint16 sequence) {
+    if (self == NULL || self->queued == NULL) {
+        return NULL;
+    }
+
+    GList *iter = self->queued->head;
+    while (iter != NULL) {
+        RtpQueuedPacket *packet = (RtpQueuedPacket *)iter->data;
+        if (packet != NULL && packet->sequence == sequence) {
+            g_queue_delete_link(self->queued, iter);
+            return packet;
+        }
+        iter = iter->next;
+    }
+
+    return NULL;
+}
+
+static GstFlowReturn push_and_advance(SstarRtpJitterBuffer *self, GstBuffer *buffer) {
+    if (self == NULL || buffer == NULL) {
+        return GST_FLOW_ERROR;
+    }
+
+    GstFlowReturn ret = gst_pad_push(self->srcpad, buffer);
+    if (ret != GST_FLOW_OK) {
+        return ret;
+    }
+
+    self->expected_seq = (guint16)(self->expected_seq + 1u);
+    self->have_expected_seq = TRUE;
+    return GST_FLOW_OK;
+}
+
+static GstFlowReturn flush_ready_packets(SstarRtpJitterBuffer *self) {
+    if (self == NULL) {
+        return GST_FLOW_ERROR;
+    }
+
+    while (TRUE) {
+        RtpQueuedPacket *queued = queue_find_by_sequence(self, self->expected_seq);
+        if (queued == NULL) {
+            self->gap_active = !g_queue_is_empty(self->queued);
+            if (self->gap_active && self->gap_started_ns == 0) {
+                self->gap_started_ns = monotonic_ns();
+            }
+            break;
+        }
+
+        self->gap_active = FALSE;
+        self->gap_started_ns = 0;
+        GstFlowReturn ret = push_and_advance(self, queued->buffer);
+        queued->buffer = NULL;
+        queued_packet_free(queued);
+        if (ret != GST_FLOW_OK) {
+            return ret;
+        }
+    }
+
+    return GST_FLOW_OK;
+}
+
+static GstFlowReturn maybe_force_skip_gap(SstarRtpJitterBuffer *self, guint64 now_ns) {
+    if (self == NULL || !self->gap_active || self->latency_ms == 0 || g_queue_is_empty(self->queued)) {
+        return GST_FLOW_OK;
+    }
+
+    guint64 wait_ns = (guint64)self->latency_ms * 1000000ull;
+    if (self->gap_started_ns == 0 || now_ns < self->gap_started_ns || now_ns - self->gap_started_ns < wait_ns) {
+        return GST_FLOW_OK;
+    }
+
+    RtpQueuedPacket *first = (RtpQueuedPacket *)g_queue_peek_head(self->queued);
+    if (first == NULL) {
+        self->gap_active = FALSE;
+        self->gap_started_ns = 0;
+        return GST_FLOW_OK;
+    }
+
+    GST_DEBUG_OBJECT(self,
+                     "Skipping missing RTP sequence range (%u..%u) after %u ms wait",
+                     (guint)self->expected_seq,
+                     (guint)((guint16)(first->sequence - 1u)),
+                     self->latency_ms);
+
+    self->expected_seq = first->sequence;
+    self->gap_active = FALSE;
+    self->gap_started_ns = 0;
+    return flush_ready_packets(self);
+}
+
+static GstFlowReturn sstar_rtp_jitterbuffer_chain(GstPad *pad, GstObject *parent, GstBuffer *buffer) {
+    SstarRtpJitterBuffer *self = SSTAR_RTP_JITTERBUFFER(parent);
+    (void)pad;
+
+    if (buffer == NULL) {
+        return GST_FLOW_OK;
+    }
+
+    if (!self->enabled) {
+        return gst_pad_push(self->srcpad, buffer);
+    }
+
+    GstMapInfo map;
+    if (!gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+        gst_buffer_unref(buffer);
+        return GST_FLOW_ERROR;
+    }
+
+    guint16 sequence = 0;
+    gboolean have_sequence = parse_rtp_sequence(&map, &sequence);
+    gst_buffer_unmap(buffer, &map);
+
+    if (!have_sequence) {
+        return gst_pad_push(self->srcpad, buffer);
+    }
+
+    guint64 now_ns = monotonic_ns();
+
+    if (!self->have_expected_seq) {
+        self->have_expected_seq = TRUE;
+        self->expected_seq = sequence;
+        self->gap_active = FALSE;
+        self->gap_started_ns = 0;
+    }
+
+    gint16 delta = seq_delta(sequence, self->expected_seq);
+    if (delta < 0) {
+        GST_LOG_OBJECT(self, "Dropping late/duplicate RTP sequence %u expected=%u", (guint)sequence,
+                       (guint)self->expected_seq);
+        gst_buffer_unref(buffer);
+        return GST_FLOW_OK;
+    }
+
+    if (delta == 0) {
+        GstFlowReturn ret = push_and_advance(self, buffer);
+        if (ret != GST_FLOW_OK) {
+            return ret;
+        }
+        return flush_ready_packets(self);
+    }
+
+    guint max_misorder = self->max_misorder;
+    if ((guint)delta > max_misorder) {
+        GST_DEBUG_OBJECT(self,
+                         "Large RTP jump seq=%u expected=%u delta=%d exceeds max-misorder=%u; forcing resync",
+                         (guint)sequence,
+                         (guint)self->expected_seq,
+                         delta,
+                         max_misorder);
+        self->expected_seq = sequence;
+        self->gap_active = FALSE;
+        self->gap_started_ns = 0;
+
+        GstFlowReturn ret = push_and_advance(self, buffer);
+        if (ret != GST_FLOW_OK) {
+            return ret;
+        }
+        return flush_ready_packets(self);
+    }
+
+    RtpQueuedPacket *queued = g_new0(RtpQueuedPacket, 1);
+    if (queued == NULL) {
+        return gst_pad_push(self->srcpad, buffer);
+    }
+
+    queued->sequence = sequence;
+    queued->buffer = buffer;
+    queue_insert_sorted(self, queued);
+
+    if (!self->gap_active) {
+        self->gap_active = TRUE;
+        self->gap_started_ns = now_ns;
+    }
+
+    return maybe_force_skip_gap(self, now_ns);
+}
+
+static gboolean sstar_rtp_jitterbuffer_sink_event(GstPad *pad, GstObject *parent, GstEvent *event) {
+    SstarRtpJitterBuffer *self = SSTAR_RTP_JITTERBUFFER(parent);
+    (void)pad;
+
+    switch (GST_EVENT_TYPE(event)) {
+    case GST_EVENT_FLUSH_STOP:
+        reset_state(self);
+        break;
+    case GST_EVENT_EOS: {
+        GstFlowReturn ret = flush_ready_packets(self);
+        if (ret != GST_FLOW_OK) {
+            GST_WARNING_OBJECT(self, "Failed to flush queued RTP packets on EOS: %s", gst_flow_get_name(ret));
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    return gst_pad_push_event(self->srcpad, event);
+}
+
+static void sstar_rtp_jitterbuffer_set_property(GObject *object, guint prop_id, const GValue *value,
+                                                GParamSpec *pspec) {
+    SstarRtpJitterBuffer *self = SSTAR_RTP_JITTERBUFFER(object);
+
+    switch (prop_id) {
+    case PROP_ENABLED:
+        self->enabled = g_value_get_boolean(value);
+        if (!self->enabled) {
+            reset_state(self);
+        }
+        break;
+    case PROP_LATENCY_MS:
+        self->latency_ms = g_value_get_uint(value);
+        break;
+    case PROP_MAX_MISORDER:
+        self->max_misorder = g_value_get_uint(value);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        break;
+    }
+}
+
+static void sstar_rtp_jitterbuffer_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec) {
+    SstarRtpJitterBuffer *self = SSTAR_RTP_JITTERBUFFER(object);
+
+    switch (prop_id) {
+    case PROP_ENABLED:
+        g_value_set_boolean(value, self->enabled);
+        break;
+    case PROP_LATENCY_MS:
+        g_value_set_uint(value, self->latency_ms);
+        break;
+    case PROP_MAX_MISORDER:
+        g_value_set_uint(value, self->max_misorder);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        break;
+    }
+}
+
+static void sstar_rtp_jitterbuffer_finalize(GObject *object) {
+    SstarRtpJitterBuffer *self = SSTAR_RTP_JITTERBUFFER(object);
+
+    reset_state(self);
+    if (self->queued != NULL) {
+        g_queue_free(self->queued);
+        self->queued = NULL;
+    }
+
+    G_OBJECT_CLASS(sstar_rtp_jitterbuffer_parent_class)->finalize(object);
+}
+
+static GstStaticPadTemplate sink_template =
+    GST_STATIC_PAD_TEMPLATE("sink",
+                            GST_PAD_SINK,
+                            GST_PAD_ALWAYS,
+                            GST_STATIC_CAPS("application/x-rtp"));
+
+static GstStaticPadTemplate src_template =
+    GST_STATIC_PAD_TEMPLATE("src",
+                            GST_PAD_SRC,
+                            GST_PAD_ALWAYS,
+                            GST_STATIC_CAPS("application/x-rtp"));
+
+static void sstar_rtp_jitterbuffer_class_init(SstarRtpJitterBufferClass *klass) {
+    GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+    GstElementClass *element_class = GST_ELEMENT_CLASS(klass);
+
+    gobject_class->set_property = sstar_rtp_jitterbuffer_set_property;
+    gobject_class->get_property = sstar_rtp_jitterbuffer_get_property;
+    gobject_class->finalize = sstar_rtp_jitterbuffer_finalize;
+
+    g_object_class_install_property(gobject_class,
+                                    PROP_ENABLED,
+                                    g_param_spec_boolean("enabled",
+                                                         "Enabled",
+                                                         "Enable RTP sequence reordering buffer",
+                                                         FALSE,
+                                                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+    g_object_class_install_property(gobject_class,
+                                    PROP_LATENCY_MS,
+                                    g_param_spec_uint("latency-ms",
+                                                      "Latency (ms)",
+                                                      "Maximum wait for missing RTP packets before skipping gap",
+                                                      0,
+                                                      2000,
+                                                      8,
+                                                      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+    g_object_class_install_property(gobject_class,
+                                    PROP_MAX_MISORDER,
+                                    g_param_spec_uint("max-misorder",
+                                                      "Max Misorder",
+                                                      "Maximum sequence-distance to hold for reorder",
+                                                      0,
+                                                      4096,
+                                                      64,
+                                                      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+    gst_element_class_set_static_metadata(element_class,
+                                          "SStar RTP jitterbuffer",
+                                          "Network/RTP",
+                                          "Lightweight RTP sequence reorder buffer",
+                                          "PixelPilot Project");
+
+    gst_element_class_add_static_pad_template(element_class, &sink_template);
+    gst_element_class_add_static_pad_template(element_class, &src_template);
+}
+
+static void sstar_rtp_jitterbuffer_init(SstarRtpJitterBuffer *self) {
+    self->sinkpad = gst_pad_new_from_static_template(&sink_template, "sink");
+    gst_pad_set_chain_function(self->sinkpad, GST_DEBUG_FUNCPTR(sstar_rtp_jitterbuffer_chain));
+    gst_pad_set_event_function(self->sinkpad, GST_DEBUG_FUNCPTR(sstar_rtp_jitterbuffer_sink_event));
+    gst_element_add_pad(GST_ELEMENT(self), self->sinkpad);
+
+    self->srcpad = gst_pad_new_from_static_template(&src_template, "src");
+    gst_pad_use_fixed_caps(self->srcpad);
+    gst_element_add_pad(GST_ELEMENT(self), self->srcpad);
+
+    self->enabled = FALSE;
+    self->latency_ms = 8;
+    self->max_misorder = 64;
+    self->have_expected_seq = FALSE;
+    self->expected_seq = 0;
+    self->gap_active = FALSE;
+    self->gap_started_ns = 0;
+    self->queued = g_queue_new();
+}
+
+gboolean sstar_rtp_jitterbuffer_register(void) {
+    static gsize once_init = 0;
+    static gboolean registered = FALSE;
+
+    if (g_once_init_enter(&once_init)) {
+        GST_DEBUG_CATEGORY_INIT(sstar_rtp_jitterbuffer_debug, "sstarrtpjitterbuffer", 0,
+                                "SStar RTP jitterbuffer");
+        registered = gst_element_register(NULL, "sstarrtpjitterbuffer", GST_RANK_PRIMARY + 10,
+                                          SSTAR_TYPE_RTP_JITTERBUFFER);
+        g_once_init_leave(&once_init, 1);
+    }
+
+    return registered;
+}

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -503,7 +503,6 @@ static void finalize_frame(struct UdpReceiver *ur, guint64 arrival_ns) {
     }
     if (ur->frame_missing) {
         ur->stats.incomplete_frames++;
-        maybe_trigger_idr_loss(ur, arrival_ns);
     }
     maybe_trigger_idr_jitter(ur, arrival_ns);
     ur->frame_active = FALSE;
@@ -596,6 +595,9 @@ static void process_rtp(struct UdpReceiver *ur,
         } else if (delta > 0) {
             ur->stats.lost_packets += delta;
             ur->expected_seq = seq_next(parsed->sequence);
+            if (!ur->frame_missing) {
+                maybe_trigger_idr_loss(ur, arrival_ns);
+            }
             ur->frame_missing = TRUE;
             sample.flags |= UDP_SAMPLE_FLAG_LOSS;
         } else { // delta < 0

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -418,6 +418,7 @@ struct VideoDecoder {
     GThread *display_thread;
 
     IdrRequester *idr_requester;
+    gboolean drop_error_frames;
 
     VideoCtm ctm;
     uint32_t frame_fourcc;
@@ -1315,16 +1316,22 @@ static gpointer frame_thread_func(gpointer data) {
             RK_U32 errinfo = mpp_frame_get_errinfo(frame);
             RK_U32 discard = mpp_frame_get_discard(frame);
             if (G_UNLIKELY(errinfo || discard)) {
-                LOGW("MPP: dropping frame errinfo=%u discard=%u", errinfo, discard);
+                if (vd->drop_error_frames) {
+                    LOGW("MPP: dropping frame errinfo=%u discard=%u", errinfo, discard);
+                } else {
+                    LOGW("MPP: keeping frame despite errinfo=%u discard=%u for continuity", errinfo, discard);
+                }
                 if (vd->idr_requester != NULL) {
                     idr_requester_handle_warning(vd->idr_requester);
                 }
-                vd->eos_received = mpp_frame_get_eos(frame) ? TRUE : FALSE;
-                mpp_frame_deinit(&frame);
-                if (vd->eos_received) {
-                    break;
+                if (vd->drop_error_frames) {
+                    vd->eos_received = mpp_frame_get_eos(frame) ? TRUE : FALSE;
+                    mpp_frame_deinit(&frame);
+                    if (vd->eos_received) {
+                        break;
+                    }
+                    continue;
                 }
-                continue;
             }
 
             MppBuffer buffer = mpp_frame_get_buffer(frame);
@@ -1461,6 +1468,7 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     vd->frame_ver_stride = 0;
     vd->packet_buf_size = 0;
     vd->packet_buf = NULL;
+    vd->drop_error_frames = cfg->decoder_drop_error_frames ? TRUE : FALSE;
 
     uint32_t chosen_plane = 0;
     if (!video_decoder_select_plane(drm_fd, vd->crtc_id, (uint32_t)cfg->plane_id, &chosen_plane)) {

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -103,6 +103,7 @@ class Injector:
         self.current_timestamp: Optional[int] = None
         self.frame_counter = 0
         self.drop_current_frame = False
+        self.current_frame_had_loss = False
         self.current_frame_burst_delay_ms = 0
         self.current_frame_burst_jitter_ms = 0
         self.burst_delay_frames_left = 0
@@ -166,9 +167,13 @@ class Injector:
         if timestamp is None:
             return
         if self.current_timestamp is None or timestamp != self.current_timestamp:
+            if self.current_timestamp is not None and self.current_frame_had_loss:
+                self.stats.frames_dropped += 1
+
             self.current_timestamp = timestamp
             self.stats.frames_seen += 1
             self.frame_counter += 1
+            self.current_frame_had_loss = False
 
             self.current_frame_burst_delay_ms = 0
             self.current_frame_burst_jitter_ms = 0
@@ -220,6 +225,7 @@ class Injector:
             n = max(1, self.params.drop_every_n_packets)
             if self.packet_counter % n == 0:
                 self.stats.packets_dropped += 1
+                self.current_frame_had_loss = True
                 return
             self._send_now(packet)
             return
@@ -228,6 +234,7 @@ class Injector:
             prob = max(0.0, min(100.0, self.params.random_drop_percent)) / 100.0
             if random.random() < prob:
                 self.stats.packets_dropped += 1
+                self.current_frame_had_loss = True
                 return
             self._send_now(packet)
             return
@@ -248,6 +255,7 @@ class Injector:
             idx = self.packet_counter % period
             if idx < length:
                 self.stats.packets_dropped += 1
+                self.current_frame_had_loss = True
                 return
             self._send_now(packet)
             return
@@ -263,6 +271,7 @@ class Injector:
         if self.mode == FaultMode.DROP_EVERY_N_FRAMES:
             if self.drop_current_frame:
                 self.stats.packets_dropped += 1
+                self.current_frame_had_loss = True
                 return
             self._send_now(packet)
             return
@@ -327,7 +336,7 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
     safe_add(row + 15, 2, f"whole_frame_delay_ms={p.whole_frame_delay_ms}")
 
     safe_add(row + 17, 0, f"Active mode tuning with +/-: {active_parameter_summary(injector)}")
-    safe_add(row + 18, 0, "Keys: q quit | r reset stats | +/- adjust active mode severity")
+    safe_add(row + 18, 0, "Keys: q quit | r reset stats | +/- primary severity | {/} secondary knob")
     safe_add(row + 19, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
 
     if max_y < 36:
@@ -350,11 +359,11 @@ def active_parameter_summary(injector: Injector) -> str:
     if mode == FaultMode.PACKET_JITTER:
         return f"jitter_delta_ms={p.jitter_delta_ms}"
     if mode == FaultMode.BURST_PACKET_LOSS:
-        return f"burst_length_packets={p.burst_length_packets}"
+        return f"burst_length_packets={p.burst_length_packets} (secondary: period={p.burst_period_packets})"
     if mode == FaultMode.BURST_PACKET_DELAY:
-        return f"burst_delay_ms={p.burst_delay_ms}"
+        return f"burst_delay_ms={p.burst_delay_ms} (secondary: period={p.burst_delay_period_frames}, length={p.burst_delay_length_frames})"
     if mode == FaultMode.BURST_PACKET_JITTER:
-        return f"burst_jitter_max_ms={p.burst_jitter_max_ms}"
+        return f"burst_jitter_max_ms={p.burst_jitter_max_ms} (secondary: period={p.burst_jitter_period_frames}, length={p.burst_jitter_length_frames})"
     if mode == FaultMode.DROP_EVERY_N_FRAMES:
         return f"drop_every_n_frames={p.drop_every_n_frames}"
     if mode == FaultMode.DELAY_WHOLE_FRAMES:
@@ -388,6 +397,20 @@ def adjust_active_mode(injector: Injector, increase: bool) -> None:
         p.whole_frame_delay_ms = max(0, p.whole_frame_delay_ms + 5 * direction)
 
 
+def adjust_secondary_mode(injector: Injector, increase: bool) -> None:
+    p = injector.params
+    direction = 1 if increase else -1
+    mode = injector.mode
+
+    if mode == FaultMode.BURST_PACKET_LOSS:
+        p.burst_period_packets = max(1, p.burst_period_packets + 10 * direction)
+        p.burst_length_packets = min(p.burst_period_packets, p.burst_length_packets)
+    elif mode == FaultMode.BURST_PACKET_DELAY:
+        p.burst_delay_period_frames = max(1, p.burst_delay_period_frames + 5 * direction)
+    elif mode == FaultMode.BURST_PACKET_JITTER:
+        p.burst_jitter_period_frames = max(1, p.burst_jitter_period_frames + 5 * direction)
+
+
 def handle_key(key: int, injector: Injector) -> bool:
     if key in (ord("q"), ord("Q")):
         return False
@@ -407,6 +430,10 @@ def handle_key(key: int, injector: Injector) -> bool:
         adjust_active_mode(injector, increase=False)
     elif key in (ord("+"), ord("=")):
         adjust_active_mode(injector, increase=True)
+    elif key in (ord("_"), ord("{")):
+        adjust_secondary_mode(injector, increase=False)
+    elif key in (ord("}"),):
+        adjust_secondary_mode(injector, increase=True)
 
     return True
 

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Interactive RTP/UDP fault injector for manual stream recovery testing.
+
+Default behavior:
+- listen on UDP :5601
+- forward to 127.0.0.1:5600
+
+Use the ncurses-style menu to switch fault modes while watching output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import curses
+import heapq
+import random
+import socket
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional, Tuple
+
+
+class FaultMode(str, Enum):
+    PASSTHROUGH = "passthrough"
+    DROP_EVERY_N_PACKETS = "drop_every_n_packets"
+    DROP_RANDOM_PACKETS = "drop_random_packets"
+    FIXED_PACKET_DELAY = "fixed_packet_delay"
+    PACKET_JITTER = "packet_jitter"
+    BURST_PACKET_LOSS = "burst_packet_loss"
+    DROP_EVERY_N_FRAMES = "drop_every_n_frames"
+    DELAY_WHOLE_FRAMES = "delay_whole_frames"
+
+
+MODE_LIST: List[FaultMode] = [
+    FaultMode.PASSTHROUGH,
+    FaultMode.DROP_EVERY_N_PACKETS,
+    FaultMode.DROP_RANDOM_PACKETS,
+    FaultMode.FIXED_PACKET_DELAY,
+    FaultMode.PACKET_JITTER,
+    FaultMode.BURST_PACKET_LOSS,
+    FaultMode.DROP_EVERY_N_FRAMES,
+    FaultMode.DELAY_WHOLE_FRAMES,
+]
+
+
+@dataclass(order=True)
+class ScheduledPacket:
+    send_at: float
+    serial: int
+    payload: bytes = field(compare=False)
+
+
+@dataclass
+class Stats:
+    packets_in: int = 0
+    packets_out: int = 0
+    packets_dropped: int = 0
+    frames_seen: int = 0
+    frames_dropped: int = 0
+
+
+@dataclass
+class Config:
+    in_port: int
+    out_host: str
+    out_port: int
+
+
+@dataclass
+class Parameters:
+    drop_every_n_packets: int = 30
+    random_drop_percent: float = 3.0
+    fixed_delay_ms: int = 30
+    jitter_base_delay_ms: int = 10
+    jitter_delta_ms: int = 20
+    burst_period_packets: int = 250
+    burst_length_packets: int = 30
+    drop_every_n_frames: int = 30
+    whole_frame_delay_ms: int = 40
+
+
+class Injector:
+    def __init__(self, cfg: Config, params: Parameters) -> None:
+        self.cfg = cfg
+        self.params = params
+        self.mode_index = 0
+        self.mode = MODE_LIST[self.mode_index]
+
+        self.stats = Stats()
+        self.packet_counter = 0
+        self.current_timestamp: Optional[int] = None
+        self.drop_current_frame = False
+
+        self.queue: List[ScheduledPacket] = []
+        self._serial = 0
+
+        self.sock_in = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock_in.bind(("0.0.0.0", cfg.in_port))
+        self.sock_in.setblocking(False)
+
+        self.sock_out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.out_addr = (cfg.out_host, cfg.out_port)
+
+    def close(self) -> None:
+        self.sock_in.close()
+        self.sock_out.close()
+
+    def set_mode(self, idx: int) -> None:
+        self.mode_index = max(0, min(len(MODE_LIST) - 1, idx))
+        self.mode = MODE_LIST[self.mode_index]
+
+    @staticmethod
+    def _parse_rtp(packet: bytes) -> Tuple[bool, Optional[int], bool]:
+        if len(packet) < 12:
+            return False, None, False
+        b0 = packet[0]
+        version = b0 >> 6
+        if version != 2:
+            return False, None, False
+        csrc_count = b0 & 0x0F
+        b1 = packet[1]
+        marker = (b1 & 0x80) != 0
+        timestamp = int.from_bytes(packet[4:8], "big")
+
+        offset = 12 + csrc_count * 4
+        if len(packet) < offset:
+            return False, None, marker
+        extension = (b0 & 0x10) != 0
+        if extension:
+            if len(packet) < offset + 4:
+                return False, None, marker
+            ext_words = int.from_bytes(packet[offset + 2 : offset + 4], "big")
+            offset += 4 + ext_words * 4
+            if len(packet) < offset:
+                return False, None, marker
+
+        return True, timestamp, marker
+
+    def _schedule(self, payload: bytes, delay_ms: int = 0) -> None:
+        send_at = time.monotonic() + max(0, delay_ms) / 1000.0
+        self._serial += 1
+        heapq.heappush(self.queue, ScheduledPacket(send_at=send_at, serial=self._serial, payload=payload))
+
+    def _handle_frame_boundary(self, timestamp: Optional[int]) -> None:
+        if timestamp is None:
+            return
+        if self.current_timestamp is None or timestamp != self.current_timestamp:
+            self.current_timestamp = timestamp
+            self.stats.frames_seen += 1
+            if self.mode == FaultMode.DROP_EVERY_N_FRAMES:
+                n = max(1, self.params.drop_every_n_frames)
+                self.drop_current_frame = (self.stats.frames_seen % n) == 0
+                if self.drop_current_frame:
+                    self.stats.frames_dropped += 1
+            else:
+                self.drop_current_frame = False
+
+    def process_packet(self, packet: bytes) -> None:
+        self.stats.packets_in += 1
+        self.packet_counter += 1
+
+        is_rtp, timestamp, _marker = self._parse_rtp(packet)
+        self._handle_frame_boundary(timestamp if is_rtp else None)
+
+        if self.mode == FaultMode.PASSTHROUGH:
+            self._schedule(packet, 0)
+            return
+
+        if self.mode == FaultMode.DROP_EVERY_N_PACKETS:
+            n = max(1, self.params.drop_every_n_packets)
+            if self.packet_counter % n == 0:
+                self.stats.packets_dropped += 1
+                return
+            self._schedule(packet, 0)
+            return
+
+        if self.mode == FaultMode.DROP_RANDOM_PACKETS:
+            prob = max(0.0, min(100.0, self.params.random_drop_percent)) / 100.0
+            if random.random() < prob:
+                self.stats.packets_dropped += 1
+                return
+            self._schedule(packet, 0)
+            return
+
+        if self.mode == FaultMode.FIXED_PACKET_DELAY:
+            self._schedule(packet, self.params.fixed_delay_ms)
+            return
+
+        if self.mode == FaultMode.PACKET_JITTER:
+            base = self.params.jitter_base_delay_ms
+            delta = self.params.jitter_delta_ms
+            self._schedule(packet, base + random.randint(-delta, delta))
+            return
+
+        if self.mode == FaultMode.BURST_PACKET_LOSS:
+            period = max(1, self.params.burst_period_packets)
+            length = max(0, min(period, self.params.burst_length_packets))
+            idx = self.packet_counter % period
+            if idx < length:
+                self.stats.packets_dropped += 1
+                return
+            self._schedule(packet, 0)
+            return
+
+        if self.mode == FaultMode.DROP_EVERY_N_FRAMES:
+            if self.drop_current_frame:
+                self.stats.packets_dropped += 1
+                return
+            self._schedule(packet, 0)
+            return
+
+        if self.mode == FaultMode.DELAY_WHOLE_FRAMES:
+            self._schedule(packet, self.params.whole_frame_delay_ms)
+            return
+
+        self._schedule(packet, 0)
+
+    def flush_due(self) -> None:
+        now = time.monotonic()
+        while self.queue and self.queue[0].send_at <= now:
+            item = heapq.heappop(self.queue)
+            self.sock_out.sendto(item.payload, self.out_addr)
+            self.stats.packets_out += 1
+
+
+def draw_ui(stdscr: curses.window, injector: Injector) -> None:
+    stdscr.erase()
+    stdscr.addstr(0, 0, "RTP Fault Injector (manual visual test)", curses.A_BOLD)
+    stdscr.addstr(1, 0, f"In: 0.0.0.0:{injector.cfg.in_port}  ->  Out: {injector.cfg.out_host}:{injector.cfg.out_port}")
+
+    stdscr.addstr(3, 0, "Modes (use Up/Down or number keys 1-8):")
+    for idx, mode in enumerate(MODE_LIST):
+        prefix = ">" if idx == injector.mode_index else " "
+        attr = curses.A_REVERSE if idx == injector.mode_index else curses.A_NORMAL
+        stdscr.addstr(4 + idx, 0, f"{prefix} {idx + 1}. {mode.value}", attr)
+
+    row = 14
+    stdscr.addstr(row, 0, "Stats:")
+    stdscr.addstr(row + 1, 2, f"packets in/out: {injector.stats.packets_in} / {injector.stats.packets_out}")
+    stdscr.addstr(row + 2, 2, f"packets dropped: {injector.stats.packets_dropped}")
+    stdscr.addstr(row + 3, 2, f"frames seen/dropped: {injector.stats.frames_seen} / {injector.stats.frames_dropped}")
+    stdscr.addstr(row + 4, 2, f"queue depth: {len(injector.queue)}")
+
+    p = injector.params
+    stdscr.addstr(row + 6, 0, "Current parameters:")
+    stdscr.addstr(row + 7, 2, f"drop_every_n_packets={p.drop_every_n_packets}")
+    stdscr.addstr(row + 8, 2, f"random_drop_percent={p.random_drop_percent:.1f}")
+    stdscr.addstr(row + 9, 2, f"fixed_delay_ms={p.fixed_delay_ms}")
+    stdscr.addstr(row + 10, 2, f"jitter_base_delay_ms={p.jitter_base_delay_ms}, jitter_delta_ms={p.jitter_delta_ms}")
+    stdscr.addstr(row + 11, 2, f"burst_period_packets={p.burst_period_packets}, burst_length_packets={p.burst_length_packets}")
+    stdscr.addstr(row + 12, 2, f"drop_every_n_frames={p.drop_every_n_frames}")
+    stdscr.addstr(row + 13, 2, f"whole_frame_delay_ms={p.whole_frame_delay_ms}")
+
+    stdscr.addstr(row + 15, 0, "Keys: q quit | r reset stats | [ ] random-drop +/-0.5 | -/= delay -/+5ms")
+    stdscr.addstr(row + 16, 0, "      ,/. frame-drop N -/+1 | ;/' drop-every-N-packets -/+1")
+
+    stdscr.refresh()
+
+
+def handle_key(key: int, injector: Injector) -> bool:
+    if key in (ord("q"), ord("Q")):
+        return False
+
+    if key == curses.KEY_UP:
+        injector.set_mode(injector.mode_index - 1)
+    elif key == curses.KEY_DOWN:
+        injector.set_mode(injector.mode_index + 1)
+    elif ord("1") <= key <= ord("8"):
+        injector.set_mode(key - ord("1"))
+    elif key in (ord("r"), ord("R")):
+        injector.stats = Stats()
+        injector.packet_counter = 0
+    elif key == ord("["):
+        injector.params.random_drop_percent = max(0.0, injector.params.random_drop_percent - 0.5)
+    elif key == ord("]"):
+        injector.params.random_drop_percent = min(100.0, injector.params.random_drop_percent + 0.5)
+    elif key == ord("-"):
+        injector.params.fixed_delay_ms = max(0, injector.params.fixed_delay_ms - 5)
+    elif key == ord("="):
+        injector.params.fixed_delay_ms += 5
+    elif key == ord(","):
+        injector.params.drop_every_n_frames = max(1, injector.params.drop_every_n_frames - 1)
+    elif key == ord("."):
+        injector.params.drop_every_n_frames += 1
+    elif key == ord(";"):
+        injector.params.drop_every_n_packets = max(1, injector.params.drop_every_n_packets - 1)
+    elif key == ord("'"):
+        injector.params.drop_every_n_packets += 1
+
+    return True
+
+
+def run_menu(stdscr: curses.window, injector: Injector) -> None:
+    curses.curs_set(0)
+    stdscr.nodelay(True)
+    stdscr.timeout(50)
+
+    keep_running = True
+    while keep_running:
+        while True:
+            try:
+                packet, _addr = injector.sock_in.recvfrom(65535)
+            except BlockingIOError:
+                break
+            injector.process_packet(packet)
+
+        injector.flush_due()
+        draw_ui(stdscr, injector)
+
+        key = stdscr.getch()
+        if key != -1:
+            keep_running = handle_key(key, injector)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Interactive RTP fault injector for manual stream testing")
+    parser.add_argument("--in-port", type=int, default=5601, help="UDP input port (default: 5601)")
+    parser.add_argument("--out-host", default="127.0.0.1", help="UDP output host (default: 127.0.0.1)")
+    parser.add_argument("--out-port", type=int, default=5600, help="UDP output port (default: 5600)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cfg = Config(in_port=args.in_port, out_host=args.out_host, out_port=args.out_port)
+    params = Parameters()
+    injector = Injector(cfg, params)
+    try:
+        curses.wrapper(run_menu, injector)
+        return 0
+    finally:
+        injector.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -225,35 +225,53 @@ class Injector:
 
 
 def draw_ui(stdscr: curses.window, injector: Injector) -> None:
-    stdscr.erase()
-    stdscr.addstr(0, 0, "RTP Fault Injector (manual visual test)", curses.A_BOLD)
-    stdscr.addstr(1, 0, f"In: 0.0.0.0:{injector.cfg.in_port}  ->  Out: {injector.cfg.out_host}:{injector.cfg.out_port}")
+    max_y, max_x = stdscr.getmaxyx()
 
-    stdscr.addstr(3, 0, "Modes (use Up/Down or number keys 1-8):")
+    def safe_add(row: int, col: int, text: str, attr: int = curses.A_NORMAL) -> None:
+        if row < 0 or row >= max_y or col >= max_x:
+            return
+        available = max_x - col
+        if available <= 0:
+            return
+        clipped = text[: max(0, available - 1)]
+        try:
+            stdscr.addstr(row, col, clipped, attr)
+        except curses.error:
+            # Terminals can still reject writes at lower-right corner.
+            pass
+
+    stdscr.erase()
+    safe_add(0, 0, "RTP Fault Injector (manual visual test)", curses.A_BOLD)
+    safe_add(1, 0, f"In: 0.0.0.0:{injector.cfg.in_port}  ->  Out: {injector.cfg.out_host}:{injector.cfg.out_port}")
+
+    safe_add(3, 0, "Modes (use Up/Down or number keys 1-8):")
     for idx, mode in enumerate(MODE_LIST):
         prefix = ">" if idx == injector.mode_index else " "
         attr = curses.A_REVERSE if idx == injector.mode_index else curses.A_NORMAL
-        stdscr.addstr(4 + idx, 0, f"{prefix} {idx + 1}. {mode.value}", attr)
+        safe_add(4 + idx, 0, f"{prefix} {idx + 1}. {mode.value}", attr)
 
     row = 14
-    stdscr.addstr(row, 0, "Stats:")
-    stdscr.addstr(row + 1, 2, f"packets in/out: {injector.stats.packets_in} / {injector.stats.packets_out}")
-    stdscr.addstr(row + 2, 2, f"packets dropped: {injector.stats.packets_dropped}")
-    stdscr.addstr(row + 3, 2, f"frames seen/dropped: {injector.stats.frames_seen} / {injector.stats.frames_dropped}")
-    stdscr.addstr(row + 4, 2, f"queue depth: {len(injector.queue)}")
+    safe_add(row, 0, "Stats:")
+    safe_add(row + 1, 2, f"packets in/out: {injector.stats.packets_in} / {injector.stats.packets_out}")
+    safe_add(row + 2, 2, f"packets dropped: {injector.stats.packets_dropped}")
+    safe_add(row + 3, 2, f"frames seen/dropped: {injector.stats.frames_seen} / {injector.stats.frames_dropped}")
+    safe_add(row + 4, 2, f"queue depth: {len(injector.queue)}")
 
     p = injector.params
-    stdscr.addstr(row + 6, 0, "Current parameters:")
-    stdscr.addstr(row + 7, 2, f"drop_every_n_packets={p.drop_every_n_packets}")
-    stdscr.addstr(row + 8, 2, f"random_drop_percent={p.random_drop_percent:.1f}")
-    stdscr.addstr(row + 9, 2, f"fixed_delay_ms={p.fixed_delay_ms}")
-    stdscr.addstr(row + 10, 2, f"jitter_base_delay_ms={p.jitter_base_delay_ms}, jitter_delta_ms={p.jitter_delta_ms}")
-    stdscr.addstr(row + 11, 2, f"burst_period_packets={p.burst_period_packets}, burst_length_packets={p.burst_length_packets}")
-    stdscr.addstr(row + 12, 2, f"drop_every_n_frames={p.drop_every_n_frames}")
-    stdscr.addstr(row + 13, 2, f"whole_frame_delay_ms={p.whole_frame_delay_ms}")
+    safe_add(row + 6, 0, "Current parameters:")
+    safe_add(row + 7, 2, f"drop_every_n_packets={p.drop_every_n_packets}")
+    safe_add(row + 8, 2, f"random_drop_percent={p.random_drop_percent:.1f}")
+    safe_add(row + 9, 2, f"fixed_delay_ms={p.fixed_delay_ms}")
+    safe_add(row + 10, 2, f"jitter_base_delay_ms={p.jitter_base_delay_ms}, jitter_delta_ms={p.jitter_delta_ms}")
+    safe_add(row + 11, 2, f"burst_period_packets={p.burst_period_packets}, burst_length_packets={p.burst_length_packets}")
+    safe_add(row + 12, 2, f"drop_every_n_frames={p.drop_every_n_frames}")
+    safe_add(row + 13, 2, f"whole_frame_delay_ms={p.whole_frame_delay_ms}")
 
-    stdscr.addstr(row + 15, 0, "Keys: q quit | r reset stats | [ ] random-drop +/-0.5 | -/= delay -/+5ms")
-    stdscr.addstr(row + 16, 0, "      ,/. frame-drop N -/+1 | ;/' drop-every-N-packets -/+1")
+    safe_add(row + 15, 0, "Keys: q quit | r reset stats | [ ] random-drop +/-0.5 | -/= delay -/+5ms")
+    safe_add(row + 16, 0, "      ,/. frame-drop N -/+1 | ;/' drop-every-N-packets -/+1")
+
+    if max_y < 32:
+        safe_add(max_y - 1, 0, "[Terminal is small: UI truncated, injector still active]", curses.A_DIM)
 
     stdscr.refresh()
 

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -102,6 +102,10 @@ class Injector:
         self.sock_out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.out_addr = (cfg.out_host, cfg.out_port)
 
+    def _send_now(self, payload: bytes) -> None:
+        self.sock_out.sendto(payload, self.out_addr)
+        self.stats.packets_out += 1
+
     def close(self) -> None:
         self.sock_in.close()
         self.sock_out.close()
@@ -164,7 +168,7 @@ class Injector:
         self._handle_frame_boundary(timestamp if is_rtp else None)
 
         if self.mode == FaultMode.PASSTHROUGH:
-            self._schedule(packet, 0)
+            self._send_now(packet)
             return
 
         if self.mode == FaultMode.DROP_EVERY_N_PACKETS:
@@ -172,7 +176,7 @@ class Injector:
             if self.packet_counter % n == 0:
                 self.stats.packets_dropped += 1
                 return
-            self._schedule(packet, 0)
+            self._send_now(packet)
             return
 
         if self.mode == FaultMode.DROP_RANDOM_PACKETS:
@@ -180,7 +184,7 @@ class Injector:
             if random.random() < prob:
                 self.stats.packets_dropped += 1
                 return
-            self._schedule(packet, 0)
+            self._send_now(packet)
             return
 
         if self.mode == FaultMode.FIXED_PACKET_DELAY:
@@ -200,21 +204,21 @@ class Injector:
             if idx < length:
                 self.stats.packets_dropped += 1
                 return
-            self._schedule(packet, 0)
+            self._send_now(packet)
             return
 
         if self.mode == FaultMode.DROP_EVERY_N_FRAMES:
             if self.drop_current_frame:
                 self.stats.packets_dropped += 1
                 return
-            self._schedule(packet, 0)
+            self._send_now(packet)
             return
 
         if self.mode == FaultMode.DELAY_WHOLE_FRAMES:
             self._schedule(packet, self.params.whole_frame_delay_ms)
             return
 
-        self._schedule(packet, 0)
+        self._send_now(packet)
 
     def flush_due(self) -> None:
         now = time.monotonic()
@@ -255,7 +259,7 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
     safe_add(row + 1, 2, f"packets in/out: {injector.stats.packets_in} / {injector.stats.packets_out}")
     safe_add(row + 2, 2, f"packets dropped: {injector.stats.packets_dropped}")
     safe_add(row + 3, 2, f"frames seen/dropped: {injector.stats.frames_seen} / {injector.stats.frames_dropped}")
-    safe_add(row + 4, 2, f"queue depth: {len(injector.queue)}")
+    safe_add(row + 4, 2, f"queue depth: {len(injector.queue)} (expected >0 in delay/jitter modes)")
 
     p = injector.params
     safe_add(row + 6, 0, "Current parameters:")
@@ -269,6 +273,7 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
 
     safe_add(row + 15, 0, "Keys: q quit | r reset stats | [ ] random-drop +/-0.5 | -/= delay -/+5ms")
     safe_add(row + 16, 0, "      ,/. frame-drop N -/+1 | ;/' drop-every-N-packets -/+1")
+    safe_add(row + 17, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
 
     if max_y < 32:
         safe_add(max_y - 1, 0, "[Terminal is small: UI truncated, injector still active]", curses.A_DIM)
@@ -312,7 +317,7 @@ def handle_key(key: int, injector: Injector) -> bool:
 def run_menu(stdscr: curses.window, injector: Injector) -> None:
     curses.curs_set(0)
     stdscr.nodelay(True)
-    stdscr.timeout(50)
+    stdscr.timeout(5)
 
     keep_running = True
     while keep_running:

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -28,6 +28,8 @@ class FaultMode(str, Enum):
     FIXED_PACKET_DELAY = "fixed_packet_delay"
     PACKET_JITTER = "packet_jitter"
     BURST_PACKET_LOSS = "burst_packet_loss"
+    BURST_PACKET_DELAY = "burst_packet_delay"
+    BURST_PACKET_JITTER = "burst_packet_jitter"
     DROP_EVERY_N_FRAMES = "drop_every_n_frames"
     DELAY_WHOLE_FRAMES = "delay_whole_frames"
 
@@ -39,6 +41,8 @@ MODE_LIST: List[FaultMode] = [
     FaultMode.FIXED_PACKET_DELAY,
     FaultMode.PACKET_JITTER,
     FaultMode.BURST_PACKET_LOSS,
+    FaultMode.BURST_PACKET_DELAY,
+    FaultMode.BURST_PACKET_JITTER,
     FaultMode.DROP_EVERY_N_FRAMES,
     FaultMode.DELAY_WHOLE_FRAMES,
 ]
@@ -76,6 +80,13 @@ class Parameters:
     jitter_delta_ms: int = 20
     burst_period_packets: int = 250
     burst_length_packets: int = 30
+    burst_delay_period_frames: int = 120
+    burst_delay_length_frames: int = 6
+    burst_delay_ms: int = 80
+    burst_jitter_period_frames: int = 150
+    burst_jitter_length_frames: int = 8
+    burst_jitter_min_ms: int = 5
+    burst_jitter_max_ms: int = 120
     drop_every_n_frames: int = 30
     whole_frame_delay_ms: int = 40
 
@@ -90,7 +101,12 @@ class Injector:
         self.stats = Stats()
         self.packet_counter = 0
         self.current_timestamp: Optional[int] = None
+        self.frame_counter = 0
         self.drop_current_frame = False
+        self.current_frame_burst_delay_ms = 0
+        self.current_frame_burst_jitter_ms = 0
+        self.burst_delay_frames_left = 0
+        self.burst_jitter_frames_left = 0
 
         self.queue: List[ScheduledPacket] = []
         self._serial = 0
@@ -152,6 +168,35 @@ class Injector:
         if self.current_timestamp is None or timestamp != self.current_timestamp:
             self.current_timestamp = timestamp
             self.stats.frames_seen += 1
+            self.frame_counter += 1
+
+            self.current_frame_burst_delay_ms = 0
+            self.current_frame_burst_jitter_ms = 0
+
+            if self.mode == FaultMode.BURST_PACKET_DELAY:
+                if self.burst_delay_frames_left > 0:
+                    self.current_frame_burst_delay_ms = self.params.burst_delay_ms
+                    self.burst_delay_frames_left -= 1
+                else:
+                    period = max(1, self.params.burst_delay_period_frames)
+                    length = max(1, self.params.burst_delay_length_frames)
+                    if self.frame_counter % period == 0:
+                        self.current_frame_burst_delay_ms = self.params.burst_delay_ms
+                        self.burst_delay_frames_left = max(0, length - 1)
+
+            if self.mode == FaultMode.BURST_PACKET_JITTER:
+                jitter_min = min(self.params.burst_jitter_min_ms, self.params.burst_jitter_max_ms)
+                jitter_max = max(self.params.burst_jitter_min_ms, self.params.burst_jitter_max_ms)
+                if self.burst_jitter_frames_left > 0:
+                    self.current_frame_burst_jitter_ms = random.randint(jitter_min, jitter_max)
+                    self.burst_jitter_frames_left -= 1
+                else:
+                    period = max(1, self.params.burst_jitter_period_frames)
+                    length = max(1, self.params.burst_jitter_length_frames)
+                    if self.frame_counter % period == 0:
+                        self.current_frame_burst_jitter_ms = random.randint(jitter_min, jitter_max)
+                        self.burst_jitter_frames_left = max(0, length - 1)
+
             if self.mode == FaultMode.DROP_EVERY_N_FRAMES:
                 n = max(1, self.params.drop_every_n_frames)
                 self.drop_current_frame = (self.stats.frames_seen % n) == 0
@@ -207,6 +252,14 @@ class Injector:
             self._send_now(packet)
             return
 
+        if self.mode == FaultMode.BURST_PACKET_DELAY:
+            self._schedule(packet, self.current_frame_burst_delay_ms)
+            return
+
+        if self.mode == FaultMode.BURST_PACKET_JITTER:
+            self._schedule(packet, self.current_frame_burst_jitter_ms)
+            return
+
         if self.mode == FaultMode.DROP_EVERY_N_FRAMES:
             if self.drop_current_frame:
                 self.stats.packets_dropped += 1
@@ -248,7 +301,7 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
     safe_add(0, 0, "RTP Fault Injector (manual visual test)", curses.A_BOLD)
     safe_add(1, 0, f"In: 0.0.0.0:{injector.cfg.in_port}  ->  Out: {injector.cfg.out_host}:{injector.cfg.out_port}")
 
-    safe_add(3, 0, "Modes (use Up/Down or number keys 1-8):")
+    safe_add(3, 0, f"Modes (use Up/Down or number keys 1-{len(MODE_LIST)}):")
     for idx, mode in enumerate(MODE_LIST):
         prefix = ">" if idx == injector.mode_index else " "
         attr = curses.A_REVERSE if idx == injector.mode_index else curses.A_NORMAL
@@ -268,17 +321,71 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
     safe_add(row + 9, 2, f"fixed_delay_ms={p.fixed_delay_ms}")
     safe_add(row + 10, 2, f"jitter_base_delay_ms={p.jitter_base_delay_ms}, jitter_delta_ms={p.jitter_delta_ms}")
     safe_add(row + 11, 2, f"burst_period_packets={p.burst_period_packets}, burst_length_packets={p.burst_length_packets}")
-    safe_add(row + 12, 2, f"drop_every_n_frames={p.drop_every_n_frames}")
-    safe_add(row + 13, 2, f"whole_frame_delay_ms={p.whole_frame_delay_ms}")
+    safe_add(row + 12, 2, f"burst_delay_period_frames={p.burst_delay_period_frames}, burst_delay_length_frames={p.burst_delay_length_frames}, burst_delay_ms={p.burst_delay_ms}")
+    safe_add(row + 13, 2, f"burst_jitter_period_frames={p.burst_jitter_period_frames}, burst_jitter_length_frames={p.burst_jitter_length_frames}, burst_jitter_range=[{p.burst_jitter_min_ms},{p.burst_jitter_max_ms}] ms")
+    safe_add(row + 14, 2, f"drop_every_n_frames={p.drop_every_n_frames}")
+    safe_add(row + 15, 2, f"whole_frame_delay_ms={p.whole_frame_delay_ms}")
 
-    safe_add(row + 15, 0, "Keys: q quit | r reset stats | [ ] random-drop +/-0.5 | -/= delay -/+5ms")
-    safe_add(row + 16, 0, "      ,/. frame-drop N -/+1 | ;/' drop-every-N-packets -/+1")
-    safe_add(row + 17, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
+    safe_add(row + 17, 0, f"Active mode tuning with +/-: {active_parameter_summary(injector)}")
+    safe_add(row + 18, 0, "Keys: q quit | r reset stats | +/- adjust active mode severity")
+    safe_add(row + 19, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
 
-    if max_y < 32:
+    if max_y < 36:
         safe_add(max_y - 1, 0, "[Terminal is small: UI truncated, injector still active]", curses.A_DIM)
 
     stdscr.refresh()
+
+
+def active_parameter_summary(injector: Injector) -> str:
+    p = injector.params
+    mode = injector.mode
+    if mode == FaultMode.PASSTHROUGH:
+        return "no-op in passthrough"
+    if mode == FaultMode.DROP_EVERY_N_PACKETS:
+        return f"drop_every_n_packets={p.drop_every_n_packets}"
+    if mode == FaultMode.DROP_RANDOM_PACKETS:
+        return f"random_drop_percent={p.random_drop_percent:.1f}"
+    if mode == FaultMode.FIXED_PACKET_DELAY:
+        return f"fixed_delay_ms={p.fixed_delay_ms}"
+    if mode == FaultMode.PACKET_JITTER:
+        return f"jitter_delta_ms={p.jitter_delta_ms}"
+    if mode == FaultMode.BURST_PACKET_LOSS:
+        return f"burst_length_packets={p.burst_length_packets}"
+    if mode == FaultMode.BURST_PACKET_DELAY:
+        return f"burst_delay_ms={p.burst_delay_ms}"
+    if mode == FaultMode.BURST_PACKET_JITTER:
+        return f"burst_jitter_max_ms={p.burst_jitter_max_ms}"
+    if mode == FaultMode.DROP_EVERY_N_FRAMES:
+        return f"drop_every_n_frames={p.drop_every_n_frames}"
+    if mode == FaultMode.DELAY_WHOLE_FRAMES:
+        return f"whole_frame_delay_ms={p.whole_frame_delay_ms}"
+    return "n/a"
+
+
+def adjust_active_mode(injector: Injector, increase: bool) -> None:
+    p = injector.params
+    direction = 1 if increase else -1
+    mode = injector.mode
+
+    if mode == FaultMode.DROP_EVERY_N_PACKETS:
+        p.drop_every_n_packets = max(1, p.drop_every_n_packets + direction)
+    elif mode == FaultMode.DROP_RANDOM_PACKETS:
+        p.random_drop_percent = min(100.0, max(0.0, p.random_drop_percent + 0.5 * direction))
+    elif mode == FaultMode.FIXED_PACKET_DELAY:
+        p.fixed_delay_ms = max(0, p.fixed_delay_ms + 5 * direction)
+    elif mode == FaultMode.PACKET_JITTER:
+        p.jitter_delta_ms = max(0, p.jitter_delta_ms + 5 * direction)
+    elif mode == FaultMode.BURST_PACKET_LOSS:
+        period = max(1, p.burst_period_packets)
+        p.burst_length_packets = min(period, max(0, p.burst_length_packets + direction))
+    elif mode == FaultMode.BURST_PACKET_DELAY:
+        p.burst_delay_ms = max(0, p.burst_delay_ms + 5 * direction)
+    elif mode == FaultMode.BURST_PACKET_JITTER:
+        p.burst_jitter_max_ms = max(p.burst_jitter_min_ms, p.burst_jitter_max_ms + 5 * direction)
+    elif mode == FaultMode.DROP_EVERY_N_FRAMES:
+        p.drop_every_n_frames = max(1, p.drop_every_n_frames + direction)
+    elif mode == FaultMode.DELAY_WHOLE_FRAMES:
+        p.whole_frame_delay_ms = max(0, p.whole_frame_delay_ms + 5 * direction)
 
 
 def handle_key(key: int, injector: Injector) -> bool:
@@ -289,27 +396,17 @@ def handle_key(key: int, injector: Injector) -> bool:
         injector.set_mode(injector.mode_index - 1)
     elif key == curses.KEY_DOWN:
         injector.set_mode(injector.mode_index + 1)
-    elif ord("1") <= key <= ord("8"):
+    elif ord("1") <= key <= ord("9"):
         injector.set_mode(key - ord("1"))
+    elif key == ord("0") and len(MODE_LIST) >= 10:
+        injector.set_mode(9)
     elif key in (ord("r"), ord("R")):
         injector.stats = Stats()
         injector.packet_counter = 0
-    elif key == ord("["):
-        injector.params.random_drop_percent = max(0.0, injector.params.random_drop_percent - 0.5)
-    elif key == ord("]"):
-        injector.params.random_drop_percent = min(100.0, injector.params.random_drop_percent + 0.5)
     elif key == ord("-"):
-        injector.params.fixed_delay_ms = max(0, injector.params.fixed_delay_ms - 5)
-    elif key == ord("="):
-        injector.params.fixed_delay_ms += 5
-    elif key == ord(","):
-        injector.params.drop_every_n_frames = max(1, injector.params.drop_every_n_frames - 1)
-    elif key == ord("."):
-        injector.params.drop_every_n_frames += 1
-    elif key == ord(";"):
-        injector.params.drop_every_n_packets = max(1, injector.params.drop_every_n_packets - 1)
-    elif key == ord("'"):
-        injector.params.drop_every_n_packets += 1
+        adjust_active_mode(injector, increase=False)
+    elif key in (ord("+"), ord("=")):
+        adjust_active_mode(injector, increase=True)
 
     return True
 

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -111,6 +111,7 @@ class Injector:
 
         self.queue: List[ScheduledPacket] = []
         self._serial = 0
+        self._last_scheduled_send_at = 0.0
 
         self.sock_in = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock_in.bind(("0.0.0.0", cfg.in_port))
@@ -148,6 +149,7 @@ class Injector:
         self.current_frame_burst_jitter_ms = 0
         self.burst_delay_frames_left = 0
         self.burst_jitter_frames_left = 0
+        self._last_scheduled_send_at = 0.0
 
     @staticmethod
     def _parse_rtp(packet: bytes) -> Tuple[bool, Optional[int], bool]:
@@ -176,8 +178,11 @@ class Injector:
 
         return True, timestamp, marker
 
-    def _schedule(self, payload: bytes, delay_ms: int = 0) -> None:
+    def _schedule(self, payload: bytes, delay_ms: int = 0, preserve_order: bool = False) -> None:
         send_at = time.monotonic() + max(0, delay_ms) / 1000.0
+        if preserve_order and send_at < self._last_scheduled_send_at:
+            send_at = self._last_scheduled_send_at
+        self._last_scheduled_send_at = send_at
         self._serial += 1
         heapq.heappush(self.queue, ScheduledPacket(send_at=send_at, serial=self._serial, payload=payload))
 
@@ -264,7 +269,7 @@ class Injector:
         if self.mode == FaultMode.PACKET_JITTER:
             base = self.params.jitter_base_delay_ms
             delta = self.params.jitter_delta_ms
-            self._schedule(packet, base + random.randint(-delta, delta))
+            self._schedule(packet, base + random.randint(-delta, delta), preserve_order=True)
             return
 
         if self.mode == FaultMode.BURST_PACKET_LOSS:
@@ -356,7 +361,8 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
     safe_add(row + 17, 0, f"Active mode tuning with +/-: {active_parameter_summary(injector)}")
     safe_add(row + 18, 0, "Keys: q quit | r reset stats | +/- primary severity | {/} secondary knob")
     safe_add(row + 19, 0, "Mode switch purges delayed queue immediately to resume fresh low-latency packets")
-    safe_add(row + 20, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
+    safe_add(row + 20, 0, "Packet jitter mode preserves packet order to avoid synthetic loss storms at low jitter")
+    safe_add(row + 21, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
 
     if max_y < 36:
         safe_add(max_y - 1, 0, "[Terminal is small: UI truncated, injector still active]", curses.A_DIM)

--- a/tests/rtp_fault_injector.py
+++ b/tests/rtp_fault_injector.py
@@ -127,9 +127,27 @@ class Injector:
         self.sock_in.close()
         self.sock_out.close()
 
+    def _purge_scheduled_packets(self) -> int:
+        purged = len(self.queue)
+        if purged:
+            self.queue.clear()
+            self.stats.packets_dropped += purged
+            self.current_frame_had_loss = True
+        return purged
+
     def set_mode(self, idx: int) -> None:
-        self.mode_index = max(0, min(len(MODE_LIST) - 1, idx))
+        next_index = max(0, min(len(MODE_LIST) - 1, idx))
+        if next_index == self.mode_index:
+            return
+
+        self._purge_scheduled_packets()
+        self.mode_index = next_index
         self.mode = MODE_LIST[self.mode_index]
+        self.drop_current_frame = False
+        self.current_frame_burst_delay_ms = 0
+        self.current_frame_burst_jitter_ms = 0
+        self.burst_delay_frames_left = 0
+        self.burst_jitter_frames_left = 0
 
     @staticmethod
     def _parse_rtp(packet: bytes) -> Tuple[bool, Optional[int], bool]:
@@ -337,7 +355,8 @@ def draw_ui(stdscr: curses.window, injector: Injector) -> None:
 
     safe_add(row + 17, 0, f"Active mode tuning with +/-: {active_parameter_summary(injector)}")
     safe_add(row + 18, 0, "Keys: q quit | r reset stats | +/- primary severity | {/} secondary knob")
-    safe_add(row + 19, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
+    safe_add(row + 19, 0, "Mode switch purges delayed queue immediately to resume fresh low-latency packets")
+    safe_add(row + 20, 0, "Note: dropping full frames can break reference chain until next IDR/CRA")
 
     if max_y < 36:
         safe_add(max_y - 1, 0, "[Terminal is small: UI truncated, injector still active]", curses.A_DIM)


### PR DESCRIPTION
### Motivation

- Provide an explicit, in-process RTP reorder stage so receiver and `udpsrc` paths can behave identically under packet reordering. 
- Give operators a tunable stability-first mode that absorbs small reorder jitter without changing the low-latency default. 
- Allow deployments to choose between low-latency partial-frame continuity and cleaner images via runtime flags and INI settings. 

### Description

- Added a new GStreamer element `sstarrtpjitterbuffer` implemented in `src/rtp_jitterbuffer.c` with header `include/rtp_jitterbuffer.h`, providing sequence-based reordering, configurable `enabled`, `latency-ms`, and `max-misorder` properties. 
- Wired the jitterbuffer into both ingest paths by registering it during GST init and inserting it into the receiver chain (`appsrc -> sstarrtpjitterbuffer -> sstarh265depay`) and into the `udpsrc` launch string, and exposed its properties via the pipeline setup in `src/pipeline.c`. 
- Exposed matching CLI and INI controls in `src/config.c` and `src/config_ini.c` and added fields to `include/config.h`: `jitterbuffer_enable`, `jitterbuffer_latency_ms`, and `jitterbuffer_max_misorder`, with defaults set to disabled/low-latency. 
- Updated documentation and shipped config templates (`README.md`, `docs/h265-corruption-recovery-analysis.md`, `config/*.ini`) to document the new stability-first profile and the new `pipeline.jitterbuffer-*` keys. 

### Testing

- Ran `make test`, which reported there is no `test` target in this repository (no-op). 
- Attempted `make` to build the project but the build failed in this environment due to missing system development headers (`xf86drm.h`, `glib.h`), so a full compile/run could not be verified here. 
- Performed repository checks (`rg`/search) to verify that new symbols, CLI strings, INI keys, element registration and pipeline wiring are present and consistent, and those text-based verifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916e297cdc832b9123d581904eaaea)