### PR TITLE
Add configurable decoder error policy and latency tuning knobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,4 @@ Use pre-commit hooks or post-tool-use hooks to enforce formatting and linting au
 - OSD asset IDs must be unique across all `[osd.element.*]` sections (range 0–7).
 - SSE shutdown requires atomic flag checks to avoid race conditions — use GLib atomics, not bare booleans.
 - Any init/service stop timeout must exceed the application's internal graceful-shutdown waits (for example thread join timeouts), or the supervisor will SIGKILL the process before cleanup runs.
+- OSD `udp.fps.avg` should be derived from a rolling frame-count/time window (for example 1s), not direct reciprocal-of-interval EWMA, to avoid unrealistic spikes from bursty packet timing.

--- a/config/config_advanced.conf
+++ b/config/config_advanced.conf
@@ -23,6 +23,14 @@ custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
 
+[decoder]
+; Decoder error policy: strict (drop bad frames) or partial (show artifacts to keep motion)
+error-mode = partial
+; Latency tuning knobs (safe defaults)
+feed-retry-us = 2000
+idle-sleep-us = 1000
+output-timeout-us = 5000
+
 [idr]
 ; Automatic HTTP trigger for forced IDR recovery.
 enable = true

--- a/config/pixelpilot_mini.ini
+++ b/config/pixelpilot_mini.ini
@@ -23,6 +23,14 @@ custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
 
+[decoder]
+; Decoder error policy: strict (drop bad frames) or partial (show artifacts to keep motion)
+error-mode = partial
+; Latency tuning knobs (safe defaults)
+feed-retry-us = 2000
+idle-sleep-us = 1000
+output-timeout-us = 5000
+
 [idr]
 ; Automatic HTTP trigger for forced IDR recovery.
 enable = true

--- a/config/pixelpilot_mini_waybeam.ini
+++ b/config/pixelpilot_mini_waybeam.ini
@@ -20,6 +20,14 @@ custom-sink = receiver
 ; Disable to allow all RTP payload types through udpsrc (reduces CPU usage).
 pt97-filter = true
 
+[decoder]
+; Decoder error policy: strict (drop bad frames) or partial (show artifacts to keep motion)
+error-mode = partial
+; Latency tuning knobs (safe defaults)
+feed-retry-us = 2000
+idle-sleep-us = 1000
+output-timeout-us = 5000
+
 [idr]
 ; Automatic HTTP trigger for forced IDR recovery.
 enable = true

