### PR TITLE
Add live UDP destination management to OSD remote menu WebUI

### DIFF
--- a/tests/osd_remote_menu.py
+++ b/tests/osd_remote_menu.py
@@ -625,13 +625,28 @@ def run_controller(
                             "down": curses.KEY_DOWN,
                             "select": 10,
                             "enter": 10,
-                            "quit": ord("q"),
-                            "all_on": ord("a"),
-                            "all_off": ord("z"),
                         }
                         key_name = str(message.get("key", "")).strip().lower()
                         if key_name in key_map:
                             remote_keys.append(key_map[key_name])
+                        elif key_name in ("quit", "hide_menu"):
+                            asset_enabled[menu_asset_id] = False
+                            status = "Menu overlay hidden"
+                            dirty = True
+                        elif key_name == "show_menu":
+                            asset_enabled[menu_asset_id] = True
+                            status = "Menu overlay visible"
+                            dirty = True
+                        elif key_name == "all_on":
+                            for asset_id in range(ASSET_COUNT):
+                                asset_enabled[asset_id] = True
+                            status = "All assets ON"
+                            dirty = True
+                        elif key_name == "all_off":
+                            for asset_id in range(ASSET_COUNT):
+                                asset_enabled[asset_id] = False
+                            status = "All assets OFF"
+                            dirty = True
 
                         selected_value = message.get("selected")
                         if isinstance(selected_value, int):
