### PR TITLE
Add external OSD gamma control, hub controls, and FPS telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,4 @@ Use pre-commit hooks or post-tool-use hooks to enforce formatting and linting au
 - The build system uses `Makefile` (not CMake) — always update `Makefile` when adding sources.
 - OSD asset IDs must be unique across all `[osd.element.*]` sections (range 0–7).
 - SSE shutdown requires atomic flag checks to avoid race conditions — use GLib atomics, not bare booleans.
+- Any init/service stop timeout must exceed the application's internal graceful-shutdown waits (for example thread join timeouts), or the supervisor will SIGKILL the process before cleanup runs.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -17,6 +17,7 @@ The payload is a JSON object. All fields are optional, but at least one should b
   "texts": ["string1", "string2", ...],
   "values": [1.23, 4.56, ...],
   "zoom": "200,200,50,50",
+  "gamma": "0.85,0.0,1.0,1.0,1.0,1.0",
   "asset_updates": [{"id": 0, "enabled": false}],
   "ttl_ms": 1000
 }
@@ -29,6 +30,7 @@ The payload is a JSON object. All fields are optional, but at least one should b
 | `texts` | Array of Strings | Updates the text slots. Max 8 items. Strings are mapped to slots 0-7 by index. |
 | `values` | Array of Numbers | Updates the value slots. Max 8 items. Values are mapped to slots 0-7 by index. |
 | `zoom` | String | Sets the zoom level and center point. See "Zoom Control" below. |
+| `gamma` | String | Sets DRM gamma LUT parameters. See "Gamma Control" below. |
 | `ttl_ms` | Integer | Time-to-live in milliseconds. If present, the updated slots will expire and clear after this duration. If omitted, updates are persistent until overwritten or cleared. |
 | `asset_updates` | Array of Objects | Optional compatibility field matching `waybeam_osd`. Each object supports `id` (0-7) and `enabled` (boolean) to show/hide a configured OSD element by configured asset `id`. |
 
@@ -59,6 +61,22 @@ Zoom can be controlled by sending a string in the `zoom` field.
 }
 ```
 This sets 2x zoom centered on the middle of the screen.
+
+
+## Gamma Control
+
+Gamma can be controlled by sending a string in the `gamma` field.
+
+*   **Command Format:** `GAMMA,LIFT,GAIN,R,G,B` (or `gamma=GAMMA,LIFT,GAIN,R,G,B`)
+    *   Valid ranges: `GAMMA` 0.20–5.00, `LIFT` -0.50–0.50, `GAIN` 0.50–1.50, `R/G/B` 0.50–1.50.
+*   **Disable Gamma Override:** `off` (or `gamma=off`). This restores a neutral LUT.
+
+**Example:**
+```json
+{
+  "gamma": "0.85,0.0,1.0,1.0,1.0,1.0"
+}
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ arriving on a different SSRC (or with a large sequence gap) is ignored entirely 
 | `udp.bitrate.avg_mbps` | Exponentially weighted moving average of the instantaneous video bitrate. |
 | `udp.jitter.latest_ms` | RFC 3550 style inter-arrival jitter derived from the video timestamps. |
 | `udp.jitter.avg_ms` | EWMA of the video jitter metric to smooth short-term spikes. |
+| `udp.fps.avg` | EWMA of completed-frame cadence, exposed as averaged frames per second. |
 | `udp.frame.count` | Number of completed video frames detected via RTP marker bits. |
 | `udp.frame.incomplete` | Frames that ended with missing video packets. |
 | `udp.frame.last_kib` | Size of the most recent completed video frame (KiB). |
