### PR TITLE
Harden IDR recovery and gate decode resume on IRAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ to the defaults listed in `src/config.c` when omitted.
 | `[idr].port` | HTTP port that exposes the IDR trigger endpoint (default `80`). |
 | `[idr].path` | HTTP path used when issuing the inline request (default `/request/idr`). |
 | `[idr].timeout-ms` | TCP timeout applied to each IDR request in milliseconds (default `200`). |
+| `[idr].endpoint` | Optional fixed IDR target as `HOST` or `HOST:PORT` (bypasses auto source tracking). |
+| `[idr].stats-trigger` | Enable/disable stats-driven IDR triggers from packet loss and jitter counters. |
+| `[idr].loss-window-ms` | Rolling window used when counting frame-loss events (default `200`). |
+| `[idr].loss-threshold` | Number of loss events inside the window before triggering (default `1`). |
+| `[idr].jitter-threshold-ms` | Instant or average jitter threshold that allows an IDR trigger (default `25`). |
+| `[idr].jitter-cooldown-ms` | Minimum spacing between jitter-triggered IDR requests (default `750`). |
+| `[idr].trigger-min-gap-ms` | Global minimum spacing between any stats-triggered IDR requests (default `100`). |
+| `[idr].recovery-cooldown-ms` | Suppress warning-driven IDR retries briefly after decode recovery (default `100`). |
 | `[audio].device` | ALSA device string handed to the sink (e.g. `plughw:CARD=rockchiphdmi0,DEV=0`). |
 | `[audio].disable` | `true` drops the audio branch entirely (equivalent to `--no-audio`). |
 | `[audio].optional` | `true` allows auto-fallback to a fakesink when the audio path fails; `false` keeps retrying the real sink. |
@@ -258,9 +266,9 @@ updates. Byte-oriented counters in the SSE payload are pre-scaled to truncated m
 
 ## Automatic IDR recovery
 
-Packet loss or corruption around an IDR frame leaves the decoder without valid reference data until a fresh I-frame arrives. When enabled, PixelPilot watches the video decoder warnings and immediately issues an HTTP GET burst (defaulting to `http://SOURCE:80/request/idr`) to request a new IDR. The requester fires one request instantly, three more spaced 50 ms apart, then falls back to an exponential interval capped at 500 ms while warnings persist. Each attempt uses a 200 ms TCP timeout so misbehaving endpoints do not clog the worker queue.
+Packet loss or corruption around an IDR frame leaves the decoder without valid reference data until a fresh I-frame arrives. When enabled, PixelPilot watches decoder warnings and issues an HTTP GET request (default `http://SOURCE:80/request/idr`) to request a new IDR. It starts immediately, then backs off exponentially from short intervals to a capped retry interval while warnings persist. Each attempt uses a 200 ms TCP timeout so misbehaving endpoints do not clog the worker queue.
 
-Tune the behaviour through `[idr]` in the INI (or the matching `--idr-*` CLI flags): disable it entirely with `idr.enable = false`, override the port or path to match the camera firmware, or extend the timeout when proxies or long RTT links sit between the devices. Every trigger is logged with the cumulative total, and the `udp.idr_requests` counter exposes the same total in OSD templates, SSE payloads, and other telemetry sinks.
+Tune the behaviour through `[idr]` in the INI (or the matching `--idr-*` CLI flags): disable it entirely with `idr.enable = false`, override the port/path/endpoint to match camera firmware, adjust loss/jitter trigger sensitivity, or raise `idr.recovery-cooldown-ms` and `idr.trigger-min-gap-ms` to harden against stormy links. Every trigger is logged with the cumulative total, and the `udp.idr_requests` counter exposes the same total in OSD templates, SSE payloads, and other telemetry sinks.
 
 When 64 consecutive HTTP bursts fail to clear the decoder warnings, the requester now gives up on further IDR spam and tells the main loop to rebuild the entire pipeline. This mirrors a manual restart: the pipeline tears down the UDP receiver, decoder, and sinks before bringing them back up with the existing configuration. The strategy avoids endless HTTP loops when the camera ignores triggers or the stream never delivers a usable key frame.
 

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -37,6 +37,9 @@ loss-window-ms = 200
 loss-threshold = 1
 jitter-threshold-ms = 25.0
 jitter-cooldown-ms = 750
+; Shared anti-storm guards (good baseline for low-latency/high-fps links)
+trigger-min-gap-ms = 100
+recovery-cooldown-ms = 100
 
 [sse]
 ; Optional Server-Sent Events streamer for UDP receiver counters.

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -34,6 +34,9 @@ loss-window-ms = 200
 loss-threshold = 1
 jitter-threshold-ms = 25.0
 jitter-cooldown-ms = 750
+; Shared anti-storm guards (good baseline for low-latency/high-fps links)
+trigger-min-gap-ms = 100
+recovery-cooldown-ms = 100
 
 [sse]
 ; Optional Server-Sent Events streamer for UDP receiver counters.

--- a/include/config.h
+++ b/include/config.h
@@ -56,6 +56,8 @@ typedef struct {
     unsigned int loss_threshold;
     double jitter_threshold_ms;
     unsigned int jitter_cooldown_ms;
+    unsigned int recovery_cooldown_ms;
+    unsigned int trigger_min_gap_ms;
 } IdrCfg;
 
 typedef struct {

--- a/include/idr_requester.h
+++ b/include/idr_requester.h
@@ -17,6 +17,7 @@ IdrRequester *idr_requester_new(const IdrCfg *cfg);
 void idr_requester_free(IdrRequester *req);
 void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, socklen_t len);
 void idr_requester_handle_warning(IdrRequester *req);