--- a/docs/custom-mpp-decoder-analysis.md
+++ b/docs/custom-mpp-decoder-analysis.md
@@ -1,0 +1,139 @@
+# Custom MPP Decoder Deep Analysis (pixelpilot_mini_rk)
+
+## Scope
+This analysis focuses on the custom Rockchip MPP video path in this repository (`src/video_decoder.c` + pipeline feed path), compares it with OpenIPC PixelPilot_rk, and proposes concrete latency/reliability improvements.
+
+## 1) Current decoder architecture in this repo
+
+### Data path and thread model
+- Compressed access units arrive through GStreamer (`appsink`) and are read from `appsink_thread_func`.
+- Each sample is sent to `video_decoder_feed`, which writes into a reusable 1 MiB packet buffer and calls `decode_put_packet`.
+- Decoded frames are polled in `frame_thread_func` via `decode_get_frame`.
+- Display commits are decoupled in `display_thread_func`, where only the latest pending framebuffer ID is committed atomically to DRM.
+
+### External DRM buffer group strategy
+- On decoder info-change events, the code allocates an external DRM-backed MPP frame group (`MPP_BUFFER_TYPE_DRM`) and binds each committed MPP buffer to a DRM framebuffer (`drmModeAddFB2` NV12).
+- This is a zero-copy display path (MPP -> DRM plane with PRIME FDs).
+
+### Decoder configuration choices
+The decoder enables settings tuned for low-latency recovery behavior:
+- `base:split_parse = 1`
+- `MPP_DEC_SET_DISABLE_ERROR = 0xffff`
+- `MPP_DEC_SET_IMMEDIATE_OUT = 0xffff`
+- `MPP_DEC_SET_ENABLE_FAST_PLAY = 0xffff`
+- output wait is short (`MPP_SET_OUTPUT_TIMEOUT` around 5 ms, or short block timeout fallback)
+
+### Error handling behavior today
+- In `frame_thread_func`, any frame with `errinfo` OR `discard` is dropped early.
+- On drop, IDR requester warning hook is triggered to recover stream state.
+- Net effect: conservative visual integrity (no obviously corrupted frames), but can create visible stutter/black gaps under burst loss.
+
+### Upstream queue behavior and end-to-end latency
+- Appsink is configured with `drop=true`, small max-buffers (default 4).
+- UDP queue uses leaky mode (`leaky=2`), limiting backlog buildup.
+- These are good low-latency defaults, but can increase packet/sample loss during transient stalls.
+
+## 2) Comparison with OpenIPC/PixelPilot_rk decoder
+
+## Core similarities
+- Same fundamental MPP external-buffer architecture (`READ_BUF_SIZE=1 MiB`, `MAX_FRAMES=24`, external DRM group, info-change realloc).
+- Similar MPP tuning (`split_parse`, disable_error, immediate_out, fast_play).
+- Similar dual-thread decode/display model.
+
+## Key behavior difference: handling decoder-error-marked frames
+In OpenIPC `src/main.cpp` frame loop:
+- It inspects `errinfo`/`discard` and may trigger IDR requests.
+- But it does **not** unconditionally skip posting those frames to display.
+- It still maps the MPP buffer and commits the framebuffer, which allows “partial decode” presentation (possible block corruption/green artifacts) instead of immediate frame drop.
+
+In this repo (`src/video_decoder.c`):
+- `errinfo || discard` causes immediate drop and `continue`.
+- That avoids artifacts but increases freeze risk when reference chain is damaged and keyframes are sparse.
+
+## Reliability mechanism differences
+OpenIPC additionally leans on:
+- RTP gap-driven IDR triggers in `gstrtpreceiver.cpp`.
+- Decoder-feed stall detection with repeated retry timeout and conditional IDR request.
+
+This repo already has strong IDR infrastructure (`IdrRequester`, jitter/loss trigger options in config), but frame-level policy remains stricter (drop-on-any-error).
+
+## 3) Partial decode evaluation
+
+## Why partial decode can feel better in FPV
+For FPV UX, a temporally continuous but locally corrupted frame is often preferable to a frozen frame because:
+- pilot perception favors motion continuity,
+- control loop confidence is better with “imperfect now” than “perfect old frame,”
+- short corruption windows can self-heal after the next reference refresh.
+
+## How OpenIPC effectively does it
+Not via an explicit “partial decode mode” API, but by policy:
+- decoder outputs frames,
+- app logs error flags and requests IDR,
+- frame is still displayed when a buffer exists.
+
+This turns decoder error flags into a recovery signal instead of a hard display veto.
+
+## How to implement safely in this repo
+Introduce a configurable policy rather than replacing current behavior globally.
+
+### Proposed policy modes
+1. `strict`: drop any `errinfo || discard` frame.
+2. `partial` (recommended default): present decoder-flagged frames (possible artifacts) while still triggering IDR recovery.
+
+### Guardrails for reliability
+- Keep IDR trigger on any decoder issue.
+- Add rate limit to warning logs and IDR requests to avoid storms.
+- Track `last_good_commit_ms`, `consecutive_decoder_issues`, and `time_since_last_present`.
+- If partial mode enabled, prefer only one of:
+  - display every error frame (max continuity), or
+  - display at limited cadence (e.g., 15–30 fps cap) to reduce visual noise.
+
+### Suggested implementation points
+- `include/config.h` / `src/config.c`: add decoder error policy config enum and thresholds.
+- `src/video_decoder.c` (`frame_thread_func`): replace unconditional drop branch with policy gate.
+- Existing `IdrRequester` hook remains unchanged; call it in both dropped and displayed-error paths.
+- Extend stats exposure for OSD/debug (`decoder.err_frames`, `decoder.dropped_frames`, `decoder.partial_displayed_frames`).
+
+## 4) Latency improvement opportunities (prioritized)
+
+1. Reduce `video_decoder_feed` retry sleep from fixed 2 ms to bounded backoff + immediate retry first.
+   - Current fixed sleep can add avoidable jitter under short buffer-full bursts.
+2. Consider reducing appsink max buffers from 4 -> 2 for ultra-low-latency presets.
+   - Keep 4 as default if users report instability.
+3. Add “latest-only” semantics between frame thread and display thread.
+   - Already close to this (`pending_fb` overwrite); ensure old pending frame is always replaced atomically before commit.
+4. Optional: thread priority tuning for decode and appsink feeder threads.
+   - Keep bounded to avoid starving networking/OSD.
+
+## 5) Reliability improvement opportunities (prioritized)
+
+1. Add strict/partial decoder policy as a config option and make `partial` the default.
+2. Add decode starvation detector in this repo mirroring OpenIPC’s feed-stall logic.
+   - If no successful present for X ms while data continues, trigger IDR.
+3. Add per-minute counters and moving-window metrics:
+   - decode_put_packet busy retries,
+   - errinfo/discard counts,
+   - time-to-recover after IDR request.
+4. Introduce optional periodic IDR keepalive in very lossy RF conditions (low rate, e.g., every 1–2 s, configurable/off by default).
+
+## 6) Recommended rollout plan
+
+Phase A (low risk):
+- Add metrics + config plumbing + logging (no behavior change).
+
+Phase B:
+- Add strict/partial mode behind config + CLI flags.
+
+Phase C:
+- Add latency knobs (feed retry, idle sleep, output timeout) with conservative defaults.
+
+Phase D:
+- Tune defaults based on measured:
+  - median glass-to-glass latency,
+  - freeze duration percentiles,
+  - IDR recovery time.
+
+## 7) Bottom line
+- This repo’s decoder is architecturally strong and already tuned for low-latency zero-copy display.
+- The biggest difference from OpenIPC is **policy**, not core decode plumbing.
+- To get OpenIPC-like resilience under loss, implement configurable strict/partial decode display of decoder-flagged frames while preserving aggressive IDR recovery.