@@ -244,7 +245,7 @@ data: {"have_stats":true,"total_packets":1234,"video_packets":1234,
        "audio_packets":0,"ignored_packets":0,"duplicate_packets":0,
        "lost_packets":2,"reordered_packets":1,"total_mbytes":9.42,
        "video_mbytes":9.42,"audio_mbytes":0.00,"frame_count":45,
-       "incomplete_frames":0,"last_frame_kib":112.5,"avg_frame_kib":108.3,
+       "incomplete_frames":0,"last_frame_kib":112.5,"avg_frame_kib":108.3,"fps_avg":59.82,
        "bitrate_mbps":12.340,"bitrate_avg_mbps":10.876,"jitter_ms":3.25,
        "jitter_avg_ms":2.97,"expected_sequence":54321,
        "idr_requests":7,"recording_enabled":true,

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ to the defaults listed in `src/config.c` when omitted.
 
 ## External OSD Control
 
-The application supports an external OSD control feed that allows third-party tools to push text, numeric values, zoom commands, and `waybeam_osd`-style `asset_updates` visibility toggles over UDP.
+The application supports an external OSD control feed that allows third-party tools to push text, numeric values, zoom commands, DRM gamma commands, and `waybeam_osd`-style `asset_updates` visibility toggles over UDP.
 
 *   **Default Port:** 5005
 *   **Protocol:** JSON over UDP

--- a/README.md
+++ b/README.md
@@ -212,12 +212,12 @@ arriving on a different SSRC (or with a large sequence gap) is ignored entirely 
 | `udp.jitter.latest_ms` | RFC 3550 style inter-arrival jitter derived from the video timestamps. |
 | `udp.jitter.avg_ms` | EWMA of the video jitter metric to smooth short-term spikes. |
 | `udp.fps.avg` | EWMA of completed-frame cadence, exposed as averaged frames per second. |
-| `udp.frame.count` | Number of completed video frames detected via RTP marker bits. |
-| `udp.frame.incomplete` | Frames that ended with missing video packets. |
-| `udp.frame.last_kib` | Size of the most recent completed video frame (KiB). |
-| `udp.frame.avg_kib` | EWMA of recent video frame sizes (KiB). |
-| `udp.sequence.expected` | The next video sequence number the receiver is waiting for. |
-| `udp.timestamp.last_video` | RTP timestamp from the most recent video packet. |
+| `udp.frames.count` | Number of completed video frames detected via RTP marker bits. |
+| `udp.frames.incomplete` | Frames that ended with missing video packets. |
+| `udp.frames.last_bytes` | Size of the most recent completed video frame (KiB, despite the historical token name). |
+| `udp.frames.avg_bytes` | EWMA of recent video frame sizes (KiB, despite the historical token name). |
+| `udp.expected_sequence` | The next video sequence number the receiver is waiting for. |
+| `udp.last_video_timestamp` | RTP timestamp from the most recent video packet. |
 | `udp.idr_requests` | Total HTTP IDR requests issued while attempting to recover corrupted streams. |
 
 The history buffer exposed through `udp.history.*` tokens retains the 512 most recent packet samples, including packet size,

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -60,6 +60,18 @@ log = false
 ; Example: affinity = 3,4,5
 affinity = 1,2,3
 
+
+[video.gamma]
+; Optional DRM gamma LUT override applied on startup.
+; External OSD UDP can update this live via the `gamma` command.
+enable = false
+gamma = 1.0
+lift = 0.0
+gain = 1.0
+r = 1.0
+g = 1.0
+b = 1.0
+
 [osd]
 enable = true
 ; The refresh interval is clamped to a minimum of 50ms to avoid busy loops.

--- a/config/osd-sample.ini
+++ b/config/osd-sample.ini
@@ -113,7 +113,7 @@ line = UDP port={udp.port} PTv={udp.vid_pt} PTa={udp.aud_pt} sinkbuf={pipeline.a
 line = Record {record.state} active={record.active} dur={record.duration_hms} size={record.megabytes}MiB
 line = Pipeline {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}
 line = RTP vpkts={udp.video_packets} loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets}
-line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps
+line = Jitter {udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms bitrate {udp.bitrate.latest_mbps}/{udp.bitrate.avg_mbps}Mbps fps {udp.fps.avg}
 line = IDR req={udp.idr_requests}
 line = Frames={udp.frames.count} incomplete={udp.frames.incomplete} avg={udp.frames.avg_bytes}KB last={udp.frames.last_bytes}KB
 line = Seq={udp.expected_sequence}
@@ -245,6 +245,7 @@ grid = transparent-white
 ;   {udp.total_bytes}, {udp.video_bytes}, {udp.audio_bytes}
 ;   {udp.bitrate.latest_mbps}, {udp.bitrate.avg_mbps}
 ;   {udp.jitter.latest_ms}, {udp.jitter.avg_ms}
+;   {udp.fps.avg}
 ;   {udp.frames.count}, {udp.frames.incomplete}, {udp.frames.last_bytes}, {udp.frames.avg_bytes}  (frame sizes in kilobytes)
 ;   {udp.expected_sequence}, {udp.last_video_timestamp}
 ;   {udp.idr_requests}          => total HTTP IDR requests issued
@@ -257,6 +258,7 @@ grid = transparent-white
 ;   udp.bitrate.avg_mbps         (double, Mbps)
 ;   udp.jitter.latest_ms         (double, milliseconds)
 ;   udp.jitter.avg_ms            (double, milliseconds)
+;   udp.fps.avg                  (double, average frames per second)
 ;   udp.frames.avg_bytes         (average frame size in kilobytes)
 ;   udp.frames.last_bytes        (last frame size in kilobytes)
 ;   udp.frames.count             (count)

--- a/include/config.h
+++ b/include/config.h
@@ -38,6 +38,16 @@ typedef struct {
 
 typedef struct {
     int enable;
+    double gamma;
+    double lift;
+    double gain;
+    double r;
+    double g;
+    double b;
+} VideoGammaCfg;
+
+typedef struct {
+    int enable;
     char bind_address[64];
     int port;
     unsigned int interval_ms;
@@ -112,6 +122,7 @@ typedef struct {
     SseCfg sse;
     IdrCfg idr;
     VideoCtmCfg video_ctm;
+    VideoGammaCfg video_gamma;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);

--- a/include/osd_external.h
+++ b/include/osd_external.h
@@ -32,6 +32,8 @@ typedef struct {
     uint64_t expiry_ns;
     uint64_t zoom_expiry_ns;
     char zoom_command[OSD_EXTERNAL_TEXT_LEN];
+    uint64_t gamma_expiry_ns;
+    char gamma_command[OSD_EXTERNAL_TEXT_LEN];
     uint8_t asset_enabled[OSD_EXTERNAL_MAX_ASSETS];
     uint8_t asset_active_mask;
     OsdExternalStatus status;
@@ -56,6 +58,7 @@ typedef struct {
     OsdExternalFeedSnapshot snapshot;
     uint64_t expiry_ns;
     uint64_t zoom_expiry_ns;
+    uint64_t gamma_expiry_ns;
     uint8_t asset_active_mask;
     uint8_t asset_enabled[OSD_EXTERNAL_MAX_ASSETS];
     uint64_t asset_expiry_ns[OSD_EXTERNAL_MAX_ASSETS];

--- a/include/pipeline.h
+++ b/include/pipeline.h
@@ -71,6 +71,7 @@ int pipeline_get_ctm_metrics(const PipelineState *ps, VideoCtmMetrics *metrics);
 gboolean pipeline_consume_reinit_request(PipelineState *ps);
 void pipeline_apply_zoom_command(PipelineState *ps, gboolean enabled, const VideoDecoderZoomRequest *request);
 void pipeline_apply_ctm_update(PipelineState *ps, const VideoCtmUpdate *update);
+void pipeline_apply_gamma_update(PipelineState *ps, const VideoGammaUpdate *update);
 void pipeline_get_video_chain_handles(const PipelineState *ps,
                                       GstElement **depay_out,
                                       GstElement **parser_out,

--- a/include/sse_streamer.h
+++ b/include/sse_streamer.h
@@ -24,6 +24,7 @@ typedef struct {
     guint64 incomplete_frames;
     guint64 last_frame_bytes;
     double frame_size_avg;
+    double fps_avg;
     double jitter_ms;
     double jitter_avg_ms;
     double bitrate_mbps;

--- a/include/udp_receiver.h
+++ b/include/udp_receiver.h
@@ -46,6 +46,7 @@ typedef struct {
     guint64 incomplete_frames;
     guint64 last_frame_bytes;
     double frame_size_avg;
+    double fps_avg;
     double jitter;
     double jitter_avg;
     double bitrate_mbps;

--- a/include/video_decoder.h
+++ b/include/video_decoder.h
@@ -26,6 +26,19 @@ typedef struct {
     guint32 h;
 } VideoDecoderZoomRect;
 
+#define VIDEO_GAMMA_UPDATE_PARAMS (1u << 0)
+
+typedef struct VideoGammaUpdate {
+    uint32_t fields;
+    gboolean enabled;
+    double gamma;
+    double lift;
+    double gain;
+    double r;
+    double g;
+    double b;
+} VideoGammaUpdate;
+
 VideoDecoder *video_decoder_new(void);
 void video_decoder_free(VideoDecoder *vd);
 
@@ -44,6 +57,7 @@ int video_decoder_set_zoom(VideoDecoder *vd, gboolean enabled, const VideoDecode
 
 size_t video_decoder_max_packet_size(const VideoDecoder *vd);
 void video_decoder_apply_ctm_update(VideoDecoder *vd, const VideoCtmUpdate *update);
+void video_decoder_apply_gamma_update(VideoDecoder *vd, const VideoGammaUpdate *update);
 void video_decoder_get_ctm_metrics(const VideoDecoder *vd, VideoCtmMetrics *metrics);
 uint32_t video_decoder_get_plane_id(const VideoDecoder *vd);
 

--- a/src/config.c
+++ b/src/config.c
@@ -248,6 +248,14 @@ void cfg_defaults(AppCfg *c) {
     for (int i = 0; i < 9; ++i) {
         c->video_ctm.matrix[i] = (i % 4 == 0) ? 1.0 : 0.0;
     }
+
+    c->video_gamma.enable = 0;
+    c->video_gamma.gamma = 1.0;
+    c->video_gamma.lift = 0.0;
+    c->video_gamma.gain = 1.0;
+    c->video_gamma.r = 1.0;
+    c->video_gamma.g = 1.0;
+    c->video_gamma.b = 1.0;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1040,6 +1040,41 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "video.gamma") == 0 || strcasecmp(section, "video_gamma") == 0) {
+        if (strcasecmp(key, "enable") == 0 || strcasecmp(key, "gamma-enable") == 0) {
+            int v = 0;
+            if (parse_bool(value, &v) != 0) {
+                return -1;
+            }
+            cfg->video_gamma.enable = v;
+            return 0;
+        }
+        if (strcasecmp(key, "gamma") == 0) {
+            cfg->video_gamma.gamma = strtod(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "lift") == 0) {
+            cfg->video_gamma.lift = strtod(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "gain") == 0) {
+            cfg->video_gamma.gain = strtod(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "r") == 0 || strcasecmp(key, "red") == 0) {
+            cfg->video_gamma.r = strtod(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "g") == 0 || strcasecmp(key, "green") == 0) {
+            cfg->video_gamma.g = strtod(value, NULL);
+            return 0;
+        }
+        if (strcasecmp(key, "b") == 0 || strcasecmp(key, "blue") == 0) {
+            cfg->video_gamma.b = strtod(value, NULL);
+            return 0;
+        }
+        return -1;
+    }
     if (strcasecmp(section, "restart") == 0 || strcasecmp(section, "restarts") == 0) {
         if (strcasecmp(key, "limit") == 0) {
             cfg->restart_limit = atoi(value);

--- a/src/main.c
+++ b/src/main.c
@@ -170,6 +170,73 @@ static gboolean parse_zoom_command(const char *cmd, gboolean *out_enabled, Video
     return TRUE;
 }
 
+
+static gboolean parse_gamma_command(const char *cmd, VideoGammaUpdate *out_update) {
+    if (out_update == NULL || cmd == NULL) {
+        return FALSE;
+    }
+    const char *p = cmd;
+    while (*p != '\0' && g_ascii_isspace(*p)) {
+        ++p;
+    }
+    memset(out_update, 0, sizeof(*out_update));
+    out_update->fields = VIDEO_GAMMA_UPDATE_PARAMS;
+    out_update->enabled = FALSE;
+    out_update->gamma = 1.0;
+    out_update->lift = 0.0;
+    out_update->gain = 1.0;
+    out_update->r = 1.0;
+    out_update->g = 1.0;
+    out_update->b = 1.0;
+    if (*p == '\0' || g_ascii_strcasecmp(p, "off") == 0 || g_ascii_strcasecmp(p, "gamma=off") == 0) {
+        return TRUE;
+    }
+    if (g_ascii_strncasecmp(p, "gamma=", 6) == 0) {
+        p += 6;
+    }
+    char buf[OSD_EXTERNAL_TEXT_LEN];
+    g_strlcpy(buf, p, sizeof(buf));
+    GStrv tokens = g_strsplit(buf, ",", 0);
+    double values[6] = {0.0};
+    int idx = 0;
+    gboolean ok = TRUE;
+    for (char **it = tokens; ok && it != NULL && *it != NULL; ++it) {
+        if (idx >= 6) {
+            ok = FALSE;
+            break;
+        }
+        char *token = g_strstrip(*it);
+        if (token[0] == '\0') {
+            ok = FALSE;
+            break;
+        }
+        errno = 0;
+        char *end_ptr = NULL;
+        double value = g_ascii_strtod(token, &end_ptr);
+        if (errno != 0 || end_ptr == token || *end_ptr != '\0') {
+            ok = FALSE;
+            break;
+        }
+        values[idx++] = value;
+    }
+    g_strfreev(tokens);
+    if (!ok || idx != 6) {
+        return FALSE;
+    }
+    if (values[0] < 0.20 || values[0] > 5.00 || values[1] < -0.50 || values[1] > 0.50 || values[2] < 0.50 || values[2] > 1.50 ||
+        values[3] < 0.50 || values[3] > 1.50 || values[4] < 0.50 || values[4] > 1.50 || values[5] < 0.50 || values[5] > 1.50) {
+        return FALSE;
+    }
+    out_update->enabled = TRUE;
+    out_update->gamma = values[0];
+    out_update->lift = values[1];
+    out_update->gain = values[2];
+    out_update->r = values[3];
+    out_update->g = values[4];
+    out_update->b = values[5];
+    return TRUE;
+}
+
 static int ensure_single_instance(void) {
     for (;;) {
         int rc = write_pid_file();
@@ -407,6 +474,7 @@ int main(int argc, char **argv) {
     struct timespec last_osd;
     clock_gettime(CLOCK_MONOTONIC, &last_osd);
     char last_zoom_command[OSD_EXTERNAL_TEXT_LEN] = "";
+    char last_gamma_command[OSD_EXTERNAL_TEXT_LEN] = "";
 
     while (!g_exit_flag) {
         pipeline_poll_child(&ps);
@@ -630,6 +698,18 @@ int main(int argc, char **argv) {
                         pipeline_apply_zoom_command(&ps, FALSE, NULL);
                     }
                     g_strlcpy(last_zoom_command, zoom_text != NULL ? zoom_text : "", sizeof(last_zoom_command));
+                }
+
+                const char *gamma_text = ext_snapshot.gamma_command;
+                if (g_strcmp0(gamma_text, last_gamma_command) != 0) {
+                    VideoGammaUpdate gamma_update = {0};
+                    if (parse_gamma_command(gamma_text, &gamma_update)) {
+                        pipeline_apply_gamma_update(&ps, &gamma_update);
+                    } else if (gamma_text != NULL && gamma_text[0] != '\0') {
+                        LOGW("External gamma command ignored: expected 'gamma=GAMMA,LIFT,GAIN,R,G,B' or 'gamma=off' (got '%s')",
+                             gamma_text);
+                    }
+                    g_strlcpy(last_gamma_command, gamma_text != NULL ? gamma_text : "", sizeof(last_gamma_command));
                 }
                 int updated = osd_update_stats(fd, &cfg, &ms, &ps, audio_disabled, restart_count, &ext_snapshot, &now, &osd);
                 if (updated) {

--- a/src/osd.c
+++ b/src/osd.c
@@ -856,6 +856,10 @@ static int osd_token_format(const OsdRenderContext *ctx, const char *token, char
         snprintf(buf, buf_sz, "%.2f", kb);
         return 0;
     }
+    if (strcmp(key, "udp.fps.avg") == 0) {
+        snprintf(buf, buf_sz, "%.2f", ctx->stats.fps_avg);
+        return 0;
+    }
     if (strcmp(key, "udp.expected_sequence") == 0) {
         snprintf(buf, buf_sz, "%u", ctx->stats.expected_sequence);
         return 0;
@@ -922,6 +926,10 @@ static int osd_metric_sample(const OsdRenderContext *ctx, const char *key, doubl
     }
     if (metric && strcmp(metric, "udp.frames.count") == 0) {
         *out_value = (double)ctx->stats.frame_count;
+        return 1;
+    }
+    if (metric && strcmp(metric, "udp.fps.avg") == 0) {
+        *out_value = ctx->stats.fps_avg;
         return 1;
     }
     if (metric && strcmp(metric, "udp.idr_requests") == 0) {

--- a/src/osd_external.c
+++ b/src/osd_external.c
@@ -65,6 +65,11 @@ static void osd_external_update_expiry_locked(OsdExternalBridge *bridge) {
             next_expiry = bridge->zoom_expiry_ns;
         }
     }
+    if (bridge->gamma_expiry_ns > 0) {
+        if (next_expiry == 0 || bridge->gamma_expiry_ns < next_expiry) {
+            next_expiry = bridge->gamma_expiry_ns;
+        }
+    }
     for (size_t i = 0; i < OSD_EXTERNAL_MAX_ASSETS; ++i) {
         if ((bridge->asset_active_mask & (1u << i)) && bridge->asset_expiry_ns[i] > 0) {
             if (next_expiry == 0 || bridge->asset_expiry_ns[i] < next_expiry) {
@@ -75,6 +80,7 @@ static void osd_external_update_expiry_locked(OsdExternalBridge *bridge) {
     bridge->expiry_ns = next_expiry;
     bridge->snapshot.expiry_ns = next_expiry;
     bridge->snapshot.zoom_expiry_ns = bridge->zoom_expiry_ns;
+    bridge->snapshot.gamma_expiry_ns = bridge->gamma_expiry_ns;
     bridge->snapshot.asset_active_mask = bridge->asset_active_mask;
     memcpy(bridge->snapshot.asset_enabled, bridge->asset_enabled, sizeof(bridge->snapshot.asset_enabled));
 }
@@ -88,12 +94,15 @@ static void osd_external_reset_locked(OsdExternalBridge *bridge) {
         bridge->snapshot.value[i] = 0.0;
     }
     bridge->snapshot.zoom_command[0] = '\0';
+    bridge->snapshot.gamma_command[0] = '\0';
     memset(bridge->snapshot.asset_enabled, 0, sizeof(bridge->snapshot.asset_enabled));
     bridge->snapshot.asset_active_mask = 0;
     bridge->snapshot.zoom_expiry_ns = 0;
+    bridge->snapshot.gamma_expiry_ns = 0;
     bridge->snapshot.last_update_ns = 0;
     bridge->snapshot.expiry_ns = 0;
     bridge->zoom_expiry_ns = 0;
+    bridge->gamma_expiry_ns = 0;
     bridge->asset_active_mask = 0;
     memset(bridge->asset_enabled, 0, sizeof(bridge->asset_enabled));
     memset(bridge->asset_expiry_ns, 0, sizeof(bridge->asset_expiry_ns));
@@ -139,6 +148,11 @@ static void osd_external_expire_locked(OsdExternalBridge *bridge, uint64_t now_n
         bridge->zoom_expiry_ns = 0;
         changed = 1;
     }
+    if (bridge->snapshot.gamma_command[0] != '\0' && bridge->gamma_expiry_ns > 0 && now_ns >= bridge->gamma_expiry_ns) {
+        bridge->snapshot.gamma_command[0] = '\0';
+        bridge->gamma_expiry_ns = 0;
+        changed = 1;
+    }
     for (size_t i = 0; i < OSD_EXTERNAL_MAX_ASSETS; ++i) {
         if ((bridge->asset_active_mask & (1u << i)) && bridge->asset_expiry_ns[i] > 0 && now_ns >= bridge->asset_expiry_ns[i]) {
             bridge->asset_active_mask &= (uint8_t)~(1u << i);
@@ -178,6 +192,8 @@ typedef struct {
     uint64_t ttl_ms;
     char zoom_command[OSD_EXTERNAL_TEXT_LEN];
     int has_zoom;
+    char gamma_command[OSD_EXTERNAL_TEXT_LEN];
+    int has_gamma;
     int has_asset_updates;
     uint8_t asset_mask;
     uint8_t asset_enabled_mask;
@@ -593,6 +609,15 @@ static int parse_message(const char *payload, OsdExternalMessage *msg) {
             }
             snprintf(msg->zoom_command, sizeof(msg->zoom_command), "%s", tmp);
             p = next;
+        } else if (strcmp(key, "gamma") == 0) {
+            msg->has_gamma = 1;
+            char tmp[OSD_EXTERNAL_TEXT_LEN];
+            const char *next = parse_string(p, tmp, sizeof(tmp));
+            if (!next) {
+                return -1;
+            }
+            snprintf(msg->gamma_command, sizeof(msg->gamma_command), "%s", tmp);
+            p = next;
         } else if (strcmp(key, "asset_updates") == 0) {
             msg->has_asset_updates = 1;
             p = parse_asset_updates_array(p, msg);
@@ -780,6 +805,22 @@ static void apply_message(OsdExternalBridge *bridge, const OsdExternalMessage *m
                 bridge->zoom_expiry_ns = 0;
             } else {
                 bridge->zoom_expiry_ns = 0;
+            }
+        }
+    }
+
+    if (msg->has_gamma) {
+        if (strncmp(bridge->snapshot.gamma_command, msg->gamma_command, sizeof(bridge->snapshot.gamma_command)) != 0) {
+            snprintf(bridge->snapshot.gamma_command, sizeof(bridge->snapshot.gamma_command), "%s", msg->gamma_command);
+            changed = 1;
+        }
+        if (has_ttl_field) {
+            if (ttl_ns > 0 && ttl_ns <= UINT64_MAX - now_ns) {
+                bridge->gamma_expiry_ns = now_ns + ttl_ns;
+            } else if (ttl_ns > 0) {
+                bridge->gamma_expiry_ns = 0;
+            } else {
+                bridge->gamma_expiry_ns = 0;
             }
         }
     }

--- a/src/osd_layout.c
+++ b/src/osd_layout.c
@@ -54,7 +54,7 @@ void osd_layout_defaults(OsdLayout *layout) {
         "Record {record.state} active={record.active} dur={record.duration_hms} bytes={record.megabytes}MiB",
         "Pipeline: {pipeline.state} restarts={pipeline.restart_count}{pipeline.audio_suffix}",
         "RTP vpkts={udp.video_packets} net-loss={udp.lost_packets} reo={udp.reordered_packets} dup={udp.duplicate_packets} jitter={udp.jitter.latest_ms}/{udp.jitter.avg_ms}ms",
-        "Frames={udp.frames.count} incomplete={udp.frames.incomplete} last={udp.frames.last_bytes}KB avg={udp.frames.avg_bytes}KB seq={udp.expected_sequence}"
+        "Frames={udp.frames.count} fps={udp.fps.avg} incomplete={udp.frames.incomplete} last={udp.frames.last_bytes}KB avg={udp.frames.avg_bytes}KB seq={udp.expected_sequence}"
     };
     for (size_t i = 0; i < sizeof(default_lines) / sizeof(default_lines[0]) && i < OSD_MAX_TEXT_LINES; ++i) {
         strncpy(text->data.text.lines[text->data.text.line_count].raw, default_lines[i],

--- a/src/pipeline.c
+++ b/src/pipeline.c
@@ -1300,3 +1300,20 @@ void pipeline_apply_ctm_update(PipelineState *ps, const VideoCtmUpdate *update) 
 
     video_decoder_apply_ctm_update(decoder, update);
 }
+
+void pipeline_apply_gamma_update(PipelineState *ps, const VideoGammaUpdate *update) {
+    if (ps == NULL || update == NULL || update->fields == 0) {
+        return;
+    }
+
+    g_mutex_lock(&ps->lock);
+    gboolean decoder_ready = ps->decoder_initialized && ps->decoder != NULL;
+    VideoDecoder *decoder = decoder_ready ? ps->decoder : NULL;
+    g_mutex_unlock(&ps->lock);
+
+    if (!decoder_ready || decoder == NULL) {
+        return;
+    }
+
+    video_decoder_apply_gamma_update(decoder, update);
+}

--- a/src/sse_streamer.c
+++ b/src/sse_streamer.c
@@ -233,7 +233,7 @@ static void format_json_payload(char *buf, size_t buf_sz, const SseStatsSnapshot
                ",\"total_mbytes\":%.2f,\"video_mbytes\":%.2f,\"audio_mbytes\":%.2f"
                ",\"frame_count\":%" G_GUINT64_FORMAT
                ",\"incomplete_frames\":%" G_GUINT64_FORMAT
-               ",\"last_frame_kib\":%.2f,\"avg_frame_kib\":%.2f,\"bitrate_mbps\":%.3f,\"bitrate_avg_mbps\":%.3f"
+               ",\"last_frame_kib\":%.2f,\"avg_frame_kib\":%.2f,\"fps_avg\":%.2f,\"bitrate_mbps\":%.3f,\"bitrate_avg_mbps\":%.3f"
                ",\"jitter_ms\":%.3f,\"jitter_avg_ms\":%.3f,\"expected_sequence\":%u"
                ",\"idr_requests\":%" G_GUINT64_FORMAT
                ",\"recording_enabled\":%s,\"recording_active\":%s,\"recording_duration_s\":%.3f"
@@ -241,7 +241,7 @@ static void format_json_payload(char *buf, size_t buf_sz, const SseStatsSnapshot
                ",\"recording_path\":\"%s\"}",
                snap->total_packets, snap->video_packets, snap->audio_packets, snap->ignored_packets,
                snap->duplicate_packets, snap->lost_packets, snap->reordered_packets, total_mbytes, video_mbytes,
-               audio_mbytes, snap->frame_count, snap->incomplete_frames, last_frame_kib, frame_avg_kib,
+               audio_mbytes, snap->frame_count, snap->incomplete_frames, last_frame_kib, frame_avg_kib, snap->fps_avg,
                snap->bitrate_mbps, snap->bitrate_avg_mbps, snap->jitter_ms, snap->jitter_avg_ms, snap->expected_sequence,
                snap->idr_requests, recording_enabled, recording_active, recording_elapsed_s, recording_media_s,
                recording_mbytes, escaped_path != NULL ? escaped_path : "");
@@ -493,6 +493,7 @@ void sse_streamer_publish(SseStreamer *streamer, const UdpReceiverStats *stats, 
         snap.incomplete_frames = stats->incomplete_frames;
         snap.last_frame_bytes = stats->last_frame_bytes;
         snap.frame_size_avg = stats->frame_size_avg;
+        snap.fps_avg = stats->fps_avg;
         snap.jitter_ms = stats->jitter / 90.0;
         snap.jitter_avg_ms = stats->jitter_avg / 90.0;
         snap.bitrate_mbps = stats->bitrate_mbps;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -44,6 +44,7 @@
 
 #define RTP_MIN_HEADER 12
 #define FRAME_EWMA_ALPHA 0.1
+#define FPS_EWMA_ALPHA 0.1
 #define JITTER_EWMA_ALPHA 0.1
 #define BITRATE_WINDOW_NS 100000000ULL // 100 ms
 #define BITRATE_EWMA_ALPHA 0.1
@@ -102,6 +103,7 @@ struct UdpReceiver {
     guint64 frame_bytes;
     gboolean frame_missing;
     guint64 frame_last_arrival_ns;
+    guint64 last_frame_complete_ns;
 
     gboolean transit_initialized;
     double last_transit;
@@ -372,6 +374,7 @@ static void reset_stats_locked(struct UdpReceiver *ur) {
     ur->frame_bytes = 0;
     ur->frame_missing = FALSE;
     ur->frame_last_arrival_ns = 0;
+    ur->last_frame_complete_ns = 0;
     ur->transit_initialized = FALSE;
     ur->last_transit = 0.0;
     ur->bitrate_window_start_ns = 0;
@@ -501,6 +504,18 @@ static void finalize_frame(struct UdpReceiver *ur, guint64 arrival_ns) {
     } else {
         ur->stats.frame_size_avg += ((double)ur->frame_bytes - ur->stats.frame_size_avg) * FRAME_EWMA_ALPHA;
     }
+    if (ur->last_frame_complete_ns != 0 && arrival_ns > ur->last_frame_complete_ns) {
+        double frame_interval_s = (double)(arrival_ns - ur->last_frame_complete_ns) / 1e9;
+        if (frame_interval_s > 0.0) {
+            double instant_fps = 1.0 / frame_interval_s;
+            if (ur->stats.fps_avg == 0.0) {
+                ur->stats.fps_avg = instant_fps;
+            } else {
+                ur->stats.fps_avg += (instant_fps - ur->stats.fps_avg) * FPS_EWMA_ALPHA;
+            }
+        }
+    }
+    ur->last_frame_complete_ns = arrival_ns;
     if (ur->frame_missing) {
         ur->stats.incomplete_frames++;
         maybe_trigger_idr_loss(ur, arrival_ns);

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -10,6 +10,7 @@
 #include <math.h>
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <sys/ioctl.h>
 #include <time.h>
 #include <unistd.h>
@@ -388,6 +389,19 @@ struct VideoDecoder {
     VideoDecoderZoomRequest zoom_request;
     VideoDecoderZoomRect zoom_rect;
     uint32_t last_committed_fb;
+
+    gboolean gamma_enabled;
+    double gamma_pow;
+    double gamma_lift;
+    double gamma_gain;
+    double gamma_r;
+    double gamma_g;
+    double gamma_b;
+    gboolean gamma_supported;
+    uint32_t prop_gamma_lut;
+    uint32_t prop_gamma_lut_size;
+    uint64_t gamma_lut_size;
+    uint32_t gamma_blob_id;
 
     uint32_t prop_fb_id;
     uint32_t prop_crtc_id;
@@ -1403,6 +1417,128 @@ uint32_t video_decoder_get_plane_id(const VideoDecoder *vd) {
     return vd->plane_id;
 }
 
+static uint16_t gamma_u16_clamp(double value) {
+    if (value <= 0.0) {
+        return 0;
+    }
+    if (value >= 65535.0) {
+        return 65535;
+    }
+    return (uint16_t)lround(value);
+}
+
+static double gamma_unit_clamp(double value) {
+    if (value < 0.0) {
+        return 0.0;
+    }
+    if (value > 1.0) {
+        return 1.0;
+    }
+    return value;
+}
+
+static void video_decoder_gamma_destroy_blob(VideoDecoder *vd) {
+    if (vd == NULL) {
+        return;
+    }
+    if (vd->gamma_blob_id != 0 && vd->drm_fd >= 0) {
+        drmModeDestroyPropertyBlob(vd->drm_fd, vd->gamma_blob_id);
+        vd->gamma_blob_id = 0;
+    }
+}
+
+static int video_decoder_apply_gamma_lut(VideoDecoder *vd) {
+    if (vd == NULL || vd->drm_fd < 0 || vd->crtc_id == 0 || !vd->gamma_supported || vd->prop_gamma_lut == 0 ||
+        vd->gamma_lut_size < 2) {
+        return -1;
+    }
+
+    uint64_t lut_size = vd->gamma_lut_size;
+    struct drm_color_lut *lut = g_new0(struct drm_color_lut, lut_size);
+    if (lut == NULL) {
+        return -1;
+    }
+
+    double gamma_pow = vd->gamma_enabled ? vd->gamma_pow : 1.0;
+    double lift = vd->gamma_enabled ? vd->gamma_lift : 0.0;
+    double gain = vd->gamma_enabled ? vd->gamma_gain : 1.0;
+    double r_mult = vd->gamma_enabled ? vd->gamma_r : 1.0;
+    double g_mult = vd->gamma_enabled ? vd->gamma_g : 1.0;
+    double b_mult = vd->gamma_enabled ? vd->gamma_b : 1.0;
+
+    for (uint64_t i = 0; i < lut_size; ++i) {
+        double x = (double)i / (double)(lut_size - 1);
+        double y = pow(x, gamma_pow);
+        y = (y + lift) * gain;
+        y = gamma_unit_clamp(y);
+
+        double r = gamma_unit_clamp(y * r_mult);
+        double g = gamma_unit_clamp(y * g_mult);
+        double b = gamma_unit_clamp(y * b_mult);
+
+        lut[i].red = gamma_u16_clamp(r * 65535.0);
+        lut[i].green = gamma_u16_clamp(g * 65535.0);
+        lut[i].blue = gamma_u16_clamp(b * 65535.0);
+    }
+
+    uint32_t blob_id = 0;
+    int ret = drmModeCreatePropertyBlob(vd->drm_fd, lut, (size_t)(sizeof(*lut) * lut_size), &blob_id);
+    g_free(lut);
+    if (ret != 0) {
+        return ret;
+    }
+
+    drmModeAtomicReq *req = drmModeAtomicAlloc();
+    if (req == NULL) {
+        drmModeDestroyPropertyBlob(vd->drm_fd, blob_id);
+        return -1;
+    }
+
+    ret = drmModeAtomicAddProperty(req, vd->crtc_id, vd->prop_gamma_lut, blob_id);
+    if (ret < 0) {
+        drmModeAtomicFree(req);
+        drmModeDestroyPropertyBlob(vd->drm_fd, blob_id);
+        return ret;
+    }
+
+    ret = drmModeAtomicCommit(vd->drm_fd, req, 0, NULL);
+    drmModeAtomicFree(req);
+    if (ret != 0) {
+        drmModeDestroyPropertyBlob(vd->drm_fd, blob_id);
+        return ret;
+    }
+
+    video_decoder_gamma_destroy_blob(vd);
+    vd->gamma_blob_id = blob_id;
+    return 0;
+}
+
+void video_decoder_apply_gamma_update(VideoDecoder *vd, const VideoGammaUpdate *update) {
+    if (vd == NULL || update == NULL || update->fields == 0) {
+        return;
+    }
+
+    if ((update->fields & VIDEO_GAMMA_UPDATE_PARAMS) == 0u) {
+        return;
+    }
+
+    vd->gamma_enabled = update->enabled ? TRUE : FALSE;
+    vd->gamma_pow = update->gamma;
+    vd->gamma_lift = update->lift;
+    vd->gamma_gain = update->gain;
+    vd->gamma_r = update->r;
+    vd->gamma_g = update->g;
+    vd->gamma_b = update->b;
+
+    if (!vd->gamma_supported) {
+        return;
+    }
+
+    if (video_decoder_apply_gamma_lut(vd) != 0) {
+        LOGW("Video decoder: failed to apply gamma LUT update");
+    }
+}
+
 void video_decoder_apply_ctm_update(VideoDecoder *vd, const VideoCtmUpdate *update) {
     if (vd == NULL || update == NULL || update->fields == 0) {
         return;
@@ -1456,6 +1592,18 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     vd->mode_w = ms->mode_w;
     vd->mode_h = ms->mode_h;
     video_ctm_init(&vd->ctm, cfg);
+    vd->gamma_enabled = cfg->video_gamma.enable ? TRUE : FALSE;
+    vd->gamma_pow = cfg->video_gamma.gamma;
+    vd->gamma_lift = cfg->video_gamma.lift;
+    vd->gamma_gain = cfg->video_gamma.gain;
+    vd->gamma_r = cfg->video_gamma.r;
+    vd->gamma_g = cfg->video_gamma.g;
+    vd->gamma_b = cfg->video_gamma.b;
+    vd->gamma_supported = FALSE;
+    vd->prop_gamma_lut = 0;
+    vd->prop_gamma_lut_size = 0;
+    vd->gamma_lut_size = 0;
+    vd->gamma_blob_id = 0;
     vd->frame_fourcc = 0;
     vd->frame_hor_stride = 0;
     vd->frame_ver_stride = 0;
@@ -1519,6 +1667,34 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
             LOGI("Video CTM: using DRM %s property on plane %u", name, vd->plane_id);
             have_ctm = TRUE;
         }
+    }
+
+    drmModeObjectProperties *crtc_props = drmModeObjectGetProperties(vd->drm_fd, vd->crtc_id, DRM_MODE_OBJECT_CRTC);
+    if (crtc_props != NULL) {
+        for (uint32_t i = 0; i < crtc_props->count_props; ++i) {
+            drmModePropertyRes *prop = drmModeGetProperty(vd->drm_fd, crtc_props->props[i]);
+            if (prop == NULL) {
+                continue;
+            }
+            if (strcmp(prop->name, "GAMMA_LUT") == 0) {
+                vd->prop_gamma_lut = prop->prop_id;
+            } else if (strcmp(prop->name, "GAMMA_LUT_SIZE") == 0) {
+                vd->prop_gamma_lut_size = prop->prop_id;
+                vd->gamma_lut_size = crtc_props->prop_values[i];
+            }
+            drmModeFreeProperty(prop);
+        }
+        drmModeFreeObjectProperties(crtc_props);
+    }
+
+    if (vd->prop_gamma_lut != 0 && vd->gamma_lut_size >= 2) {
+        vd->gamma_supported = TRUE;
+        LOGI("Video gamma: using DRM GAMMA_LUT on CRTC %u (size=%" PRIu64 ")", vd->crtc_id, vd->gamma_lut_size);
+        if (video_decoder_apply_gamma_lut(vd) != 0) {
+            LOGW("Video gamma: failed to apply startup gamma LUT");
+        }
+    } else if (vd->gamma_enabled) {
+        LOGW("Video gamma: GAMMA_LUT not available on CRTC %u", vd->crtc_id);
     }
 
     // Suppress noisy parser error spam from the Rockchip HEVC decoder; keep only fatal logs.
@@ -1599,6 +1775,8 @@ void video_decoder_deinit(VideoDecoder *vd) {
         g_free(vd->packet_buf);
         vd->packet_buf = NULL;
     }
+
+    video_decoder_gamma_destroy_blob(vd);
 
     if (vd->drm_fd >= 0) {
         close(vd->drm_fd);

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -1513,6 +1513,24 @@ static int video_decoder_apply_gamma_lut(VideoDecoder *vd) {
     return 0;
 }
 
+static void video_decoder_restore_neutral_gamma(VideoDecoder *vd) {
+    if (vd == NULL || !vd->gamma_supported) {
+        return;
+    }
+
+    vd->gamma_enabled = FALSE;
+    vd->gamma_pow = 1.0;
+    vd->gamma_lift = 0.0;
+    vd->gamma_gain = 1.0;
+    vd->gamma_r = 1.0;
+    vd->gamma_g = 1.0;
+    vd->gamma_b = 1.0;
+
+    if (video_decoder_apply_gamma_lut(vd) != 0) {
+        LOGW("Video gamma: failed to restore neutral LUT during shutdown");
+    }
+}
+
 void video_decoder_apply_gamma_update(VideoDecoder *vd, const VideoGammaUpdate *update) {
     if (vd == NULL || update == NULL || update->fields == 0) {
         return;
@@ -1776,6 +1794,7 @@ void video_decoder_deinit(VideoDecoder *vd) {
         vd->packet_buf = NULL;
     }
 
+    video_decoder_restore_neutral_gamma(vd);
     video_decoder_gamma_destroy_blob(vd);
 
     if (vd->drm_fd >= 0) {

--- a/waybeam_hub/README.md
+++ b/waybeam_hub/README.md
@@ -10,7 +10,7 @@ Waybeam Hub is a remote menu driver and WebUI companion for PixelPilot Mini RK. 
 - **Zoom control** — step-based zoom in/out with configurable step size and maximum percentage.
 - **Shell actions from INI** — execute arbitrary shell commands (reboot, record, gamma presets, etc.) defined in a simple INI file.
 - **Radio rule triggers** — fire commands automatically when a CRSF channel value enters a configured range, with debounce and latch logic to prevent accidental repeats.
-- **WebUI** — dark-themed browser dashboard with real-time state display, OSD text/value overrides, asset toggles, zoom, destination management, and debug recording/playback.
+- **WebUI** — dark-themed browser dashboard with real-time state display, OSD text/value overrides, asset toggles, zoom, live gamma LUT sliders, destination management, and debug recording/playback.
 - **Multi-destination UDP** — send OSD payloads to multiple PixelPilot instances simultaneously.
 - **JSON config file** — all settings (including tuning constants) are read from a single JSON file; no CLI flags required.
 
@@ -169,8 +169,12 @@ The WebUI serves `index.html` at the root and exposes a JSON command endpoint:
 {"values": [50.5, null, null, null, null, null, null, null]}
 {"zoom": "150,150,50,50"}
 {"zoom": "off"}
+{"gamma": "0.85,0.00,1.00,1.00,1.00,1.00"}
+{"gamma": "off"}
 {"destinations": [{"host": "10.6.0.50", "port": 7777}]}
 ```
+
+The `OSD Control` tab includes a `Gamma LUT` card with six sliders (`gamma`, `lift`, `gain`, `R`, `G`, `B`) plus `Send Neutral` and `Disable Gamma`. Slider changes are debounced and sent as one-shot external OSD `gamma` commands.
 
 ## OSD text slot layout
 
@@ -203,3 +207,4 @@ line = {ext.text8}
 | `config.json` | Default JSON configuration (all settings and tuning constants) |
 | `index.html` | Browser-based control panel (served by the WebUI) |
 | `menu.ini` | Default menu actions and radio rule definitions |
+| `S99waybeam_hub` | Example init-style startup script for deployment |

--- a/waybeam_hub/S99waybeam_hub
+++ b/waybeam_hub/S99waybeam_hub
@@ -47,7 +47,7 @@ stop() {
     PIDS="$(get_pids)"
     kill $PIDS 2>/dev/null
 
-    for _ in 1 2 3 4 5; do
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
         sleep 0.2
         is_running || { echo "OK"; return 0; }
     done

--- a/waybeam_hub/S99waybeam_hub
+++ b/waybeam_hub/S99waybeam_hub
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Simple control script for waybeam_hub
+
+PYTHON="/usr/bin/python3"
+SCRIPT="/usr/bin/waybeam_hub.py"
+SCRIPT_ARGS="--config /etc/waybeam_hub.json"
+NAME="$(basename "$SCRIPT")"
+
+get_pids() {
+    if command -v pgrep >/dev/null 2>&1; then
+        pgrep -f "^$PYTHON[[:space:]]+$SCRIPT([[:space:]]|$)"
+    else
+        ps | grep "$SCRIPT" | grep -v grep | awk '{print $1}'
+    fi
+}
+
+is_running() {
+    [ -n "$(get_pids)" ]
+}
+
+start() {
+    if is_running; then
+        echo "$NAME already running (PIDs: $(get_pids))"
+        return 0
+    fi
+
+    echo -n "Starting $NAME: "
+    "$PYTHON" "$SCRIPT" $SCRIPT_ARGS >/dev/null 2>&1 &
+    sleep 0.2
+
+    if is_running; then
+        echo "OK (PIDs: $(get_pids))"
+        return 0
+    else
+        echo "FAIL"
+        return 1
+    fi
+}
+
+stop() {
+    if ! is_running; then
+        echo "$NAME is not running"
+        return 0
+    fi
+
+    echo -n "Stopping $NAME: "
+    PIDS="$(get_pids)"
+    kill $PIDS 2>/dev/null
+
+    for _ in 1 2 3 4 5; do
+        sleep 0.2
+        is_running || { echo "OK"; return 0; }
+    done
+
+    kill -9 $(get_pids) 2>/dev/null
+    sleep 0.2
+    is_running && { echo "FAIL"; return 1; }
+    echo "OK"
+    return 0
+}
+
+restart() {
+    stop
+    sleep 0.2
+    start
+}
+
+case "$1" in
+    start) start ;;
+    stop) stop ;;
+    restart) restart ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+        ;;
+esac

--- a/waybeam_hub/index.html
+++ b/waybeam_hub/index.html
@@ -275,6 +275,12 @@
       padding: 0;
     }
 
+    .gamma-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(220px, 1fr));
+      gap: 10px;
+    }
+
     .inline-value {
       color: var(--primary);
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -330,6 +336,7 @@
       .asset-grid { grid-template-columns: repeat(2, minmax(120px, 1fr)); }
       .crsf-grid { grid-template-columns: repeat(2, minmax(120px, 1fr)); }
       .index-grid { grid-template-columns: repeat(2, minmax(120px, 1fr)); }
+      .gamma-grid { grid-template-columns: 1fr; }
       input, select { width: 100%; }
     }
   </style>
@@ -457,12 +464,48 @@
 
       <div class="card">
         <h3>OSD Request Recorder <span id="debug-record-pill" class="pill off">OFF</span></h3>
-        <p class="dest-meta">Records the last 10 OSD update requests sent from this WebUI (`values`, `texts`, `asset_updates`, `all_on`, `all_off`).</p>
+        <p class="dest-meta">Records the last 10 OSD update requests sent from this WebUI (`values`, `texts`, `asset_updates`, `gamma`, `all_on`, `all_off`).</p>
         <div class="row" style="margin-top:10px;">
           <button type="button" id="debug-record-toggle" class="alt">Start Recording</button>
           <button type="button" id="debug-clear" class="ghost">Clear</button>
         </div>
         <div id="debug-log" class="state debug-log" style="margin-top:10px;">Recording is OFF.</div>
+      </div>
+
+      <div class="card">
+        <h3>Gamma LUT</h3>
+        <p class="dest-meta">Send live `gamma` overrides to the selected OSD destinations. Slider changes auto-send after a short debounce.</p>
+        <div id="gamma-summary" class="state" style="margin-top:10px;">Live gamma override is OFF.</div>
+        <div class="row" style="margin-top:10px;">
+          <button type="button" id="gamma-neutral" class="ghost">Send Neutral</button>
+          <button type="button" id="gamma-off" class="danger">Disable Gamma</button>
+        </div>
+        <div class="gamma-grid" style="margin-top:10px;">
+          <div class="slider-row">
+            <label for="gamma-gamma-slider">Gamma <span id="gamma-gamma-readout" class="inline-value">1.00</span></label>
+            <input id="gamma-gamma-slider" type="range" min="0.20" max="5.00" step="0.01" value="1.00" />
+          </div>
+          <div class="slider-row">
+            <label for="gamma-lift-slider">Lift <span id="gamma-lift-readout" class="inline-value">0.00</span></label>
+            <input id="gamma-lift-slider" type="range" min="-0.50" max="0.50" step="0.01" value="0.00" />
+          </div>
+          <div class="slider-row">
+            <label for="gamma-gain-slider">Gain <span id="gamma-gain-readout" class="inline-value">1.00</span></label>
+            <input id="gamma-gain-slider" type="range" min="0.50" max="1.50" step="0.01" value="1.00" />
+          </div>
+          <div class="slider-row">
+            <label for="gamma-r-slider">Red <span id="gamma-r-readout" class="inline-value">1.00</span></label>
+            <input id="gamma-r-slider" type="range" min="0.50" max="1.50" step="0.01" value="1.00" />
+          </div>
+          <div class="slider-row">
+            <label for="gamma-g-slider">Green <span id="gamma-g-readout" class="inline-value">1.00</span></label>
+            <input id="gamma-g-slider" type="range" min="0.50" max="1.50" step="0.01" value="1.00" />
+          </div>
+          <div class="slider-row">
+            <label for="gamma-b-slider">Blue <span id="gamma-b-readout" class="inline-value">1.00</span></label>
+            <input id="gamma-b-slider" type="range" min="0.50" max="1.50" step="0.01" value="1.00" />
+          </div>
+        </div>
       </div>
     </section>
 
@@ -519,6 +562,24 @@ const ASSET_UPDATE_PROPERTY_DEFS = [
   { key: 'rounded_outline', label: 'rounded_outline', kind: 'bool', help: 'Rounded outline/background style.' },
 ];
 const ASSET_UPDATE_PROPERTY_MAP = new Map(ASSET_UPDATE_PROPERTY_DEFS.map((item) => [item.key, item]));
+const GAMMA_CONTROL_DEFS = [
+  { key: 'gamma', label: 'Gamma', min: 0.20, max: 5.00, step: 0.01, defaultValue: 1.00, digits: 2 },
+  { key: 'lift', label: 'Lift', min: -0.50, max: 0.50, step: 0.01, defaultValue: 0.00, digits: 2 },
+  { key: 'gain', label: 'Gain', min: 0.50, max: 1.50, step: 0.01, defaultValue: 1.00, digits: 2 },
+  { key: 'r', label: 'Red', min: 0.50, max: 1.50, step: 0.01, defaultValue: 1.00, digits: 2 },
+  { key: 'g', label: 'Green', min: 0.50, max: 1.50, step: 0.01, defaultValue: 1.00, digits: 2 },
+  { key: 'b', label: 'Blue', min: 0.50, max: 1.50, step: 0.01, defaultValue: 1.00, digits: 2 },
+];
+const GAMMA_CONTROL_MAP = new Map(GAMMA_CONTROL_DEFS.map((item) => [item.key, item]));
+const GAMMA_DEFAULT_STATE = Object.freeze({
+  enabled: false,
+  gamma: 1.00,
+  lift: 0.00,
+  gain: 1.00,
+  r: 1.00,
+  g: 1.00,
+  b: 1.00,
+});
 
 let baseUrl = '';
 let pollTimer = null;
@@ -532,8 +593,11 @@ let textIndexSelection = new Set(Array.from({ length: MAX_OSD_SLOTS }, (_item, i
 let assetUpdateIdSelection = new Set([0]);
 let valueSendTimer = null;
 let textSendTimer = null;
+let gammaSendTimer = null;
 let lastValuePayloadSignature = '';
 let lastTextPayloadSignature = '';
+let lastGammaPayloadSignature = '';
+let gammaUiSyncHoldUntil = 0;
 let osdSenderMode = 'value';
 let assetButtonStates = [];
 let assetButtonsInitialized = false;
@@ -576,6 +640,7 @@ function isOsdUpdateCommand(obj){
   if (Array.isArray(obj.values)) return true;
   if (Array.isArray(obj.texts)) return true;
   if (Array.isArray(obj.asset_updates) && obj.asset_updates.length > 0) return true;
+  if (typeof obj.gamma === 'string') return true;
   if (obj.key === 'all_on' || obj.key === 'all_off') return true;
   return false;
 }
@@ -671,6 +736,10 @@ function commandPartTexts(texts){
 
 function commandPartAssetUpdates(assetUpdates){
   return { asset_updates: assetUpdates };
+}
+
+function commandPartGamma(gammaCommand){
+  return { gamma: gammaCommand };
 }
 
 function sortSelectedIndexes(selectedIndexes){
@@ -882,6 +951,101 @@ function setIndexSelection(selectedIndexes, enabled){
   if (enabled) {
     for (let index = 0; index < MAX_OSD_SLOTS; index += 1) selectedIndexes.add(index);
   }
+}
+
+function clampGammaControlValue(key, rawValue){
+  const def = GAMMA_CONTROL_MAP.get(key);
+  if (!def) return 0;
+  const parsed = Number(rawValue);
+  const fallback = def.defaultValue;
+  const baseValue = Number.isFinite(parsed) ? parsed : fallback;
+  const clamped = Math.max(def.min, Math.min(def.max, baseValue));
+  const factor = 10 ** def.digits;
+  return Math.round(clamped * factor) / factor;
+}
+
+function formatGammaControlValue(key, value){
+  const def = GAMMA_CONTROL_MAP.get(key);
+  if (!def) return String(value);
+  return clampGammaControlValue(key, value).toFixed(def.digits);
+}
+
+function setGammaControlValue(key, value){
+  const slider = document.getElementById(`gamma-${key}-slider`);
+  const readout = document.getElementById(`gamma-${key}-readout`);
+  const normalized = clampGammaControlValue(key, value);
+  const formatted = formatGammaControlValue(key, normalized);
+  slider.value = formatted;
+  readout.textContent = formatted;
+  return normalized;
+}
+
+function buildGammaCommandFromState(state){
+  if (!state || state.enabled !== true) return 'off';
+  return GAMMA_CONTROL_DEFS
+    .map((def) => formatGammaControlValue(def.key, state[def.key]))
+    .join(',');
+}
+
+function normalizeGammaState(rawState){
+  const normalized = { ...GAMMA_DEFAULT_STATE };
+  if (rawState && typeof rawState === 'object') {
+    normalized.enabled = rawState.enabled === true;
+    GAMMA_CONTROL_DEFS.forEach((def) => {
+      normalized[def.key] = clampGammaControlValue(def.key, rawState[def.key]);
+    });
+  }
+  return normalized;
+}
+
+function applyGammaStateToControls(state){
+  const normalized = normalizeGammaState(state);
+  GAMMA_CONTROL_DEFS.forEach((def) => {
+    normalized[def.key] = setGammaControlValue(def.key, normalized[def.key]);
+  });
+  const preview = buildGammaCommandFromState({ ...normalized, enabled: true });
+  const summary = document.getElementById('gamma-summary');
+  summary.textContent = normalized.enabled
+    ? `Live gamma override is ON.\nCommand: ${preview}`
+    : `Live gamma override is OFF.\nPreset: ${preview}`;
+  return normalized;
+}
+
+function getGammaStateFromControls(){
+  const state = { enabled: true };
+  GAMMA_CONTROL_DEFS.forEach((def) => {
+    state[def.key] = setGammaControlValue(def.key, document.getElementById(`gamma-${def.key}-slider`).value);
+  });
+  return state;
+}
+
+function sendGammaState(state){
+  const normalized = applyGammaStateToControls(state);
+  const command = buildGammaCommandFromState(normalized);
+  const signature = JSON.stringify({ gamma: command });
+  if (signature === lastGammaPayloadSignature) return;
+  lastGammaPayloadSignature = signature;
+  gammaUiSyncHoldUntil = Date.now() + 750;
+  send(composeCommandPayload([commandPartGamma(command)]));
+}
+
+function scheduleGammaSend(){
+  if (gammaSendTimer) clearTimeout(gammaSendTimer);
+  gammaSendTimer = setTimeout(() => {
+    gammaSendTimer = null;
+    sendGammaState({ ...getGammaStateFromControls(), enabled: true });
+  }, 90);
+}
+
+function isGammaControlActive(){
+  const active = document.activeElement;
+  if (!active) return false;
+  return GAMMA_CONTROL_DEFS.some((def) => active.id === `gamma-${def.key}-slider`);
+}
+
+function syncGammaControlsFromState(state){
+  if (Date.now() < gammaUiSyncHoldUntil || isGammaControlActive()) return;
+  applyGammaStateToControls(normalizeGammaState(state && state.gamma_control));
 }
 
 function updateValueReadout(){
@@ -1297,6 +1461,7 @@ function renderState(state){
   const txBatch = Number.isFinite(tx.last_batch_size) ? tx.last_batch_size : 0;
   document.getElementById('asset-tx-summary').textContent = `Asset updates tx: count=${txCount} last=${txLastAge} batch=${txBatch}`;
   syncAssetsFromStateIfNeeded(state);
+  syncGammaControlsFromState(state);
 }
 
 document.getElementById('tab-btn-menu').onclick = () => { setActiveTab('menu'); };
@@ -1364,6 +1529,21 @@ document.getElementById('asset-prop-select').onkeydown = (event) => {
   if (event.key === 'Enter') applyAssetPropertyUpdate();
 };
 
+GAMMA_CONTROL_DEFS.forEach((def) => {
+  document.getElementById(`gamma-${def.key}-slider`).oninput = () => {
+    setGammaControlValue(def.key, document.getElementById(`gamma-${def.key}-slider`).value);
+    scheduleGammaSend();
+  };
+});
+
+document.getElementById('gamma-neutral').onclick = () => {
+  sendGammaState({ ...GAMMA_DEFAULT_STATE, enabled: true });
+};
+
+document.getElementById('gamma-off').onclick = () => {
+  sendGammaState({ ...getGammaStateFromControls(), enabled: false });
+};
+
 document.getElementById('add-destination').onclick = () => {
   const host = document.getElementById('dest-host').value.trim();
   const port = Number(document.getElementById('dest-port').value.trim());
@@ -1411,6 +1591,7 @@ document.getElementById('debug-clear').onclick = () => {
   renderIndexSelectors('text-indexes', textIndexSelection, 'Text index', scheduleTextIndexesSend);
   renderAssetUpdateIdSelectors();
   updateValueReadout();
+  applyGammaStateToControls(GAMMA_DEFAULT_STATE);
   setOsdSenderMode('value');
   setDebugRecording(false);
   setActiveTab('menu');

--- a/waybeam_hub/waybeam_hub.py
+++ b/waybeam_hub/waybeam_hub.py
@@ -69,6 +69,19 @@ KEY_MENU_TOGGLE = -1002
 SSE_SOURCES = ("serial", "joystick")
 DEFAULT_EXTRA_DESTINATION = "10.6.0.50:7777"
 
+GAMMA_DEFAULT = 1.0
+GAMMA_LIFT_DEFAULT = 0.0
+GAMMA_GAIN_DEFAULT = 1.0
+GAMMA_CHANNEL_DEFAULT = 1.0
+GAMMA_MIN = 0.20
+GAMMA_MAX = 5.00
+GAMMA_LIFT_MIN = -0.50
+GAMMA_LIFT_MAX = 0.50
+GAMMA_GAIN_MIN = 0.50
+GAMMA_GAIN_MAX = 1.50
+GAMMA_CHANNEL_MIN = 0.50
+GAMMA_CHANNEL_MAX = 1.50
+
 
 @dataclass(frozen=True)
 class UdpDestination:
@@ -618,6 +631,68 @@ def current_zoom_command(zoom_enabled: bool, zoom_percent: int) -> str:
     return f"{zoom_percent},{zoom_percent},50,50"
 
 
+def _format_gamma_value(value: float) -> str:
+    return f"{value:.2f}"
+
+
+def current_gamma_command(
+    gamma_enabled: bool,
+    gamma_value: float,
+    gamma_lift: float,
+    gamma_gain: float,
+    gamma_r: float,
+    gamma_g: float,
+    gamma_b: float,
+) -> str:
+    if not gamma_enabled:
+        return "off"
+    values = (
+        gamma_value,
+        gamma_lift,
+        gamma_gain,
+        gamma_r,
+        gamma_g,
+        gamma_b,
+    )
+    return ",".join(_format_gamma_value(value) for value in values)
+
+
+def parse_gamma_command(command: str) -> Tuple[bool, Optional[Tuple[float, float, float, float, float, float]]]:
+    value = command.strip()
+    if not value:
+        return False, None
+
+    lowered = value.lower()
+    if lowered in ("off", "gamma=off"):
+        return False, None
+    if lowered.startswith("gamma="):
+        value = value[6:]
+
+    parts = [part.strip() for part in value.split(",")]
+    if len(parts) != 6 or any(part == "" for part in parts):
+        raise ValueError("expected gamma command as GAMMA,LIFT,GAIN,R,G,B")
+
+    try:
+        gamma_value, gamma_lift, gamma_gain, gamma_r, gamma_g, gamma_b = (float(part) for part in parts)
+    except ValueError as exc:
+        raise ValueError("gamma command contains non-numeric values") from exc
+
+    if not (GAMMA_MIN <= gamma_value <= GAMMA_MAX):
+        raise ValueError(f"gamma must be between {GAMMA_MIN:.2f} and {GAMMA_MAX:.2f}")
+    if not (GAMMA_LIFT_MIN <= gamma_lift <= GAMMA_LIFT_MAX):
+        raise ValueError(f"lift must be between {GAMMA_LIFT_MIN:.2f} and {GAMMA_LIFT_MAX:.2f}")
+    if not (GAMMA_GAIN_MIN <= gamma_gain <= GAMMA_GAIN_MAX):
+        raise ValueError(f"gain must be between {GAMMA_GAIN_MIN:.2f} and {GAMMA_GAIN_MAX:.2f}")
+    if not (GAMMA_CHANNEL_MIN <= gamma_r <= GAMMA_CHANNEL_MAX):
+        raise ValueError(f"R must be between {GAMMA_CHANNEL_MIN:.2f} and {GAMMA_CHANNEL_MAX:.2f}")
+    if not (GAMMA_CHANNEL_MIN <= gamma_g <= GAMMA_CHANNEL_MAX):
+        raise ValueError(f"G must be between {GAMMA_CHANNEL_MIN:.2f} and {GAMMA_CHANNEL_MAX:.2f}")
+    if not (GAMMA_CHANNEL_MIN <= gamma_b <= GAMMA_CHANNEL_MAX):
+        raise ValueError(f"B must be between {GAMMA_CHANNEL_MIN:.2f} and {GAMMA_CHANNEL_MAX:.2f}")
+
+    return True, (gamma_value, gamma_lift, gamma_gain, gamma_r, gamma_g, gamma_b)
+
+
 def build_payload(menu_window: Tuple[str, str, str], zoom_enabled: bool, zoom_percent: int) -> dict:
     texts: List[Optional[str]] = [None] * MAX_OSD_SLOTS
     texts[MENU_TEXT_SLOT_START + 0] = clamp_text(menu_window[0])
@@ -1145,6 +1220,13 @@ def build_webui_state(
     asset_enabled: Sequence[Optional[bool]],
     zoom_enabled: bool,
     zoom_percent: int,
+    gamma_enabled: bool,
+    gamma_value: float,
+    gamma_lift: float,
+    gamma_gain: float,
+    gamma_r: float,
+    gamma_g: float,
+    gamma_b: float,
     destinations: Sequence[UdpDestination],
     source_states: Mapping[str, SourceInputState],
     active_source: Optional[str],
@@ -1188,6 +1270,24 @@ def build_webui_state(
         "status": status,
         "asset_enabled": list(asset_enabled),
         "zoom": current_zoom_command(zoom_enabled, zoom_percent),
+        "gamma": current_gamma_command(
+            gamma_enabled,
+            gamma_value,
+            gamma_lift,
+            gamma_gain,
+            gamma_r,
+            gamma_g,
+            gamma_b,
+        ),
+        "gamma_control": {
+            "enabled": gamma_enabled,
+            "gamma": gamma_value,
+            "lift": gamma_lift,
+            "gain": gamma_gain,
+            "r": gamma_r,
+            "g": gamma_g,
+            "b": gamma_b,
+        },
         "destinations": [{"host": destination.host, "port": destination.port} for destination in destinations],
         "asset_update_tx": {
             "count": asset_update_tx_count,
@@ -1246,7 +1346,9 @@ def run_controller(
     STOP_REQUESTED = False
 
     prev_sigint = signal.getsignal(signal.SIGINT)
+    prev_sigterm = signal.getsignal(signal.SIGTERM)
     signal.signal(signal.SIGINT, _on_sigint)
+    signal.signal(signal.SIGTERM, _on_sigint)
 
     def emit_status(message: str) -> None:
         print(f"[{time.strftime('%H:%M:%S')}] {message}", flush=True)
@@ -1264,6 +1366,13 @@ def run_controller(
 
         zoom_enabled = False
         zoom_percent = 100
+        gamma_enabled = False
+        gamma_value = GAMMA_DEFAULT
+        gamma_lift = GAMMA_LIFT_DEFAULT
+        gamma_gain = GAMMA_GAIN_DEFAULT
+        gamma_r = GAMMA_CHANNEL_DEFAULT
+        gamma_g = GAMMA_CHANNEL_DEFAULT
+        gamma_b = GAMMA_CHANNEL_DEFAULT
         top_entries = build_top_entries(action_sections)
         submenu_table = build_submenu_table(action_sections, actions_by_section)
         fallback_entries = [MenuEntry(kind="return")]
@@ -1282,9 +1391,11 @@ def run_controller(
         manual_text_overrides: List[Optional[str]] = [None] * MAX_OSD_SLOTS
         manual_value_overrides: List[Optional[float]] = [None] * MAX_OSD_SLOTS
         manual_asset_updates: List[dict] = []
+        manual_gamma_command = ""
         manual_text_overrides_pending = False
         manual_value_overrides_pending = False
         manual_asset_updates_pending = False
+        manual_gamma_pending = False
         asset_update_tx_count = 0
         asset_update_tx_last_monotonic = 0.0
         asset_update_tx_last_batch_size = 0
@@ -1430,6 +1541,36 @@ def run_controller(
                             elif manual_asset_updates_pending:
                                 manual_asset_updates_pending = False
 
+                        gamma_command = message.get("gamma")
+                        if isinstance(gamma_command, str):
+                            try:
+                                parsed_gamma_enabled, parsed_gamma_values = parse_gamma_command(gamma_command)
+                            except ValueError as exc:
+                                status = f"Ignored invalid gamma command: {exc}"
+                            else:
+                                gamma_enabled = parsed_gamma_enabled
+                                if parsed_gamma_values is not None:
+                                    (
+                                        gamma_value,
+                                        gamma_lift,
+                                        gamma_gain,
+                                        gamma_r,
+                                        gamma_g,
+                                        gamma_b,
+                                    ) = parsed_gamma_values
+                                manual_gamma_command = current_gamma_command(
+                                    gamma_enabled,
+                                    gamma_value,
+                                    gamma_lift,
+                                    gamma_gain,
+                                    gamma_r,
+                                    gamma_g,
+                                    gamma_b,
+                                )
+                                manual_gamma_pending = True
+                                last_menu_activity_monotonic = time.monotonic()
+                                dirty = True
+
                         if isinstance(message.get("destinations"), list):
                             destination_payload = message["destinations"]
                             requested_destinations = [
@@ -1535,6 +1676,13 @@ def run_controller(
                             asset_enabled,
                             zoom_enabled,
                             zoom_percent,
+                            gamma_enabled,
+                            gamma_value,
+                            gamma_lift,
+                            gamma_gain,
+                            gamma_r,
+                            gamma_g,
+                            gamma_b,
                             destinations,
                             source_states,
                             active_source,
@@ -1553,6 +1701,7 @@ def run_controller(
                         applied_value_overrides = False
                         applied_state_asset_updates = False
                         applied_asset_updates = False
+                        applied_gamma = False
 
                         if pending_asset_updates:
                             payload["asset_updates"] = [
@@ -1588,6 +1737,10 @@ def run_controller(
                             payload["asset_updates"] = merged_updates
                             applied_asset_updates = True
 
+                        if manual_gamma_pending and manual_gamma_command:
+                            payload["gamma"] = manual_gamma_command
+                            applied_gamma = True
+
                         failures = send_payloads(sock, destinations, payload)
                         last_send_monotonic = now
                         if failures:
@@ -1606,6 +1759,8 @@ def run_controller(
                                 pending_asset_updates.clear()
                             if applied_asset_updates:
                                 manual_asset_updates_pending = False
+                            if applied_gamma:
+                                manual_gamma_pending = False
                             dirty = False
 
                     if status != last_logged_status:
@@ -1732,6 +1887,7 @@ def run_controller(
         return 0
     finally:
         signal.signal(signal.SIGINT, prev_sigint)
+        signal.signal(signal.SIGTERM, prev_sigterm)
 
 
 _CONFIG_DEFAULTS: Dict[str, object] = {


### PR DESCRIPTION
### Motivation
- Expose live DRM gamma/LUT adjustments via the external OSD UDP control path so display gamma can be tuned remotely without restarting the pipeline.
- Add a live Waybeam Hub control surface for the new gamma command and ensure normal shutdown restores a neutral LUT.
- Surface averaged FPS telemetry in the OSD/SSE stats alongside bitrate, jitter, and frame counters.

### Description
- Protocol and config: add `gamma` to the external OSD protocol docs, add sample `[video.gamma]` config, and parse/store startup gamma settings.
- External feed and pipeline: extend the external OSD snapshot/parser for `gamma`, validate `gamma=GAMMA,LIFT,GAIN,R,G,B` or `gamma=off` in the main loop, and route updates through `pipeline_apply_gamma_update` to the decoder.
- DRM gamma: detect `GAMMA_LUT` support, build/apply LUT blobs, and on normal/graceful shutdown restore a neutral LUT before tearing DRM down.
- Waybeam Hub: add a Gamma LUT card to the `OSD Control` tab with six sliders plus `Send Neutral` / `Disable Gamma`, forward gamma commands through the existing `/command` flow, and add an init-style `S99waybeam_hub` launcher plus `SIGTERM` handling for graceful stop.
- Telemetry: add `udp.fps.avg` as an EWMA of completed-frame cadence, expose it to OSD tokens/metrics and SSE, and include it in the sample/default OSD text.

### Testing
- Manual verification: gamma control was tested live remotely and confirmed working.
- Python verification: `python3 -m py_compile waybeam_hub/waybeam_hub.py`
- Shell verification: `sh -n waybeam_hub/S99waybeam_hub`
- Diff hygiene: `git diff --check`
- Build attempt: `make` was run, but this environment still fails on missing `rockchip/rk_mpi.h`, so I could not verify a full local build here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e76778f4832bb30c0f7163ec6b25)