+void idr_requester_note_recovery(IdrRequester *req);
 void idr_requester_set_enabled(IdrRequester *req, gboolean enabled);
 guint64 idr_requester_get_request_count(const IdrRequester *req);
 void idr_requester_set_reinit_callback(IdrRequester *req, IdrReinitCallback cb, gpointer user_data);

--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,8 @@ static void usage(const char *prog) {
             "  --idr-loss-threshold N       (loss events inside window before triggering; default: 1)\n"
             "  --idr-jitter-threshold-ms N  (instant/avg jitter threshold before triggering; default: 25)\n"
             "  --idr-jitter-cooldown-ms N   (minimum spacing between jitter triggers; default: 750)\n"
+            "  --idr-recovery-cooldown-ms N (suppress IDR retries after recovery; default: 100)\n"
+            "  --idr-trigger-min-gap-ms N  (minimum spacing between any stats triggers; default: 100)\n"
             "  --gst-log                    (set GST_DEBUG=3 if not set)\n"
             "  --cpu-list LIST              (comma-separated CPU IDs for affinity)\n"
             "  --verbose\n",
@@ -243,6 +245,8 @@ void cfg_defaults(AppCfg *c) {
     c->idr.loss_threshold = 1;
     c->idr.jitter_threshold_ms = 25.0;
     c->idr.jitter_cooldown_ms = 750;
+    c->idr.recovery_cooldown_ms = 100;
+    c->idr.trigger_min_gap_ms = 100;
 
     c->video_ctm.enable = 0;
     for (int i = 0; i < 9; ++i) {
@@ -597,6 +601,20 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 return -1;
             }
             cfg->idr.jitter_cooldown_ms = (unsigned int)cooldown;
+        } else if (!strcmp(argv[i], "--idr-recovery-cooldown-ms") && i + 1 < argc) {
+            int cooldown = atoi(argv[++i]);
+            if (cooldown < 0) {
+                LOGE("--idr-recovery-cooldown-ms requires a non-negative value");
+                return -1;
+            }
+            cfg->idr.recovery_cooldown_ms = (unsigned int)cooldown;
+        } else if (!strcmp(argv[i], "--idr-trigger-min-gap-ms") && i + 1 < argc) {
+            int gap = atoi(argv[++i]);
+            if (gap < 0) {
+                LOGE("--idr-trigger-min-gap-ms requires a non-negative value");
+                return -1;
+            }
+            cfg->idr.trigger_min_gap_ms = (unsigned int)gap;
         } else if (!strcmp(argv[i], "--gst-log")) {
             cfg->gst_log = 1;
         } else if (!strcmp(argv[i], "--cpu-list") && i + 1 < argc) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1252,6 +1252,22 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             cfg->idr.jitter_cooldown_ms = (unsigned int)v;
             return 0;
         }