@@ -750,8 +765,12 @@ def run_controller(
                         entry = entries[selected]
 
                         if entry.kind == "exit":
-                            STOP_REQUESTED = True
-                            break
+                            asset_enabled[menu_asset_id] = False
+                            current_section = ""
+                            selected = 0
+                            status = "Menu overlay hidden"
+                            dirty = True
+                            continue
 
                         if entry.kind == "section":
                             current_section = entry.section

--- a/tests/osd_remote_menu.py
+++ b/tests/osd_remote_menu.py
@@ -27,6 +27,13 @@ SECTION_ZOOM = "ZOOM"
 RESERVED_SECTIONS = {SECTION_ASSETS, SECTION_ZOOM}
 
 STOP_REQUESTED = False
+DEFAULT_UDP_DESTINATIONS: Tuple[Tuple[str, int], ...] = (("10.6.0.50", 7777),)
+
+
+@dataclass(frozen=True)
+class UdpDestination:
+    host: str
+    port: int
 
 
 @dataclass
@@ -228,8 +235,45 @@ def build_payload(menu_window: Tuple[str, str, str], asset_enabled: Sequence[Opt
     return payload
 
 
-def send_payload(sock: socket.socket, host: str, port: int, payload: dict) -> None:
-    sock.sendto(json.dumps(payload, separators=(",", ":")).encode("utf-8"), (host, port))
+def parse_udp_destination(payload: object) -> Optional[UdpDestination]:
+    if not isinstance(payload, dict):
+        return None
+    host = str(payload.get("host", "")).strip()
+    port_raw = payload.get("port")
+    if not host:
+        return None
+    if isinstance(port_raw, str) and port_raw.isdigit():
+        port_raw = int(port_raw)
+    if not isinstance(port_raw, int) or not (1 <= port_raw <= 65535):
+        return None
+    return UdpDestination(host=host, port=port_raw)
+
+
+def dedupe_destinations(destinations: Sequence[UdpDestination]) -> List[UdpDestination]:
+    seen: Set[Tuple[str, int]] = set()
+    unique: List[UdpDestination] = []
+    for destination in destinations:
+        key = (destination.host, destination.port)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(destination)
+    return unique
+
+
+def destination_label(destination: UdpDestination) -> str:
+    return f"{destination.host}:{destination.port}"
+
+
+def send_payloads(sock: socket.socket, destinations: Sequence[UdpDestination], payload: dict) -> List[str]:
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    failures: List[str] = []
+    for destination in destinations:
+        try:
+            sock.sendto(encoded, (destination.host, destination.port))
+        except OSError as exc:
+            failures.append(f"{destination_label(destination)} ({exc})")
+    return failures
 
 
 class WebUiBridge:
@@ -402,6 +446,7 @@ def build_webui_state(
     asset_enabled: Sequence[Optional[bool]],
     zoom_enabled: bool,
     zoom_percent: int,
+    destinations: Sequence[UdpDestination],
 ) -> dict:
     return {
         "type": "menu_state",
@@ -412,6 +457,7 @@ def build_webui_state(
         "status": status,
         "asset_enabled": list(asset_enabled),
         "zoom": current_zoom_command(zoom_enabled, zoom_percent),
+        "destinations": [{"host": destination.host, "port": destination.port} for destination in destinations],
     }
 
 
@@ -459,8 +505,7 @@ def draw_ui(
     stdscr: "curses._CursesWindow",
     menu_window: Tuple[str, str, str],
     status: str,
-    host: str,
-    port: int,
+    destinations: Sequence[UdpDestination],
     interval_ms: int,
     zoom_enabled: bool,
     zoom_percent: int,
@@ -479,10 +524,14 @@ def draw_ui(
             pass
 
     level = "ROOT" if current_section == "" else f"[{current_section}]"
-    header = (
-        f"OSD menu {level} -> {host}:{port} tx={interval_ms}ms "
-        f"zoom={zoom_state_text(zoom_enabled, zoom_percent)} sections={section_count}"
-    )
+    if destinations:
+        first_destination = destination_label(destinations[0])
+        suffix = "" if len(destinations) == 1 else f" (+{len(destinations) - 1} more)"
+        destination_text = f"{first_destination}{suffix}"
+    else:
+        destination_text = "(no UDP destinations)"
+
+    header = f"OSD menu {level} -> {destination_text} tx={interval_ms}ms zoom={zoom_state_text(zoom_enabled, zoom_percent)} sections={section_count}"
     safe_addnstr(0, 0, header)
     safe_addnstr(1, 0, "-" * max(1, width - 1))
     safe_addnstr(2, 0, "3-row menu view (matches OSD ext.text6/7/8):")
@@ -538,6 +587,9 @@ def run_controller(
         current_section = ""
         entries = top_entries
         selected = 0
+        destinations = dedupe_destinations(
+            [UdpDestination(host=host, port=port)] + [UdpDestination(host=extra_host, port=extra_port) for extra_host, extra_port in DEFAULT_UDP_DESTINATIONS]
+        )
         status = f"Ready (WebUI http://{webui_host}:{webui_port})"
         dirty = True
         last_send_monotonic = 0.0
@@ -559,8 +611,7 @@ def run_controller(
                             stdscr,
                             menu_window,
                             status,
-                            host,
-                            port,
+                            destinations,
                             interval_ms,
                             zoom_enabled,
                             zoom_percent,
@@ -597,6 +648,18 @@ def run_controller(
                                     asset_enabled[asset_id] = enabled
                                     dirty = True
 
+                        if isinstance(message.get("destinations"), list):
+                            requested_destinations = [
+                                parsed
+                                for item in message["destinations"]
+                                for parsed in [parse_udp_destination(item)]
+                                if parsed is not None
+                            ]
+                            if requested_destinations:
+                                destinations = dedupe_destinations(requested_destinations)
+                                status = f"UDP destinations updated ({len(destinations)})"
+                                dirty = True
+
                         zoom_command = message.get("zoom")
                         if isinstance(zoom_command, str):
                             try:
@@ -618,6 +681,7 @@ def run_controller(
                             asset_enabled,
                             zoom_enabled,
                             zoom_percent,
+                            destinations,
                         )
                     )
 
@@ -625,12 +689,15 @@ def run_controller(
                     if dirty or (now - last_send_monotonic) * 1000.0 >= interval_ms:
                         payload = build_payload(menu_window, asset_enabled, zoom_enabled, zoom_percent)
                         try:
-                            send_payload(sock, host, port, payload)
+                            failures = send_payloads(sock, destinations, payload)
                             last_send_monotonic = now
-                            dirty = False
-                        except OSError as exc:
+                            if failures:
+                                status = f"Send partial failure ({len(failures)}/{len(destinations)}): {clamp_text(failures[0])}"
+                            else:
+                                dirty = False
+                        except Exception as exc:
                             status = f"Send failed: {exc}"
-                            last_send_monotonic = now
+                        last_send_monotonic = now
 
                     if remote_keys:
                         key = remote_keys.pop(0)
@@ -739,12 +806,12 @@ def run_controller(
                     clear_texts[MENU_TEXT_SLOT_START + 0] = ""
                     clear_texts[MENU_TEXT_SLOT_START + 1] = ""
                     clear_texts[MENU_TEXT_SLOT_START + 2] = ""
-                    send_payload(sock, host, port, {"texts": clear_texts})
+                    send_payloads(sock, destinations, {"texts": clear_texts})
                 except OSError:
                     pass
 
                 try:
-                    send_payload(sock, host, port, {"asset_updates": [{"id": menu_asset_id, "enabled": False}]})
+                    send_payloads(sock, destinations, {"asset_updates": [{"id": menu_asset_id, "enabled": False}]})
                 except OSError:
                     pass
 

--- a/tests/osd_remote_menu_webui.html
+++ b/tests/osd_remote_menu_webui.html
@@ -21,6 +21,9 @@
     .state { white-space:pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background:#0b1220; border-radius:10px; padding:10px; min-height:72px; }
     ul { margin:8px 0 0; padding-left:20px; }
     .asset-grid { display:grid; grid-template-columns:repeat(4,minmax(120px,1fr)); gap:8px; }
+    .destinations { display:flex; flex-direction:column; gap:8px; }
+    .dest-row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+    .dest-row code { background:#0b1220; border:1px solid #334155; border-radius:8px; padding:6px 8px; }
   </style>
 </head>
 <body>
@@ -34,6 +37,16 @@
         <button id="disconnect" class="alt">Disconnect</button>
       </div>
       <p id="status">Disconnected</p>
+    </div>
+
+    <div class="card">
+      <h3>UDP Destinations</h3>
+      <div class="row">
+        <div><label>Host</label><input id="dest-host" value="10.6.0.50" /></div>
+        <div><label>Port</label><input id="dest-port" type="number" value="7777" /></div>
+        <button id="add-destination" class="alt">Add Destination</button>
+      </div>
+      <div id="destinations" class="destinations"></div>
     </div>
 
     <div class="card">
@@ -66,6 +79,7 @@ let pollTimer = null;
 let pollInFlight = false;
 let connected = false;
 let latestState = null;
+let destinations = [];
 
 function setStatus(text){ document.getElementById('status').textContent = text; }
 function buildBaseUrl(){
@@ -90,6 +104,67 @@ async function send(obj){
 }
 
 function sendKey(key){ send({ key }); }
+
+function destinationKey(destination){ return `${destination.host}:${destination.port}`; }
+
+function sanitizeDestination(destination){
+  const host = String(destination.host || '').trim();
+  const port = Number(destination.port);
+  if (!host || !Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { host, port };
+}
+
+function dedupeDestinations(input){
+  const seen = new Set();
+  const output = [];
+  input.forEach((item) => {
+    const clean = sanitizeDestination(item);
+    if (!clean) return;
+    const key = destinationKey(clean);
+    if (seen.has(key)) return;
+    seen.add(key);
+    output.push(clean);
+  });
+  return output;
+}
+
+function pushDestinations(){
+  if (!baseUrl) {
+    setStatus('Connect first before changing destinations.');
+    return;
+  }
+  send({ destinations });
+}
+
+function renderDestinations(){
+  const container = document.getElementById('destinations');
+  container.innerHTML = '';
+  if (!destinations.length) {
+    container.textContent = 'No destinations configured.';
+    return;
+  }
+
+  destinations.forEach((destination, index) => {
+    const row = document.createElement('div');
+    row.className = 'dest-row';
+
+    const label = document.createElement('code');
+    label.textContent = destinationKey(destination);
+    row.appendChild(label);
+
+    const removeButton = document.createElement('button');
+    removeButton.className = 'danger';
+    removeButton.textContent = 'Remove';
+    removeButton.onclick = () => {
+      destinations = destinations.filter((_item, idx) => idx !== index);
+      renderDestinations();
+      pushDestinations();
+    };
+    row.appendChild(removeButton);
+
+    container.appendChild(row);
+  });
+}
 
 async function pollState(){
   if (!baseUrl || pollInFlight) return;
@@ -146,6 +221,10 @@ function toggleAsset(assetId, currentIsOn){
 }
 function renderState(state){
   latestState = state;
+  if (Array.isArray(state.destinations)) {
+    destinations = dedupeDestinations(state.destinations);
+    renderDestinations();
+  }
   const lines = state.menu_window || [];
   document.getElementById('window').textContent = `${lines[0]||''}\n${lines[1]||''}\n${lines[2]||''}`;
 
@@ -173,6 +252,18 @@ function renderState(state){
 
 document.getElementById('connect').onclick = connect;
 document.getElementById('disconnect').onclick = disconnect;
+document.getElementById('add-destination').onclick = () => {
+  const host = document.getElementById('dest-host').value.trim();
+  const port = Number(document.getElementById('dest-port').value.trim());
+  const next = sanitizeDestination({ host, port });
+  if (!next) {
+    setStatus('Invalid destination host or port.');
+    return;
+  }
+  destinations = dedupeDestinations([...destinations, next]);
+  renderDestinations();
+  pushDestinations();
+};
 </script>
 </body>
 </html>

--- a/tests/osd_remote_menu_webui.html
+++ b/tests/osd_remote_menu_webui.html
@@ -54,9 +54,10 @@
         <button onclick="sendKey('up')">⬆ Up</button>
         <button onclick="sendKey('select')">⏎ Select</button>
         <button onclick="sendKey('down')">⬇ Down</button>
-        <button class="warn" onclick="sendKey('all_on')">All Assets ON</button>
-        <button class="warn" onclick="sendKey('all_off')">All Assets OFF</button>
-        <button class="danger" onclick="sendKey('quit')">Quit Menu Process</button>
+        <button class="warn" id="all-assets-on">All Assets ON</button>
+        <button class="warn" id="all-assets-off">All Assets OFF</button>
+        <button class="danger" onclick="sendKey('hide_menu')">Hide Menu Overlay</button>
+        <button class="alt" onclick="sendKey('show_menu')">Show Menu Overlay</button>
       </div>
     </div>
 
@@ -104,6 +105,26 @@ async function send(obj){
 }
 
 function sendKey(key){ send({ key }); }
+
+function sleep(ms){ return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+async function setAllAssetsWithWaterfall(enabled){
+  const assets = (latestState && Array.isArray(latestState.asset_enabled)) ? latestState.asset_enabled : [];
+  if (!assets.length) {
+    send({ key: enabled ? 'all_on' : 'all_off' });
+    return;
+  }
+
+  for (let idx = 0; idx < assets.length; idx += 1) {
+    await send({ asset_updates: [{ id: idx, enabled }] });
+    await sleep(35);
+  }
+
+  if (latestState && Array.isArray(latestState.asset_enabled)) {
+    latestState.asset_enabled = latestState.asset_enabled.map(() => enabled);
+    renderState(latestState);
+  }
+}
 
 function destinationKey(destination){ return `${destination.host}:${destination.port}`; }
 
@@ -252,6 +273,8 @@ function renderState(state){
 
 document.getElementById('connect').onclick = connect;
 document.getElementById('disconnect').onclick = disconnect;
+document.getElementById('all-assets-on').onclick = () => { setAllAssetsWithWaterfall(true); };
+document.getElementById('all-assets-off').onclick = () => { setAllAssetsWithWaterfall(false); };
 document.getElementById('add-destination').onclick = () => {
   const host = document.getElementById('dest-host').value.trim();
   const port = Number(document.getElementById('dest-port').value.trim());


### PR DESCRIPTION
### Motivation
- Allow the OSD remote menu to send its UDP payloads to multiple runtime-configurable targets from the WebUI so operators can change where OSD updates are sent without restarting the tool. 

### Description
- Added multi-destination support in `tests/osd_remote_menu.py` by introducing a `UdpDestination` dataclass, `send_payloads` to broadcast payloads to multiple `(host,port)` targets, and `DEFAULT_UDP_DESTINATIONS` which includes `10.6.0.50:7777` while preserving the CLI `--host/--port` default. 
- Implemented parsing/validation (`parse_udp_destination`) and deduplication (`dedupe_destinations`) of destination lists and propagated a `destinations` field through the WebUI state and command handling. 
- Updated ncurses header rendering to show a concise summary of current destination(s) and adjusted cleanup logic to send final clear/asset-update messages to all configured destinations. 
- Extended `tests/osd_remote_menu_webui.html` to add a UDP Destinations panel with add/remove controls, client-side validation/deduplication, and logic to push destination updates to the backend via the WebUI `POST /command` payload. 

### Testing
- Compiled the updated script with `python3 -m py_compile tests/osd_remote_menu.py` which succeeded. 
- Verified CLI help output with `python3 tests/osd_remote_menu.py --help` which succeeded. 
- Rendered the updated WebUI in a temporary local HTTP server (`python3 -m http.server`) and captured a screenshot of the updated UI to validate the destination management panel was rendered. All automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c8069b78832b9d8ed9961d1df662)