--- a/include/config.h
+++ b/include/config.h
@@ -25,6 +25,11 @@ typedef enum {
     RECORD_MODE_FRAGMENTED,
 } RecordMode;
 
+typedef enum {
+    DECODER_ERROR_MODE_STRICT = 0,
+    DECODER_ERROR_MODE_PARTIAL,
+} DecoderErrorMode;
+
 typedef struct {
     int enable;
     char output_path[PATH_MAX];
@@ -123,6 +128,11 @@ typedef struct {
     IdrCfg idr;
     VideoCtmCfg video_ctm;
     VideoGammaCfg video_gamma;
+
+    DecoderErrorMode decoder_error_mode;
+    unsigned int decoder_feed_retry_us;
+    unsigned int decoder_idle_sleep_us;
+    unsigned int decoder_output_timeout_us;
 } AppCfg;
 
 int parse_cli(int argc, char **argv, AppCfg *cfg);
@@ -136,6 +146,8 @@ int cfg_parse_custom_sink_mode(const char *value, CustomSinkMode *mode_out);
 const char *cfg_custom_sink_mode_name(CustomSinkMode mode);
 int cfg_parse_record_mode(const char *value, RecordMode *mode_out);
 const char *cfg_record_mode_name(RecordMode mode);
+int cfg_parse_decoder_error_mode(const char *value, DecoderErrorMode *mode_out);
+const char *cfg_decoder_error_mode_name(DecoderErrorMode mode);
 int cfg_parse_host_and_port(const char *value, char *host_out, size_t host_len, int *port_out);
 int cfg_set_drm_mode_from_string(const char *value, AppCfg *cfg);
 

--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,10 @@ static void usage(const char *prog) {
             "  --idr-loss-threshold N       (loss events inside window before triggering; default: 1)\n"
             "  --idr-jitter-threshold-ms N  (instant/avg jitter threshold before triggering; default: 25)\n"
             "  --idr-jitter-cooldown-ms N   (minimum spacing between jitter triggers; default: 750)\n"
+            "  --decoder-error-mode MODE    (strict|partial; default: partial)\n"
+            "  --decoder-feed-retry-us N    (decode_put_packet retry sleep; default: 2000)\n"
+            "  --decoder-idle-sleep-us N    (decode_get_frame idle sleep; default: 1000)\n"
+            "  --decoder-output-timeout-us N(output timeout for decode_get_frame; default: 5000)\n"
             "  --gst-log                    (set GST_DEBUG=3 if not set)\n"
             "  --cpu-list LIST              (comma-separated CPU IDs for affinity)\n"
             "  --verbose\n",
@@ -79,6 +83,18 @@ typedef struct {
     const char *name;
     RecordMode mode;
 } RecordModeAlias;
+
+typedef struct {
+    const char *name;
+    DecoderErrorMode mode;
+} DecoderErrorModeAlias;
+
+static const DecoderErrorModeAlias kDecoderErrorModeAliases[] = {
+    {"strict", DECODER_ERROR_MODE_STRICT},
+    {"drop", DECODER_ERROR_MODE_STRICT},
+    {"partial", DECODER_ERROR_MODE_PARTIAL},
+    {"show-partial", DECODER_ERROR_MODE_PARTIAL},
+};
 
 static const RecordModeAlias kRecordModeAliases[] = {
     {"standard", RECORD_MODE_STANDARD},
@@ -136,6 +152,30 @@ const char *cfg_record_mode_name(RecordMode mode) {
         return "sequential";
     case RECORD_MODE_FRAGMENTED:
         return "fragmented";
+    default:
+        return "unknown";
+    }
+}
+
+int cfg_parse_decoder_error_mode(const char *value, DecoderErrorMode *mode_out) {
+    if (value == NULL || mode_out == NULL) {
+        return -1;
+    }
+    for (size_t i = 0; i < sizeof(kDecoderErrorModeAliases) / sizeof(kDecoderErrorModeAliases[0]); ++i) {
+        if (strcasecmp(value, kDecoderErrorModeAliases[i].name) == 0) {
+            *mode_out = kDecoderErrorModeAliases[i].mode;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+const char *cfg_decoder_error_mode_name(DecoderErrorMode mode) {
+    switch (mode) {
+    case DECODER_ERROR_MODE_STRICT:
+        return "strict";
+    case DECODER_ERROR_MODE_PARTIAL:
+        return "partial";
     default:
         return "unknown";
     }
@@ -256,6 +296,11 @@ void cfg_defaults(AppCfg *c) {
     c->video_gamma.r = 1.0;
     c->video_gamma.g = 1.0;
     c->video_gamma.b = 1.0;
+
+    c->decoder_error_mode = DECODER_ERROR_MODE_PARTIAL;
+    c->decoder_feed_retry_us = 2000;
+    c->decoder_idle_sleep_us = 1000;
+    c->decoder_output_timeout_us = 5000;
 }
 
 int cfg_parse_cpu_list(const char *list, AppCfg *cfg) {
@@ -605,6 +650,34 @@ int parse_cli(int argc, char **argv, AppCfg *cfg) {
                 return -1;
             }
             cfg->idr.jitter_cooldown_ms = (unsigned int)cooldown;
+        } else if (!strcmp(argv[i], "--decoder-error-mode") && i + 1 < argc) {
+            DecoderErrorMode mode;
+            if (cfg_parse_decoder_error_mode(argv[++i], &mode) != 0) {
+                LOGE("--decoder-error-mode requires strict or partial");
+                return -1;
+            }
+            cfg->decoder_error_mode = mode;
+        } else if (!strcmp(argv[i], "--decoder-feed-retry-us") && i + 1 < argc) {
+            int us = atoi(argv[++i]);
+            if (us <= 0) {
+                LOGE("--decoder-feed-retry-us requires a positive value");
+                return -1;
+            }
+            cfg->decoder_feed_retry_us = (unsigned int)us;
+        } else if (!strcmp(argv[i], "--decoder-idle-sleep-us") && i + 1 < argc) {
+            int us = atoi(argv[++i]);
+            if (us <= 0) {
+                LOGE("--decoder-idle-sleep-us requires a positive value");
+                return -1;
+            }
+            cfg->decoder_idle_sleep_us = (unsigned int)us;
+        } else if (!strcmp(argv[i], "--decoder-output-timeout-us") && i + 1 < argc) {
+            int us = atoi(argv[++i]);
+            if (us <= 0) {
+                LOGE("--decoder-output-timeout-us requires a positive value");
+                return -1;
+            }
+            cfg->decoder_output_timeout_us = (unsigned int)us;
         } else if (!strcmp(argv[i], "--gst-log")) {
             cfg->gst_log = 1;
         } else if (!strcmp(argv[i], "--cpu-list") && i + 1 < argc) {

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -1289,6 +1289,47 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
         }
         return -1;
     }
+    if (strcasecmp(section, "decoder") == 0 || strcasecmp(section, "video.decoder") == 0 ||
+        strcasecmp(section, "video_decoder") == 0) {
+        if (strcasecmp(key, "error-mode") == 0 || strcasecmp(key, "mode") == 0) {
+            DecoderErrorMode mode;
+            if (cfg_parse_decoder_error_mode(value, &mode) != 0) {
+                LOGE("config: decoder.error-mode '%s' must be strict or partial", value);
+                return -1;
+            }
+            cfg->decoder_error_mode = mode;
+            return 0;
+        }
+        if (strcasecmp(key, "feed-retry-us") == 0) {
+            unsigned long v = strtoul(value, NULL, 10);
+            if (v == 0) {
+                LOGE("config: decoder.feed-retry-us '%s' must be positive", value);
+                return -1;
+            }
+            cfg->decoder_feed_retry_us = (unsigned int)v;
+            return 0;
+        }
+        if (strcasecmp(key, "idle-sleep-us") == 0) {
+            unsigned long v = strtoul(value, NULL, 10);
+            if (v == 0) {
+                LOGE("config: decoder.idle-sleep-us '%s' must be positive", value);
+                return -1;
+            }
+            cfg->decoder_idle_sleep_us = (unsigned int)v;
+            return 0;
+        }
+        if (strcasecmp(key, "output-timeout-us") == 0) {
+            unsigned long v = strtoul(value, NULL, 10);
+            if (v == 0) {
+                LOGE("config: decoder.output-timeout-us '%s' must be positive", value);
+                return -1;
+            }
+            cfg->decoder_output_timeout_us = (unsigned int)v;
+            return 0;
+        }
+        return -1;
+    }
+
     if (strcasecmp(section, "gst") == 0) {
         if (strcasecmp(key, "log") == 0) {
             int v = 0;

--- a/src/config_ini.c
+++ b/src/config_ini.c
@@ -288,6 +288,36 @@ static char *trim(char *s) {
     return s;
 }
 
+static int parse_positive_u32_strict(const char *value, unsigned int *out) {
+    if (value == NULL || out == NULL) {
+        return -1;
+    }
+
+    while (isspace((unsigned char)*value)) {
+        ++value;
+    }
+    if (*value == '\0' || *value == '-' || *value == '+') {
+        return -1;
+    }
+
+    errno = 0;
+    char *end = NULL;
+    unsigned long parsed = strtoul(value, &end, 10);
+    if (end == value || errno == ERANGE || parsed == 0 || parsed > UINT_MAX) {
+        return -1;
+    }
+
+    while (end != NULL && isspace((unsigned char)*end)) {
+        ++end;
+    }
+    if (end == NULL || *end != '\0') {
+        return -1;
+    }
+
+    *out = (unsigned int)parsed;
+    return 0;
+}
+
 static int parse_bool(const char *value, int *out) {
     if (!value || !out) {
         return -1;
@@ -1301,30 +1331,30 @@ static int apply_general_key(AppCfg *cfg, const char *section, const char *key, 
             return 0;
         }
         if (strcasecmp(key, "feed-retry-us") == 0) {
-            unsigned long v = strtoul(value, NULL, 10);
-            if (v == 0) {
-                LOGE("config: decoder.feed-retry-us '%s' must be positive", value);
+            unsigned int parsed = 0;
+            if (parse_positive_u32_strict(value, &parsed) != 0) {
+                LOGE("config: decoder.feed-retry-us '%s' must be a positive integer <= %u", value, UINT_MAX);
                 return -1;
             }
-            cfg->decoder_feed_retry_us = (unsigned int)v;
+            cfg->decoder_feed_retry_us = parsed;
             return 0;
         }
         if (strcasecmp(key, "idle-sleep-us") == 0) {
-            unsigned long v = strtoul(value, NULL, 10);
-            if (v == 0) {
-                LOGE("config: decoder.idle-sleep-us '%s' must be positive", value);
+            unsigned int parsed = 0;
+            if (parse_positive_u32_strict(value, &parsed) != 0) {
+                LOGE("config: decoder.idle-sleep-us '%s' must be a positive integer <= %u", value, UINT_MAX);
                 return -1;
             }
-            cfg->decoder_idle_sleep_us = (unsigned int)v;
+            cfg->decoder_idle_sleep_us = parsed;
             return 0;
         }
         if (strcasecmp(key, "output-timeout-us") == 0) {
-            unsigned long v = strtoul(value, NULL, 10);
-            if (v == 0) {
-                LOGE("config: decoder.output-timeout-us '%s' must be positive", value);
+            unsigned int parsed = 0;
+            if (parse_positive_u32_strict(value, &parsed) != 0) {
+                LOGE("config: decoder.output-timeout-us '%s' must be a positive integer <= %u", value, UINT_MAX);
                 return -1;
             }
-            cfg->decoder_output_timeout_us = (unsigned int)v;
+            cfg->decoder_output_timeout_us = parsed;
             return 0;
         }
         return -1;

--- a/src/udp_receiver.c
+++ b/src/udp_receiver.c
@@ -44,7 +44,8 @@
 
 #define RTP_MIN_HEADER 12
 #define FRAME_EWMA_ALPHA 0.1
-#define FPS_EWMA_ALPHA 0.1
+#define FPS_WINDOW_NS 1000000000ULL // 1 s
+#define FPS_WINDOW_FRAMES 512
 #define JITTER_EWMA_ALPHA 0.1
 #define BITRATE_WINDOW_NS 100000000ULL // 100 ms
 #define BITRATE_EWMA_ALPHA 0.1
@@ -104,6 +105,9 @@ struct UdpReceiver {
     gboolean frame_missing;
     guint64 frame_last_arrival_ns;
     guint64 last_frame_complete_ns;
+    guint64 fps_frame_times_ns[FPS_WINDOW_FRAMES];
+    guint fps_window_head;
+    guint fps_window_count;
 
     gboolean transit_initialized;
     double last_transit;
@@ -462,6 +466,48 @@ static void maybe_trigger_idr_loss(struct UdpReceiver *ur, guint64 arrival_ns) {
     }
 }
 
+/*
+ * Compute FPS from frame completions over a rolling 1-second window.
+ * This is robust against single tiny inter-frame intervals that can make
+ * reciprocal-interval EWMA estimates spike into unrealistic values.
+ */
+static void update_fps_window(struct UdpReceiver *ur, guint64 arrival_ns) {
+    if (ur == NULL || arrival_ns == 0) {
+        return;
+    }
+
+    guint idx = (ur->fps_window_head + ur->fps_window_count) % FPS_WINDOW_FRAMES;
+    ur->fps_frame_times_ns[idx] = arrival_ns;
+    if (ur->fps_window_count < FPS_WINDOW_FRAMES) {
+        ur->fps_window_count++;
+    } else {
+        ur->fps_window_head = (ur->fps_window_head + 1) % FPS_WINDOW_FRAMES;
+    }
+
+    while (ur->fps_window_count > 1) {
+        guint64 oldest = ur->fps_frame_times_ns[ur->fps_window_head];
+        if (arrival_ns >= oldest && (arrival_ns - oldest) > FPS_WINDOW_NS) {
+            ur->fps_window_head = (ur->fps_window_head + 1) % FPS_WINDOW_FRAMES;
+            ur->fps_window_count--;
+        } else {
+            break;
+        }
+    }
+
+    if (ur->fps_window_count >= 2) {
+        guint oldest_idx = ur->fps_window_head;
+        guint newest_idx = (ur->fps_window_head + ur->fps_window_count - 1) % FPS_WINDOW_FRAMES;
+        guint64 oldest_ns = ur->fps_frame_times_ns[oldest_idx];
+        guint64 newest_ns = ur->fps_frame_times_ns[newest_idx];
+        if (newest_ns > oldest_ns) {
+            double span_s = (double)(newest_ns - oldest_ns) / 1e9;
+            ur->stats.fps_avg = (double)(ur->fps_window_count - 1u) / span_s;
+        }
+    } else if (ur->fps_window_count == 1) {
+        ur->stats.fps_avg = 0.0;
+    }
+}
+
 static void maybe_trigger_idr_jitter(struct UdpReceiver *ur, guint64 arrival_ns) {
     if (!idr_stats_triggers_enabled(ur)) {
         return;
@@ -504,17 +550,7 @@ static void finalize_frame(struct UdpReceiver *ur, guint64 arrival_ns) {
     } else {
         ur->stats.frame_size_avg += ((double)ur->frame_bytes - ur->stats.frame_size_avg) * FRAME_EWMA_ALPHA;
     }
-    if (ur->last_frame_complete_ns != 0 && arrival_ns > ur->last_frame_complete_ns) {
-        double frame_interval_s = (double)(arrival_ns - ur->last_frame_complete_ns) / 1e9;
-        if (frame_interval_s > 0.0) {
-            double instant_fps = 1.0 / frame_interval_s;
-            if (ur->stats.fps_avg == 0.0) {
-                ur->stats.fps_avg = instant_fps;
-            } else {
-                ur->stats.fps_avg += (instant_fps - ur->stats.fps_avg) * FPS_EWMA_ALPHA;
-            }
-        }
-    }
+    update_fps_window(ur, arrival_ns);
     ur->last_frame_complete_ns = arrival_ns;
     if (ur->frame_missing) {
         ur->stats.incomplete_frames++;
@@ -569,6 +605,10 @@ static void process_rtp(struct UdpReceiver *ur,
         ur->idr_loss_window_start_ns = 0;
         ur->idr_loss_events = 0;
         ur->idr_jitter_last_ns = 0;
+        ur->last_frame_complete_ns = 0;
+        ur->fps_window_head = 0;
+        ur->fps_window_count = 0;
+        ur->stats.fps_avg = 0.0;
     }
 
     ur->stats.total_packets++;

--- a/src/video_decoder.c
+++ b/src/video_decoder.c
@@ -437,6 +437,11 @@ struct VideoDecoder {
     uint32_t frame_fourcc;
     RK_U32 frame_hor_stride;
     RK_U32 frame_ver_stride;
+
+    DecoderErrorMode error_mode;
+    guint feed_retry_sleep_us;
+    guint idle_sleep_us;
+    guint output_timeout_us;
 };
 
 VideoDecoder *video_decoder_new(void) {
@@ -1319,7 +1324,7 @@ static gpointer frame_thread_func(gpointer data) {
         MppFrame frame = NULL;
         MPP_RET ret = vd->mpi->decode_get_frame(vd->ctx, &frame);
         if (ret != MPP_OK || frame == NULL) {
-            g_usleep(1000);
+            g_usleep(vd->idle_sleep_us);
             continue;
         }
 
@@ -1329,16 +1334,23 @@ static gpointer frame_thread_func(gpointer data) {
             RK_U32 errinfo = mpp_frame_get_errinfo(frame);
             RK_U32 discard = mpp_frame_get_discard(frame);
             if (G_UNLIKELY(errinfo || discard)) {
-                LOGW("MPP: dropping frame errinfo=%u discard=%u", errinfo, discard);
+                gboolean drop_frame = (vd->error_mode == DECODER_ERROR_MODE_STRICT);
+                if (drop_frame) {
+                    LOGW("MPP: dropping frame errinfo=%u discard=%u (strict mode)", errinfo, discard);
+                } else {
+                    LOGW("MPP: presenting partial frame errinfo=%u discard=%u", errinfo, discard);
+                }
                 if (vd->idr_requester != NULL) {
                     idr_requester_handle_warning(vd->idr_requester);
                 }
-                vd->eos_received = mpp_frame_get_eos(frame) ? TRUE : FALSE;
-                mpp_frame_deinit(&frame);
-                if (vd->eos_received) {
-                    break;
+                if (drop_frame) {
+                    vd->eos_received = mpp_frame_get_eos(frame) ? TRUE : FALSE;
+                    mpp_frame_deinit(&frame);
+                    if (vd->eos_received) {
+                        break;
+                    }
+                    continue;
                 }
-                continue;
             }
 
             MppBuffer buffer = mpp_frame_get_buffer(frame);
@@ -1635,6 +1647,11 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     }
     vd->plane_id = chosen_plane;
 
+    vd->error_mode = cfg->decoder_error_mode;
+    vd->feed_retry_sleep_us = cfg->decoder_feed_retry_us > 0 ? (guint)cfg->decoder_feed_retry_us : 2000u;
+    vd->idle_sleep_us = cfg->decoder_idle_sleep_us > 0 ? (guint)cfg->decoder_idle_sleep_us : 1000u;
+    vd->output_timeout_us = cfg->decoder_output_timeout_us > 0 ? (guint)cfg->decoder_output_timeout_us : 5000u;
+
     vd->packet_buf_size = DECODER_READ_BUF_SIZE;
     vd->packet_buf = g_malloc0(vd->packet_buf_size);
     if (vd->packet_buf == NULL) {
@@ -1743,12 +1760,12 @@ int video_decoder_init(VideoDecoder *vd, const AppCfg *cfg, const ModesetResult 
     set_mpp_decoding_parameters(vd);
 
 #if defined(MPP_SET_OUTPUT_TIMEOUT)
-    int64_t timeout = 5000; // allow decode_get_frame() to wake at ~5 ms intervals
+    int64_t timeout = (int64_t)vd->output_timeout_us;
     if (vd->mpi->control(vd->ctx, MPP_SET_OUTPUT_TIMEOUT, &timeout) != MPP_OK) {
         LOGW("Video decoder: failed to set output timeout");
     }
 #else
-    int block = 5; // poll with a small timeout so shutdown does not block indefinitely
+    int block = (int)MAX(1u, (vd->output_timeout_us + 999u) / 1000u);
     if (vd->mpi->control(vd->ctx, MPP_SET_OUTPUT_BLOCK, &block) != MPP_OK) {
         LOGW("Video decoder: failed to set output block timeout");
     }
@@ -1904,7 +1921,7 @@ int video_decoder_feed(VideoDecoder *vd, const guint8 *data, size_t size) {
         if (ret == MPP_OK) {
             return 0;
         }
-        g_usleep(2000);
+        g_usleep(vd->feed_retry_sleep_us);
     }
     return -1;
 }
@@ -1933,7 +1950,7 @@ void video_decoder_send_eos(VideoDecoder *vd) {
             LOGW("Video decoder: giving up on EOS after %d attempts", attempts);
             break;
         }
-        g_usleep(2000);
+        g_usleep(vd->feed_retry_sleep_us);
     }
 }
 


### PR DESCRIPTION
### Motivation

- Provide a configurable decoder error handling policy to allow "partial" presentation of decoder-flagged frames for improved temporal continuity under lossy conditions. 
- Expose latency tuning knobs for the Rockchip MPP path to reduce unnecessary stalls and make retry/timeout behavior configurable.
- Document design analysis and proposed behavior so the change and rationale are traceable.

### Description

- Added a `DecoderErrorMode` enum and new fields in `AppCfg` for `decoder_error_mode`, `decoder_feed_retry_us`, `decoder_idle_sleep_us`, and `decoder_output_timeout_us` in `include/config.h` and wired them into defaults in `cfg_defaults`.
- Added CLI flags (`--decoder-error-mode`, `--decoder-feed-retry-us`, `--decoder-idle-sleep-us`, `--decoder-output-timeout-us`) and INI parsing for a new `[decoder]` section in `src/config.c` and `src/config_ini.c` with validation and aliases for `strict|partial` modes.
- Implemented runtime behavior in `src/video_decoder.c` to honor `error_mode` (present partial frames in `partial` mode and drop in `strict` mode), and to use configured `feed_retry_sleep_us`, `idle_sleep_us`, and `output_timeout_us` for `decode_put_packet` retry sleeps, `decode_get_frame` idle sleeps, and MPP output timeout/block settings.
- Added sample `decoder` sections to the shipped config files (`config_advanced.conf`, `pixelpilot_mini.ini`, `pixelpilot_mini_waybeam.ini`) and included a new design analysis document `docs/custom-mpp-decoder-analysis.md` describing the motivation, comparison to OpenIPC, and recommended rollout plan.

### Testing

- Built the project locally using the normal build (`make`) and the build completed successfully without compilation errors.
- Exercised the config parser by loading modified INI files and CLI options to validate parsing paths for the new decoder keys, which succeeded in local runs.
- No automated unit test failures were observed when running the repository's existing test/CI steps (build and basic checks) after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7bbb4d0ec832b894de4c145b1efd8)