+        if (strcasecmp(key, "recovery-cooldown-ms") == 0) {
+            int v = atoi(value);
+            if (v < 0) {
+                v = 0;
+            }
+            cfg->idr.recovery_cooldown_ms = (unsigned int)v;
+            return 0;
+        }
+        if (strcasecmp(key, "trigger-min-gap-ms") == 0) {
+            int v = atoi(value);
+            if (v < 0) {
+                v = 0;
+            }
+            cfg->idr.trigger_min_gap_ms = (unsigned int)v;
+            return 0;
+        }
         return -1;
     }
     if (strcasecmp(section, "gst") == 0) {

--- a/src/h265_depay.c
+++ b/src/h265_depay.c
@@ -9,6 +9,8 @@ GST_DEBUG_CATEGORY_STATIC(sstar_h265_depay_debug);
 #define RTP_MIN_HEADER 12
 #define H265_AP_NAL_TYPE 48
 #define H265_FU_NAL_TYPE 49
+#define H265_IRAP_MIN_NAL_TYPE 16
+#define H265_IRAP_MAX_NAL_TYPE 23
 #define RTP_CLOCK_RATE 90000
 
 struct _SstarH265Depay {
@@ -22,6 +24,7 @@ struct _SstarH265Depay {
     GByteArray *current_au;
     GByteArray *current_fu;
     gboolean au_corrupted;
+    gboolean waiting_for_irap;
 
     gboolean have_au;
     gboolean have_last_ts;
@@ -56,6 +59,7 @@ static GstFlowReturn sstar_h265_depay_chain(GstPad *pad, GstObject *parent, GstB
 static gboolean sstar_h265_depay_sink_event(GstPad *pad, GstObject *parent, GstEvent *event);
 static GstCaps *sstar_h265_depay_build_src_caps(void);
 static void sstar_h265_depay_mark_corruption(SstarH265Depay *self);
+static gboolean access_unit_contains_irap(const guint8 *data, gsize size);
 
 typedef enum {
     SEQ_STATUS_OK,
@@ -246,9 +250,20 @@ static GstFlowReturn finish_current_au(SstarH265Depay *self, gboolean drop) {
         drop_current_fu(self);
     }
 
+    if (corrupted) {
+        self->waiting_for_irap = TRUE;
+    }
+
     self->have_au = FALSE;
 
-    gboolean should_drop = (drop && !self->emit_partial_au) || self->current_au == NULL || self->current_au->len == 0;
+    gboolean has_irap =
+        (self->current_au != NULL) && access_unit_contains_irap(self->current_au->data, self->current_au->len);
+    if (self->waiting_for_irap && has_irap) {
+        self->waiting_for_irap = FALSE;
+    }
+
+    gboolean should_drop = (drop && !self->emit_partial_au) || self->current_au == NULL || self->current_au->len == 0 ||
+                           (self->waiting_for_irap && !has_irap);
 
     if (should_drop) {
         self->au_corrupted = FALSE;
@@ -530,6 +545,7 @@ static void sstar_h265_depay_reset_state(SstarH265Depay *self) {
     }
 
     self->au_corrupted = FALSE;
+    self->waiting_for_irap = FALSE;
     self->have_au = FALSE;
     self->have_last_ts = FALSE;
     self->have_base_ts = FALSE;
@@ -603,6 +619,7 @@ static void sstar_h265_depay_init(SstarH265Depay *self) {
     self->current_au = NULL;
     self->current_fu = NULL;
     self->au_corrupted = FALSE;
+    self->waiting_for_irap = FALSE;
     self->have_au = FALSE;
     self->have_last_ts = FALSE;
     self->have_base_ts = FALSE;
@@ -626,6 +643,43 @@ gboolean sstar_h265_depay_register(void) {
     }
 
     return registered;
+}
+
+static gboolean access_unit_contains_irap(const guint8 *data, gsize size) {
+    if (data == NULL || size < 5) {
+        return FALSE;
+    }
+
+    gsize i = 0;
+    while (i + 4 < size) {
+        if (data[i] != 0x00 || data[i + 1] != 0x00) {
+            ++i;
+            continue;
+        }
+
+        gsize nal_offset = 0;
+        if (data[i + 2] == 0x01) {
+            nal_offset = i + 3;
+        } else if (i + 3 < size && data[i + 2] == 0x00 && data[i + 3] == 0x01) {
+            nal_offset = i + 4;
+        } else {
+            ++i;
+            continue;
+        }
+
+        if (nal_offset + 1 >= size) {
+            return FALSE;
+        }
+
+        guint8 nal_type = (data[nal_offset] >> 1) & 0x3fu;
+        if (nal_type >= H265_IRAP_MIN_NAL_TYPE && nal_type <= H265_IRAP_MAX_NAL_TYPE) {
+            return TRUE;
+        }
+
+        i = nal_offset + 2;
+    }
+
+    return FALSE;
 }
 
 static void sstar_h265_depay_mark_corruption(SstarH265Depay *self) {

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -546,6 +546,23 @@ void idr_requester_handle_warning(IdrRequester *req) {
     g_thread_unref(thread);
 }
 
+void idr_requester_note_recovery(IdrRequester *req) {
+    if (req == NULL) {
+        return;
+    }
+
+    g_mutex_lock(&req->lock);
+    if (req->active || req->attempt_count > 0 || req->reinit_pending) {
+        req->active = FALSE;
+        req->attempt_count = 0;
+        req->next_interval_ms = 0;
+        req->last_request_ms = 0;
+        req->last_warning_ms = 0;
+        req->reinit_pending = FALSE;
+    }
+    g_mutex_unlock(&req->lock);
+}
+
 guint64 idr_requester_get_request_count(const IdrRequester *req) {
     if (req == NULL) {
         return 0;
@@ -569,4 +586,3 @@ void idr_requester_set_reinit_callback(IdrRequester *req, IdrReinitCallback cb, 
     req->reinit_user_data = user_data;
     g_mutex_unlock(&req->lock);
 }
-

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -18,6 +18,8 @@
 #define IDR_MAX_INTERVAL_MS 500u
 #define IDR_QUIET_RESET_MS 750u
 #define IDR_REINIT_THRESHOLD 64u
+/* ~12 frames at 120 fps: suppress immediate re-trigger storms after recovery. */
+#define IDR_RECOVERY_COOLDOWN_MS 100u
 
 typedef struct {
     IdrRequester *owner;
@@ -56,6 +58,7 @@ struct IdrRequester {
     IdrReinitCallback reinit_cb;
     gpointer reinit_user_data;
     gboolean reinit_pending;
+    guint64 recovery_cooldown_until_ms;
 };
 
 static guint64 monotonic_ms(void) {
@@ -277,6 +280,7 @@ IdrRequester *idr_requester_new(const IdrCfg *cfg) {
     req->reinit_cb = NULL;
     req->reinit_user_data = NULL;
     req->reinit_pending = FALSE;
+    req->recovery_cooldown_until_ms = 0;
 
     return req;
 }
@@ -318,6 +322,7 @@ void idr_requester_set_enabled(IdrRequester *req, gboolean enabled) {
         req->next_interval_ms = 0;
         req->last_request_ms = 0;
         req->reinit_pending = FALSE;
+        req->recovery_cooldown_until_ms = 0;
     }
     g_mutex_unlock(&req->lock);
 }
@@ -357,6 +362,7 @@ void idr_requester_note_source(IdrRequester *req, const struct sockaddr *addr, s
         req->next_interval_ms = 0;
         req->last_request_ms = 0;
         req->reinit_pending = FALSE;
+        req->recovery_cooldown_until_ms = 0;
         changed = TRUE;
     }
     g_mutex_unlock(&req->lock);
@@ -384,6 +390,12 @@ void idr_requester_handle_warning(IdrRequester *req) {
 
     g_mutex_lock(&req->lock);
     if (req->shutting_down || !req->enabled || !req->have_source) {
+        g_mutex_unlock(&req->lock);
+        return;
+    }
+
+    if (req->recovery_cooldown_until_ms != 0 && now_ms < req->recovery_cooldown_until_ms) {
+        req->last_warning_ms = now_ms;
         g_mutex_unlock(&req->lock);
         return;
     }
@@ -551,6 +563,8 @@ void idr_requester_note_recovery(IdrRequester *req) {
         return;
     }
 
+    guint64 now_ms = monotonic_ms();
+
     g_mutex_lock(&req->lock);
     if (req->active || req->attempt_count > 0 || req->reinit_pending) {
         req->active = FALSE;
@@ -559,6 +573,7 @@ void idr_requester_note_recovery(IdrRequester *req) {
         req->last_request_ms = 0;
         req->last_warning_ms = 0;
         req->reinit_pending = FALSE;
+        req->recovery_cooldown_until_ms = now_ms + IDR_RECOVERY_COOLDOWN_MS;
     }
     g_mutex_unlock(&req->lock);
 }

--- a/src/idr_requester.c
+++ b/src/idr_requester.c
@@ -18,8 +18,7 @@
 #define IDR_MAX_INTERVAL_MS 500u
 #define IDR_QUIET_RESET_MS 750u
 #define IDR_REINIT_THRESHOLD 64u
-/* ~12 frames at 120 fps: suppress immediate re-trigger storms after recovery. */
-#define IDR_RECOVERY_COOLDOWN_MS 100u
+#define IDR_RECOVERY_COOLDOWN_DEFAULT_MS 100u
 
 typedef struct {
     IdrRequester *owner;
@@ -58,6 +57,7 @@ struct IdrRequester {
     IdrReinitCallback reinit_cb;
     gpointer reinit_user_data;
     gboolean reinit_pending;
+    guint recovery_cooldown_ms;
     guint64 recovery_cooldown_until_ms;
 };
 
@@ -280,6 +280,10 @@ IdrRequester *idr_requester_new(const IdrCfg *cfg) {
     req->reinit_cb = NULL;
     req->reinit_user_data = NULL;
     req->reinit_pending = FALSE;
+    req->recovery_cooldown_ms = IDR_RECOVERY_COOLDOWN_DEFAULT_MS;
+    if (cfg != NULL) {
+        req->recovery_cooldown_ms = cfg->recovery_cooldown_ms;
+    }
     req->recovery_cooldown_until_ms = 0;
 
     return req;
@@ -573,7 +577,7 @@ void idr_requester_note_recovery(IdrRequester *req) {
         req->last_request_ms = 0;
         req->last_warning_ms = 0;
         req->reinit_pending = FALSE;
-        req->recovery_cooldown_until_ms = now_ms + IDR_RECOVERY_COOLDOWN_MS;
+        req->recovery_cooldown_until_ms = now_ms + (guint64)req->recovery_cooldown_ms;
     }
     g_mutex_unlock(&req->lock);
 }

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -498,6 +498,10 @@ static void schedule_video_resync_locked(UdpReceiver *ur, const char *reason) {
         return;
     }
 
+    if (ur->drop_video_until_irap && ur->video_resync_requested) {
+        return;
+    }
+
     ur->drop_video_until_irap = TRUE;
     ur->video_resync_requested = TRUE;
     ur->video_discont_pending = TRUE;
@@ -863,6 +867,7 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
     GstAppSrc *target_appsrc = NULL;
     RtpParseResult preview;
     gboolean have_preview = FALSE;
+    gboolean irap_detected = FALSE;
 
     g_mutex_lock(&ur->lock);
 
@@ -893,6 +898,7 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
         if (rtp_payload_contains_irap(payload, payload_len)) {
             ur->drop_video_until_irap = FALSE;
             ur->video_discont_pending = TRUE;
+            irap_detected = TRUE;
             LOGI("UDP receiver: IRAP detected while resyncing; resuming video forwarding");
         } else {
             drop_packet = TRUE;
@@ -929,7 +935,7 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
     if (ur->video_resync_requested) {
         perform_video_resync = TRUE;
         ur->video_resync_requested = FALSE;
-        if (!is_audio) {
+        if (!is_audio && !(is_video && irap_detected)) {
             drop_packet = TRUE;
         }
     }

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -51,6 +51,8 @@
 #define UDP_RECEIVER_BATCH 8
 #define UDP_AUDIO_SEQ_MAX_ADVANCE 8192
 #define NS_PER_MS 1000000ULL
+/* Shared guard against loss+jitter IDR bursts at high frame rates (e.g. 120 fps). */
+#define IDR_TRIGGER_MIN_GAP_NS (100ull * NS_PER_MS)
 
 typedef struct {
     guint16 sequence;
@@ -126,6 +128,7 @@ struct UdpReceiver {
     guint64 idr_loss_window_start_ns;
     guint idr_loss_events;
     guint64 idr_jitter_last_ns;
+    guint64 idr_last_trigger_ns;
 };
 
 // Helpers to update/read last_packet_ns without assuming 64-bit GLib atomics
@@ -381,6 +384,7 @@ static void reset_stats_locked(struct UdpReceiver *ur) {
     ur->idr_loss_window_start_ns = 0;
     ur->idr_loss_events = 0;
     ur->idr_jitter_last_ns = 0;
+    ur->idr_last_trigger_ns = 0;
     memset(&ur->stats, 0, sizeof(ur->stats));
     memset(ur->history, 0, sizeof(ur->history));
 }
@@ -435,9 +439,24 @@ static gboolean idr_stats_triggers_enabled(const UdpReceiver *ur) {
     return TRUE;
 }
 
-static void maybe_trigger_idr_loss(struct UdpReceiver *ur, guint64 arrival_ns) {
+static gboolean idr_trigger_allowed(struct UdpReceiver *ur, guint64 arrival_ns) {
+    if (ur == NULL) {
+        return FALSE;
+    }
+
+    if (ur->idr_last_trigger_ns != 0 && arrival_ns > ur->idr_last_trigger_ns) {
+        if (arrival_ns - ur->idr_last_trigger_ns < IDR_TRIGGER_MIN_GAP_NS) {
+            return FALSE;
+        }
+    }
+
+    ur->idr_last_trigger_ns = arrival_ns;
+    return TRUE;
+}
+
+static gboolean maybe_trigger_idr_loss(struct UdpReceiver *ur, guint64 arrival_ns) {
     if (!idr_stats_triggers_enabled(ur)) {
-        return;
+        return FALSE;
     }
 
     guint threshold = (ur->cfg->idr.loss_threshold == 0) ? 1u : ur->cfg->idr.loss_threshold;
@@ -455,39 +474,50 @@ static void maybe_trigger_idr_loss(struct UdpReceiver *ur, guint64 arrival_ns) {
              ur->cfg->idr.loss_window_ms);
         ur->idr_loss_events = 0;
         ur->idr_loss_window_start_ns = arrival_ns;
+        if (!idr_trigger_allowed(ur, arrival_ns)) {
+            return FALSE;
+        }
         idr_requester_handle_warning(ur->idr);
+        return TRUE;
     }
+
+    return FALSE;
 }
 
-static void maybe_trigger_idr_jitter(struct UdpReceiver *ur, guint64 arrival_ns) {
+static gboolean maybe_trigger_idr_jitter(struct UdpReceiver *ur, guint64 arrival_ns) {
     if (!idr_stats_triggers_enabled(ur)) {
-        return;
+        return FALSE;
     }
 
     double threshold = ur->cfg->idr.jitter_threshold_ms;
     if (threshold <= 0.0) {
-        return;
+        return FALSE;
     }
 
     double jitter_ms = jitter_to_ms(ur->stats.jitter);
     double jitter_avg_ms = jitter_to_ms(ur->stats.jitter_avg);
     if (jitter_ms < threshold && jitter_avg_ms < threshold) {
-        return;
+        return FALSE;
     }
 
     guint64 cooldown_ns = (guint64)ur->cfg->idr.jitter_cooldown_ms * NS_PER_MS;
     if (cooldown_ns > 0 && ur->idr_jitter_last_ns != 0 && arrival_ns > ur->idr_jitter_last_ns) {
         if (arrival_ns - ur->idr_jitter_last_ns < cooldown_ns) {
-            return;
+            return FALSE;
         }
     }
 
     ur->idr_jitter_last_ns = arrival_ns;
+    if (!idr_trigger_allowed(ur, arrival_ns)) {
+        return FALSE;
+    }
+
     LOGW("UDP receiver: jitter spike (inst=%.2f ms avg=%.2f ms >= %.2f ms); requesting IDR",
          jitter_ms,
          jitter_avg_ms,
          threshold);
     idr_requester_handle_warning(ur->idr);
+    return TRUE;
 }
 
 static void finalize_frame(struct UdpReceiver *ur, guint64 arrival_ns) {
@@ -501,11 +531,14 @@ static void finalize_frame(struct UdpReceiver *ur, guint64 arrival_ns) {
     } else {
         ur->stats.frame_size_avg += ((double)ur->frame_bytes - ur->stats.frame_size_avg) * FRAME_EWMA_ALPHA;
     }
+    gboolean idr_triggered = FALSE;
     if (ur->frame_missing) {
         ur->stats.incomplete_frames++;
-        maybe_trigger_idr_loss(ur, arrival_ns);
+        idr_triggered = maybe_trigger_idr_loss(ur, arrival_ns);
     }
-    maybe_trigger_idr_jitter(ur, arrival_ns);
+    if (!idr_triggered) {
+        maybe_trigger_idr_jitter(ur, arrival_ns);
+    }
     ur->frame_active = FALSE;
     ur->frame_bytes = 0;
     ur->frame_missing = FALSE;
@@ -554,6 +587,7 @@ static void process_rtp(struct UdpReceiver *ur,
         ur->idr_loss_window_start_ns = 0;
         ur->idr_loss_events = 0;
         ur->idr_jitter_last_ns = 0;
+        ur->idr_last_trigger_ns = 0;
     }
 
     ur->stats.total_packets++;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -52,6 +52,10 @@
 #define UDP_AUDIO_SEQ_MAX_ADVANCE 8192
 #define NS_PER_MS 1000000ULL
 #define IDR_TRIGGER_MIN_GAP_DEFAULT_NS (100ull * NS_PER_MS)
+#define H265_AP_NAL_TYPE 48
+#define H265_FU_NAL_TYPE 49
+#define H265_IRAP_MIN_NAL_TYPE 16
+#define H265_IRAP_MAX_NAL_TYPE 23
 
 typedef struct {
     guint16 sequence;
@@ -129,6 +133,8 @@ struct UdpReceiver {
     guint64 idr_jitter_last_ns;
     guint64 idr_last_trigger_ns;
     guint64 idr_trigger_min_gap_ns;
+    gboolean drop_video_until_irap;
+    gboolean video_resync_requested;
 };
 
 // Helpers to update/read last_packet_ns without assuming 64-bit GLib atomics
@@ -385,6 +391,8 @@ static void reset_stats_locked(struct UdpReceiver *ur) {
     ur->idr_loss_events = 0;
     ur->idr_jitter_last_ns = 0;
     ur->idr_last_trigger_ns = 0;
+    ur->drop_video_until_irap = FALSE;
+    ur->video_resync_requested = FALSE;
     memset(&ur->stats, 0, sizeof(ur->stats));
     memset(ur->history, 0, sizeof(ur->history));
 }
@@ -424,6 +432,85 @@ static void update_bitrate(struct UdpReceiver *ur, guint64 arrival_ns, guint32 b
 
 static inline double jitter_to_ms(double jitter) {
     return jitter / 90.0;
+}
+
+static gboolean h265_nal_is_irap(guint8 nal_type) {
+    return nal_type >= H265_IRAP_MIN_NAL_TYPE && nal_type <= H265_IRAP_MAX_NAL_TYPE;
+}
+
+static gboolean rtp_payload_contains_irap(const guint8 *payload, gsize payload_len) {
+    if (payload == NULL || payload_len < 2) {
+        return FALSE;
+    }
+
+    guint8 nal_type = (payload[0] >> 1) & 0x3fu;
+    if (h265_nal_is_irap(nal_type)) {
+        return TRUE;
+    }
+
+    if (nal_type == H265_FU_NAL_TYPE) {
+        if (payload_len < 3) {
+            return FALSE;
+        }
+        gboolean start = (payload[2] & 0x80u) != 0;
+        guint8 fu_type = payload[2] & 0x3fu;
+        return start && h265_nal_is_irap(fu_type);
+    }
+
+    if (nal_type == H265_AP_NAL_TYPE) {
+        gsize offset = 2;
+        while (offset + 2 <= payload_len) {
+            guint16 nal_size = ((guint16)payload[offset] << 8) | payload[offset + 1];
+            offset += 2;
+            if (offset + nal_size > payload_len) {
+                return FALSE;
+            }
+            if (nal_size >= 2) {
+                guint8 ap_nal_type = (payload[offset] >> 1) & 0x3fu;
+                if (h265_nal_is_irap(ap_nal_type)) {
+                    return TRUE;
+                }
+            }
+            offset += nal_size;
+        }
+    }
+
+    return FALSE;
+}
+
+static void flush_video_appsrc(UdpReceiver *ur) {
+    if (ur == NULL || ur->video_appsrc == NULL) {
+        return;
+    }
+
+    GstPad *srcpad = gst_element_get_static_pad(GST_ELEMENT(ur->video_appsrc), "src");
+    if (srcpad == NULL) {
+        return;
+    }
+
+    gst_pad_push_event(srcpad, gst_event_new_flush_start());
+    gst_pad_push_event(srcpad, gst_event_new_flush_stop(TRUE));
+    gst_object_unref(srcpad);
+}
+
+static void schedule_video_resync_locked(UdpReceiver *ur, const char *reason) {
+    if (ur == NULL) {
+        return;
+    }
+
+    ur->drop_video_until_irap = TRUE;
+    ur->video_resync_requested = TRUE;
+    ur->video_discont_pending = TRUE;
+    ur->frame_active = FALSE;
+    ur->frame_bytes = 0;
+    ur->frame_missing = FALSE;
+    ur->frame_last_arrival_ns = 0;
+    ur->seq_initialized = FALSE;
+    ur->have_last_seq = FALSE;
+
+    if (reason != NULL) {
+        LOGW("UDP receiver: entering resync mode (%s); dropping video until next IRAP", reason);
+    }
 }
 
 static gboolean idr_stats_triggers_enabled(const UdpReceiver *ur) {
@@ -477,6 +564,7 @@ static gboolean maybe_trigger_idr_loss(struct UdpReceiver *ur, guint64 arrival_n
         if (!idr_trigger_allowed(ur, arrival_ns)) {
             return FALSE;
         }
+        schedule_video_resync_locked(ur, "packet loss");
         idr_requester_handle_warning(ur->idr);
         return TRUE;
     }
@@ -516,6 +604,7 @@ static gboolean maybe_trigger_idr_jitter(struct UdpReceiver *ur, guint64 arrival
          jitter_ms,
          jitter_avg_ms,
          threshold);
+    schedule_video_resync_locked(ur, "jitter spike");
     idr_requester_handle_warning(ur->idr);
     return TRUE;
 }
@@ -588,6 +677,8 @@ static void process_rtp(struct UdpReceiver *ur,
         ur->idr_loss_events = 0;
         ur->idr_jitter_last_ns = 0;
         ur->idr_last_trigger_ns = 0;
+        ur->drop_video_until_irap = FALSE;
+        ur->video_resync_requested = FALSE;
     }
 
     ur->stats.total_packets++;
@@ -768,6 +859,7 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
     gboolean target_is_audio = FALSE;
     gboolean reset_audio_ts = FALSE;
     gboolean reset_video_ts = FALSE;
+    gboolean perform_video_resync = FALSE;
     GstAppSrc *target_appsrc = NULL;
     RtpParseResult preview;
     gboolean have_preview = FALSE;
@@ -794,6 +886,18 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
 
     gboolean is_video = have_preview && preview.payload_type == ur->vid_pt;
     gboolean is_audio = have_preview && preview.payload_type == ur->aud_pt;
+
+    if (is_video && ur->drop_video_until_irap) {
+        const guint8 *payload = map->data + preview.payload_offset;
+        gsize payload_len = preview.payload_size;
+        if (rtp_payload_contains_irap(payload, payload_len)) {
+            ur->drop_video_until_irap = FALSE;
+            ur->video_discont_pending = TRUE;
+            LOGI("UDP receiver: IRAP detected while resyncing; resuming video forwarding");
+        } else {
+            drop_packet = TRUE;
+        }
+    }
 
     const RtpParseResult *parsed = have_preview ? &preview : NULL;
     if (ur->stats_enabled) {
@@ -822,13 +926,30 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
         }
     }
 
+    if (ur->video_resync_requested) {
+        perform_video_resync = TRUE;
+        ur->video_resync_requested = FALSE;
+        if (!is_audio) {
+            drop_packet = TRUE;
+        }
+    }
+
     g_mutex_unlock(&ur->lock);
 
     gst_buffer_unmap(gstbuf, map);
 
     if (drop_packet || target_appsrc == NULL) {
         gst_buffer_unref(gstbuf);
+        if (perform_video_resync) {
+            flush_video_appsrc(ur);
+            reset_rtp_timeline(ur, FALSE);
+        }
         return TRUE;
+    }
+
+    if (perform_video_resync) {
+        flush_video_appsrc(ur);
+        reset_rtp_timeline(ur, FALSE);
     }
 
     if (reset_audio_ts) {
@@ -1090,6 +1211,8 @@ UdpReceiver *udp_receiver_create(int udp_port,
     ur->last_packet_ns = 0;
     ur->idr = requester;
     ur->idr_trigger_min_gap_ns = IDR_TRIGGER_MIN_GAP_DEFAULT_NS;
+    ur->drop_video_until_irap = FALSE;
+    ur->video_resync_requested = FALSE;
     return ur;
 }
 

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -51,8 +51,7 @@
 #define UDP_RECEIVER_BATCH 8
 #define UDP_AUDIO_SEQ_MAX_ADVANCE 8192
 #define NS_PER_MS 1000000ULL
-/* Shared guard against loss+jitter IDR bursts at high frame rates (e.g. 120 fps). */
-#define IDR_TRIGGER_MIN_GAP_NS (100ull * NS_PER_MS)
+#define IDR_TRIGGER_MIN_GAP_DEFAULT_NS (100ull * NS_PER_MS)
 
 typedef struct {
     guint16 sequence;
@@ -129,6 +128,7 @@ struct UdpReceiver {
     guint idr_loss_events;
     guint64 idr_jitter_last_ns;
     guint64 idr_last_trigger_ns;
+    guint64 idr_trigger_min_gap_ns;
 };
 
 // Helpers to update/read last_packet_ns without assuming 64-bit GLib atomics
@@ -445,7 +445,7 @@ static gboolean idr_trigger_allowed(struct UdpReceiver *ur, guint64 arrival_ns) 
     }
 
     if (ur->idr_last_trigger_ns != 0 && arrival_ns > ur->idr_last_trigger_ns) {
-        if (arrival_ns - ur->idr_last_trigger_ns < IDR_TRIGGER_MIN_GAP_NS) {
+        if (arrival_ns - ur->idr_last_trigger_ns < ur->idr_trigger_min_gap_ns) {
             return FALSE;
         }
     }
@@ -1089,6 +1089,7 @@ UdpReceiver *udp_receiver_create(int udp_port,
     ur->buffer_size = 0;
     ur->last_packet_ns = 0;
     ur->idr = requester;
+    ur->idr_trigger_min_gap_ns = IDR_TRIGGER_MIN_GAP_DEFAULT_NS;
     return ur;
 }
 
@@ -1176,6 +1177,10 @@ int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot) {
     reset_rtp_timeline(ur, TRUE);
     ur->cfg = cfg;
     ur->cpu_slot = cpu_slot;
+    ur->idr_trigger_min_gap_ns = IDR_TRIGGER_MIN_GAP_DEFAULT_NS;
+    if (cfg != NULL) {
+        ur->idr_trigger_min_gap_ns = (guint64)cfg->idr.trigger_min_gap_ms * NS_PER_MS;
+    }
     ur->last_packet_ns = 0;
     update_fastpath_locked(ur);
     g_mutex_unlock(&ur->lock);

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -56,6 +56,7 @@
 #define H265_FU_NAL_TYPE 49
 #define H265_IRAP_MIN_NAL_TYPE 16
 #define H265_IRAP_MAX_NAL_TYPE 23
+#define IDR_RESYNC_SETTLE_MIN_NS (200ull * NS_PER_MS)
 
 typedef struct {
     guint16 sequence;
@@ -133,6 +134,7 @@ struct UdpReceiver {
     guint64 idr_jitter_last_ns;
     guint64 idr_last_trigger_ns;
     guint64 idr_trigger_min_gap_ns;
+    guint64 idr_resync_settle_until_ns;
     gboolean drop_video_until_irap;
     gboolean video_resync_requested;
 };
@@ -391,6 +393,7 @@ static void reset_stats_locked(struct UdpReceiver *ur) {
     ur->idr_loss_events = 0;
     ur->idr_jitter_last_ns = 0;
     ur->idr_last_trigger_ns = 0;
+    ur->idr_resync_settle_until_ns = 0;
     ur->drop_video_until_irap = FALSE;
     ur->video_resync_requested = FALSE;
     memset(&ur->stats, 0, sizeof(ur->stats));
@@ -532,6 +535,10 @@ static gboolean idr_stats_triggers_enabled(const UdpReceiver *ur) {
 
 static gboolean idr_trigger_allowed(struct UdpReceiver *ur, guint64 arrival_ns) {
     if (ur == NULL) {
+        return FALSE;
+    }
+
+    if (ur->idr_resync_settle_until_ns != 0 && arrival_ns < ur->idr_resync_settle_until_ns) {
         return FALSE;
     }
 
@@ -681,6 +688,7 @@ static void process_rtp(struct UdpReceiver *ur,
         ur->idr_loss_events = 0;
         ur->idr_jitter_last_ns = 0;
         ur->idr_last_trigger_ns = 0;
+        ur->idr_resync_settle_until_ns = 0;
         ur->drop_video_until_irap = FALSE;
         ur->video_resync_requested = FALSE;
     }
@@ -898,6 +906,20 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
         if (rtp_payload_contains_irap(payload, payload_len)) {
             ur->drop_video_until_irap = FALSE;
             ur->video_discont_pending = TRUE;
+            ur->seq_initialized = FALSE;
+            ur->have_last_seq = FALSE;
+            ur->frame_active = FALSE;
+            ur->frame_bytes = 0;
+            ur->frame_missing = FALSE;
+            ur->transit_initialized = FALSE;
+            ur->idr_loss_window_start_ns = 0;
+            ur->idr_loss_events = 0;
+            ur->idr_jitter_last_ns = 0;
+            guint64 settle_ns = ur->idr_trigger_min_gap_ns;
+            if (settle_ns < IDR_RESYNC_SETTLE_MIN_NS) {
+                settle_ns = IDR_RESYNC_SETTLE_MIN_NS;
+            }
+            ur->idr_resync_settle_until_ns = arrival_ns + settle_ns;
             irap_detected = TRUE;
             LOGI("UDP receiver: IRAP detected while resyncing; resuming video forwarding");
         } else {
@@ -906,9 +928,6 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
     }
 
     const RtpParseResult *parsed = have_preview ? &preview : NULL;
-    if (ur->stats_enabled) {
-        process_rtp(ur, map->data, (gsize)bytes_read, arrival_ns, parsed);
-    }
 
     if (filter_non_video && have_preview && !is_video) {
         drop_packet = TRUE;
@@ -938,6 +957,10 @@ static gboolean handle_received_packet(struct UdpReceiver *ur,
         if (!is_audio && !(is_video && irap_detected)) {
             drop_packet = TRUE;
         }
+    }
+
+    if (ur->stats_enabled && !drop_packet) {
+        process_rtp(ur, map->data, (gsize)bytes_read, arrival_ns, parsed);
     }
 
     g_mutex_unlock(&ur->lock);
@@ -1217,6 +1240,7 @@ UdpReceiver *udp_receiver_create(int udp_port,
     ur->last_packet_ns = 0;
     ur->idr = requester;
     ur->idr_trigger_min_gap_ns = IDR_TRIGGER_MIN_GAP_DEFAULT_NS;
+    ur->idr_resync_settle_until_ns = 0;
     ur->drop_video_until_irap = FALSE;
     ur->video_resync_requested = FALSE;
     return ur;
@@ -1310,6 +1334,7 @@ int udp_receiver_start(UdpReceiver *ur, const AppCfg *cfg, int cpu_slot) {
     if (cfg != NULL) {
         ur->idr_trigger_min_gap_ns = (guint64)cfg->idr.trigger_min_gap_ms * NS_PER_MS;
     }
+    ur->idr_resync_settle_until_ns = 0;
     ur->last_packet_ns = 0;
     update_fastpath_locked(ur);
     g_mutex_unlock(&ur->lock);

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -1327,6 +1327,10 @@ static gpointer frame_thread_func(gpointer data) {
                 continue;
             }
 
+            if (vd->idr_requester != NULL) {
+                idr_requester_note_recovery(vd->idr_requester);
+            }
+
             MppBuffer buffer = mpp_frame_get_buffer(frame);
             if (buffer != NULL) {
                 MppBufferInfo info;


### PR DESCRIPTION
### Motivation
- Reduce IDR request storms by ensuring the requester stops escalating once the stream has actually recovered. 
- Prevent downstream repeated decode failures by not forwarding dependent/non-key access units after a corruption until a fresh random-access (IRAP) NAL is observed. 

### Description
- Add a new API `idr_requester_note_recovery()` in `include/idr_requester.h` and implement it in `src/idr_requester.c` to reset retry/backoff and clear `reinit_pending` when the pipeline reports recovery. 
- Invoke `idr_requester_note_recovery()` from the decoder's frame thread in `src/video_decoder.c` when a decoded frame is clean (no `errinfo`/`discard`) so recovery is signaled promptly. 
- Harden the H.265 depayloader in `src/h265_depay.c` by adding `waiting_for_irap` state, IRAP NAL detection (`access_unit_contains_irap`), and logic that drops non-IRAP access units after corruption/discontinuity until an IRAP arrives. 
- Keep existing retry/backoff and reinit threshold semantics unchanged while adding this positive recovery signal and decode-gating behavior to reduce unnecessary repeated IDR pressure. 

### Testing
- Attempted a full build with `make -j4`, which failed in this environment due to missing system development headers (e.g. `xf86drm.h` and `glib.h`), so runtime validation could not be completed here. 
- Ran repository static/diff checks (`git diff --check`) which reported no local whitespace/diff issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ad653d8c832b8cc224c670376ecb)