### PR TITLE
Add commands tab, subscriber system, and subscribe video to vehicle WebUI

### DIFF
--- a/waybeam_hub/PLAN.md
+++ b/waybeam_hub/PLAN.md
@@ -32,6 +32,12 @@ waybeam_hub.py
 | 2026-02-28 | Initial waybeam_hub: SSE menu driver, WebUI, radio rules, asset/zoom control |
 | 2026-02-28 | Replaced CLI arguments with JSON config file (`config.json`) |
 | 2026-02-28 | Exposed tuning constants (debounce, deadband, timeouts) in config `tuning` section |
+| 2026-03-04 | C port: Added WebUI with Dashboard tab (status, CRSF input, peer sync, raw state) |
+| 2026-03-04 | C port: Added Commands tab with menu.ini actions, config commands, and subscribe video dropdown |
+| 2026-03-04 | C port: Added subscriber system (`/subscribe` endpoint, expiry, identity tracking) |
+| 2026-03-04 | C port: Added subscribe video (`/subscribe_video` endpoint, command template with `{ip}`/`{port}`) |
+| 2026-03-04 | C port: Added `"cmd"` config section for custom shell commands (up to 16 entries) |
+| 2026-03-04 | C port: Extended `/state` JSON with actions, cmds, subscribers, action_running, identity |
 
 ## Known issues
 

--- a/waybeam_hub/README.md
+++ b/waybeam_hub/README.md
@@ -12,6 +12,9 @@ Waybeam Hub is a remote menu driver and WebUI companion for PixelPilot Mini RK. 
 - **Radio rule triggers** — fire commands automatically when a CRSF channel value enters a configured range, with debounce and latch logic to prevent accidental repeats.
 - **WebUI** — dark-themed browser dashboard with real-time state display, OSD text/value overrides, asset toggles, zoom, live gamma LUT sliders, destination management, and debug recording/playback.
 - **Multi-destination UDP** — send OSD payloads to multiple PixelPilot instances simultaneously.
+- **Subscriber system** — HTTP-based subscriber registration with automatic expiry; discovered subscribers appear in the WebUI for video subscription.
+- **Subscribe video** — redirect the vehicle video stream to a selected subscriber via a configurable command template with `{ip}` and `{port}` substitution.
+- **Config commands** — define custom shell commands in a `"cmd"` config section, displayed as buttons in the WebUI Commands tab alongside menu.ini actions.
 - **JSON config file** — all settings (including tuning constants) are read from a single JSON file; no CLI flags required.
 
 ## Quick start
@@ -51,6 +54,10 @@ All settings are read from a JSON config file. The only CLI argument is `--confi
 | `action_shell` | string | `""` | Shell for actions (`$SHELL` fallback `/bin/sh`) |
 | `webui_host` | string | `"0.0.0.0"` | WebUI HTTP bind address |
 | `webui_port` | int | `8060` | WebUI HTTP port |
+| `webui_html` | string | `"waybeam_hub_c.html"` | WebUI HTML filename (resolved from asset_folder) |
+| `identity` | string | hostname | Hub identity name shown to subscribers (defaults to system hostname) |
+| `subscribe_video_cmd` | string | `""` | Shell command template for video subscription; supports `{ip}` and `{port}` placeholders |
+| `subscriber_timeout_s` | int | `120` | Seconds before an inactive subscriber is expired |
 | `sse_url` | string | `"http://127.0.0.1:8070/sse"` | SSE endpoint providing CRSF channel data |
 | `priority` | string | `"serial"` | Preferred input source (`"serial"` or `"joystick"`) |
 | `priority_fallback_s` | float | `5.0` | Seconds before falling back to the non-priority source |
@@ -108,6 +115,35 @@ The optional `tuning` object exposes internal constants for fine-tuning radio/jo
 ```
 
 Only include the keys you want to override — missing keys use the built-in runtime defaults.
+
+### Config commands (`cmd` section)
+
+The optional `cmd` object defines custom shell commands exposed in the WebUI Commands tab:
+
+```json
+{
+  "cmd": {
+    "Restart majestic": "killall -1 majestic",
+    "Reboot": "reboot",
+    "Show IP": "hostname -I"
+  }
+}
+```
+
+Each key is the button label; the value is the shell command to execute. Up to 16 entries are supported.
+
+### Subscribe video configuration
+
+To enable the Subscribe Video feature, set `subscribe_video_cmd` to a command template:
+
+```json
+{
+  "subscribe_video_cmd": "majestic-cmd set --outport {port} --outhost {ip}",
+  "subscriber_timeout_s": 120
+}
+```
+
+The `{ip}` and `{port}` placeholders are replaced with the selected subscriber's IP address and video port. The IP is validated via `inet_pton` before substitution to prevent command injection.
 
 When `actions_ini` is left empty, Waybeam Hub looks for `menu.ini` inside `asset_folder`. The WebUI also serves `index.html` from the same directory. The default deployment layout now assumes:
 
@@ -169,8 +205,10 @@ The WebUI serves `index.html` at the root and exposes a JSON command endpoint:
 | Endpoint | Method | Description |
 | --- | --- | --- |
 | `/` | GET | WebUI HTML page |
-| `/state` | GET | Current menu state as JSON |
+| `/state` | GET | Current menu state as JSON (includes actions, cmds, subscribers, action_running) |
 | `/command` | POST | Send a JSON command |
+| `/subscribe` | POST | Register as a subscriber (`{identity, ip, video_port}`) |
+| `/subscribe_video` | POST | Redirect video to a subscriber (`{ip, port}`) |
 
 ### Command examples
 
@@ -191,6 +229,8 @@ The WebUI serves `index.html` at the root and exposes a JSON command endpoint:
 {"gamma": "0.85,0.00,1.00,1.00,1.00,1.00"}
 {"gamma": "off"}
 {"destinations": [{"host": "10.6.0.50", "port": 7777}]}
+{"command": "run_action", "section": "SYSTEM", "name": "reboot"}
+{"command": "run_cmd", "name": "Restart majestic"}
 ```
 
 The `OSD Control` tab includes a `Gamma LUT` card with six sliders (`gamma`, `lift`, `gain`, `R`, `G`, `B`) plus `Gregify`, `Send Neutral`, and `Disable Gamma`. Slider changes are debounced and sent as one-shot external OSD `gamma` commands. Accepted ranges are `gamma` 0.20-5.00, `lift` -0.50-0.50, `gain` 0.50-3.00, and `R/G/B` 0.50-1.50. The `Gregify` preset sends `1.00,-0.15,2.75,1.00,1.00,1.00`.
@@ -223,7 +263,10 @@ line = {ext.text8}
 | File | Description |
 | --- | --- |
 | `waybeam_hub.py` | Main application — SSE client, menu engine, WebUI server, UDP sender |
+| `waybeam_hub.c` | C port for vehicle (SigmaStar) — poll()-based, subscriber system, commands tab, subscribe video |
+| `waybeam_hub_c.html` | WebUI for C port — Dashboard + Commands tabs, action/cmd buttons, subscriber dropdown |
 | `config.json` | Default JSON configuration (all settings and tuning constants) |
-| `index.html` | Browser-based control panel (served by the WebUI) |
+| `index.html` | Browser-based control panel for Python version (served by the WebUI) |
 | `menu.ini` | Default menu actions and radio rule definitions |
-| `S99waybeam_hub` | Example init-style startup script for deployment |
+| `S99waybeam_hub` | Example init-style startup script for Python version |
+| `S97waybeam-hub` | Init script for C port deployment |

--- a/waybeam_hub/waybeam_hub.c
+++ b/waybeam_hub/waybeam_hub.c
@@ -2155,7 +2155,7 @@ static void webui_handle_request(app_state_t *app, const char *req, int req_len)
       webui_send_response(web->client_fd, "200 OK", "application/json", "{\"ok\":true}", 11);
     else
       webui_send_response(web->client_fd, "500 Internal Server Error", "application/json",
-                          "{\"error\":\"action failed\"}", 24);
+                          "{\"error\":\"action failed\"}", 25);
     return;
   }
 

--- a/waybeam_hub/waybeam_hub.c
+++ b/waybeam_hub/waybeam_hub.c
@@ -64,6 +64,8 @@
 #define MAX_SECTIONS       16
 #define MAX_DESTINATIONS   4
 #define MAX_KEY_QUEUE      8
+#define MAX_SUBSCRIBERS    8
+#define MAX_CMD_ENTRIES   16
 
 #define SSE_LINE_BUF       4096
 #define SSE_DATA_BUF       4096
@@ -76,7 +78,7 @@
 #define SYNC_MAX_ACTIONS      16
 #define SYNC_BUF              1280
 #define WEB_REQ_BUF        4096
-#define WEB_HTML_BUF      16384
+#define WEB_HTML_BUF      32768
 
 #define SECTION_NAME_LEN   32
 #define ACTION_NAME_LEN    64
@@ -149,6 +151,11 @@ typedef struct {
 } splashscreen_t;
 
 typedef struct {
+  char name[ACTION_NAME_LEN];
+  char command[ACTION_CMD_LEN];
+} cmd_entry_t;
+
+typedef struct {
   char host[HOST_LEN];
   int port;
   int interval_ms;
@@ -171,6 +178,11 @@ typedef struct {
   splashscreen_t splashscreen;
   char sync_peer[HOST_LEN];
   char sync_role[16];
+  char identity[HOST_LEN];
+  char subscribe_video_cmd[ACTION_CMD_LEN];
+  int subscriber_timeout_s;
+  cmd_entry_t cmds[MAX_CMD_ENTRIES];
+  int cmd_count;
 } config_t;
 
 typedef struct {
@@ -214,6 +226,13 @@ typedef struct {
 } radio_rule_state_t;
 
 typedef struct {
+  char identity[HOST_LEN];
+  char ip[HOST_LEN];
+  int video_port;
+  double last_seen_mono;
+} subscriber_t;
+
+typedef struct {
   int channels[CRSF_DISPLAY_CHANNELS];
   int select_pressed;
   int back_pressed;
@@ -255,6 +274,7 @@ typedef struct {
 typedef struct {
   int server_fd;
   int client_fd;
+  char client_ip[HOST_LEN];
   char req_buf[WEB_REQ_BUF];
   int req_len;
   char html[WEB_HTML_BUF];
@@ -379,6 +399,8 @@ typedef struct app_state {
   char last_logged_status[256];
   webui_server_t webui;
   sync_state_t sync;
+  subscriber_t subscribers[MAX_SUBSCRIBERS];
+  int subscriber_count;
 } app_state_t;
 
 /* ---------------------------------------------------------------------------
@@ -538,6 +560,14 @@ static void config_defaults(config_t *cfg) {
   cfg->splashscreen.delay_s = 0.0;
   cfg->splashscreen.fadeout_s = 0.0;
 
+  /* Subscriber defaults */
+  cfg->subscribe_video_cmd[0] = '\0';
+  cfg->subscriber_timeout_s = 120;
+
+  /* Identity defaults to hostname */
+  if (gethostname(cfg->identity, sizeof(cfg->identity)) != 0)
+    snprintf(cfg->identity, sizeof(cfg->identity), "waybeam-hub");
+
   /* Sync defaults */
   cfg->sync_peer[0] = '\0';
   snprintf(cfg->sync_role, sizeof(cfg->sync_role), "vehicle");
@@ -626,6 +656,42 @@ static int parse_splashscreen_object(const char *p, splashscreen_t *s) {
   return -1;
 }
 
+static int parse_cmd_object(const char *p, config_t *cfg) {
+  if (!p || *p != '{') return -1;
+  ++p;
+  cfg->cmd_count = 0;
+  while (*p) {
+    p = skip_ws(p);
+    if (*p == '}') return 0;
+    if (*p != '"') return -1;
+    if (cfg->cmd_count >= MAX_CMD_ENTRIES) {
+      p = skip_json_value(p);        /* skip key */
+      if (!p) return -1;
+      p = skip_ws(p);
+      if (*p != ':') return -1;
+      ++p; p = skip_ws(p);
+      p = skip_json_value(p);        /* skip value */
+      if (!p) return -1;
+    } else {
+      cmd_entry_t *c = &cfg->cmds[cfg->cmd_count];
+      const char *next = parse_string(p, c->name, sizeof(c->name));
+      if (!next) return -1;
+      p = skip_ws(next);
+      if (*p != ':') return -1;
+      ++p; p = skip_ws(p);
+      next = parse_string(p, c->command, sizeof(c->command));
+      if (!next) return -1;
+      p = next;
+      cfg->cmd_count++;
+    }
+    p = skip_ws(p);
+    if (*p == ',') { ++p; continue; }
+    if (*p == '}') return 0;
+    return -1;
+  }
+  return -1;
+}
+
 static int parse_config_json(const char *path, config_t *cfg) {
   config_defaults(cfg);
 
@@ -665,8 +731,11 @@ static int parse_config_json(const char *path, config_t *cfg) {
     else if (strcmp(key, "priority") == 0) { p = parse_string(p, cfg->priority, sizeof(cfg->priority)); }
     else if (strcmp(key, "priority_fallback_s") == 0) { p = parse_json_double(p, &cfg->priority_fallback_s); }
     else if (strcmp(key, "verbose") == 0) { p = parse_json_bool(p, &cfg->verbose); }
+    else if (strcmp(key, "identity") == 0) { p = parse_string(p, cfg->identity, sizeof(cfg->identity)); }
     else if (strcmp(key, "sync_peer") == 0) { p = parse_string(p, cfg->sync_peer, sizeof(cfg->sync_peer)); }
     else if (strcmp(key, "sync_role") == 0) { p = parse_string(p, cfg->sync_role, sizeof(cfg->sync_role)); }
+    else if (strcmp(key, "subscribe_video_cmd") == 0) { p = parse_string(p, cfg->subscribe_video_cmd, sizeof(cfg->subscribe_video_cmd)); }
+    else if (strcmp(key, "subscriber_timeout_s") == 0) { p = parse_json_int(p, &cfg->subscriber_timeout_s); }
     else if (strcmp(key, "initial_off") == 0) {
       p = parse_json_int_array(p, cfg->initial_off, ASSET_COUNT, &cfg->initial_off_count);
     }
@@ -679,6 +748,10 @@ static int parse_config_json(const char *path, config_t *cfg) {
     }
     else if (strcmp(key, "splashscreen") == 0) {
       if (parse_splashscreen_object(p, &cfg->splashscreen) < 0) return -1;
+      p = skip_json_value(p);
+    }
+    else if (strcmp(key, "cmd") == 0) {
+      if (parse_cmd_object(p, cfg) < 0) return -1;
       p = skip_json_value(p);
     }
     else { p = skip_json_value(p); }
@@ -1458,6 +1531,8 @@ static void parse_destinations_array(const char *body, app_state_t *app) {
   }
 }
 
+static int action_launch(app_state_t *app, const menu_action_t *action);
+
 static int webui_enqueue_command(app_state_t *app, const char *body) {
   /* Commands that contain "menu" as substring must be checked FIRST */
   if (strstr(body, "\"show_menu\"")) {
@@ -1486,6 +1561,39 @@ static int webui_enqueue_command(app_state_t *app, const char *body) {
       set_asset_enabled(app, i, 0);
     app->dirty = 1;
     return 0;
+  }
+  if (strstr(body, "\"run_action\"")) {
+    char section[SECTION_NAME_LEN] = "", name[ACTION_NAME_LEN] = "";
+    const char *sp = strstr(body, "\"section\"");
+    if (sp) { sp += 9; while (*sp && (*sp == ' ' || *sp == ':')) sp++; if (*sp == '"') parse_string(sp, section, sizeof(section)); }
+    const char *np = strstr(body, "\"name\"");
+    if (np) { np += 6; while (*np && (*np == ' ' || *np == ':')) np++; if (*np == '"') parse_string(np, name, sizeof(name)); }
+    if (section[0] && name[0]) {
+      for (int i = 0; i < app->action_count; i++) {
+        if (strcmp(app->actions[i].section, section) == 0 &&
+            strcmp(app->actions[i].name, name) == 0) {
+          return action_launch(app, &app->actions[i]);
+        }
+      }
+    }
+    return -1;
+  }
+  if (strstr(body, "\"run_cmd\"")) {
+    char name[ACTION_NAME_LEN] = "";
+    const char *np = strstr(body, "\"name\"");
+    if (np) { np += 6; while (*np && (*np == ' ' || *np == ':')) np++; if (*np == '"') parse_string(np, name, sizeof(name)); }
+    if (name[0]) {
+      for (int i = 0; i < app->cfg.cmd_count; i++) {
+        if (strcmp(app->cfg.cmds[i].name, name) == 0) {
+          menu_action_t action;
+          snprintf(action.section, sizeof(action.section), "cmd");
+          snprintf(action.name, sizeof(action.name), "%s", app->cfg.cmds[i].name);
+          snprintf(action.command, sizeof(action.command), "%s", app->cfg.cmds[i].command);
+          return action_launch(app, &action);
+        }
+      }
+    }
+    return -1;
   }
   if (strstr(body, "\"remote_action\"")) {
     if (!app->sync.enabled) return -1;
@@ -1554,6 +1662,100 @@ static int webui_enqueue_command(app_state_t *app, const char *body) {
   return -1;
 }
 
+/* ---------------------------------------------------------------------------
+ * Subscriber tracking
+ * --------------------------------------------------------------------------- */
+
+static subscriber_t *subscriber_find_or_create(app_state_t *app, const char *identity) {
+  /* Find existing by identity */
+  for (int i = 0; i < app->subscriber_count; i++) {
+    if (strcmp(app->subscribers[i].identity, identity) == 0)
+      return &app->subscribers[i];
+  }
+  /* Allocate new slot */
+  if (app->subscriber_count < MAX_SUBSCRIBERS) {
+    subscriber_t *s = &app->subscribers[app->subscriber_count++];
+    memset(s, 0, sizeof(*s));
+    snprintf(s->identity, sizeof(s->identity), "%s", identity);
+    return s;
+  }
+  /* Evict oldest */
+  int oldest = 0;
+  for (int i = 1; i < app->subscriber_count; i++) {
+    if (app->subscribers[i].last_seen_mono < app->subscribers[oldest].last_seen_mono)
+      oldest = i;
+  }
+  subscriber_t *s = &app->subscribers[oldest];
+  memset(s, 0, sizeof(*s));
+  snprintf(s->identity, sizeof(s->identity), "%s", identity);
+  return s;
+}
+
+static void subscriber_expire(app_state_t *app, double now) {
+  double timeout = (double)app->cfg.subscriber_timeout_s;
+  int i = 0;
+  while (i < app->subscriber_count) {
+    if ((now - app->subscribers[i].last_seen_mono) >= timeout) {
+      LOGI("Subscriber expired: %s (%s)", app->subscribers[i].identity, app->subscribers[i].ip);
+      app->subscribers[i] = app->subscribers[app->subscriber_count - 1];
+      app->subscriber_count--;
+    } else {
+      i++;
+    }
+  }
+}
+
+static int subscribe_video_exec(app_state_t *app, const char *ip, int port) {
+  if (!app->cfg.subscribe_video_cmd[0]) return -1;
+
+  /* Validate IP */
+  struct in_addr tmp;
+  if (inet_pton(AF_INET, ip, &tmp) != 1) {
+    LOGW("subscribe_video: invalid IP '%s'", ip);
+    return -1;
+  }
+  /* Validate port */
+  if (port < 1 || port > 65535) {
+    LOGW("subscribe_video: invalid port %d", port);
+    return -1;
+  }
+
+  /* Build command by replacing {ip} and {port} */
+  char cmd[ACTION_CMD_LEN];
+  char port_str[8];
+  snprintf(port_str, sizeof(port_str), "%d", port);
+
+  int ci = 0;
+  const char *p = app->cfg.subscribe_video_cmd;
+  while (*p && ci < (int)sizeof(cmd) - 1) {
+    if (strncmp(p, "{ip}", 4) == 0) {
+      int len = (int)strlen(ip);
+      if (ci + len >= (int)sizeof(cmd)) break;
+      memcpy(cmd + ci, ip, len);
+      ci += len;
+      p += 4;
+    } else if (strncmp(p, "{port}", 6) == 0) {
+      int len = (int)strlen(port_str);
+      if (ci + len >= (int)sizeof(cmd)) break;
+      memcpy(cmd + ci, port_str, len);
+      ci += len;
+      p += 6;
+    } else {
+      cmd[ci++] = *p++;
+    }
+  }
+  cmd[ci] = '\0';
+
+  /* Launch via action_launch using a temporary action struct */
+  menu_action_t action;
+  snprintf(action.section, sizeof(action.section), "subscribe");
+  snprintf(action.name, sizeof(action.name), "video→%s:%d", ip, port);
+  snprintf(action.command, sizeof(action.command), "%s", cmd);
+
+  LOGI("subscribe_video: executing: %s", cmd);
+  return action_launch(app, &action);
+}
+
 static int webui_build_state_json(app_state_t *app, char *out, int out_sz) {
   menu_entry_t *entries;
   int entry_count;
@@ -1591,9 +1793,12 @@ static int webui_build_state_json(app_state_t *app, char *out, int out_sz) {
   int combo_active = src ? src->combo_active : 0;
   int combo_latched = src ? src->combo_latched : 0;
 
+  char identity_esc[HOST_LEN * 2];
+  json_escape(app->cfg.identity, identity_esc, sizeof(identity_esc));
+
   int n = 0;
   n += snprintf(out + n, out_sz - n,
-                "{\"type\":\"menu_state\",\"status\":\"%s\","
+                "{\"type\":\"menu_state\",\"identity\":\"%s\",\"status\":\"%s\","
                 "\"active_source\":\"%s\",\"menu_visible\":%s,"
                 "\"current_section\":\"%s\",\"selected\":%d,\"entry_count\":%d,"
                 "\"selected_label\":\"%s\","
@@ -1601,6 +1806,7 @@ static int webui_build_state_json(app_state_t *app, char *out, int out_sz) {
                 "\"channels\":%s,\"last_update_age_ms\":%d,"
                 "\"nav_direction\":\"%s\",\"select_pressed\":%s,"
                 "\"combo_active\":%s,\"combo_latched\":%s}",
+                identity_esc,
                 status_esc,
                 app->active_source == 0 ? "serial" : (app->active_source == 1 ? "joystick" : "none"),
                 menu_visible ? "true" : "false",
@@ -1708,6 +1914,58 @@ static int webui_build_state_json(app_state_t *app, char *out, int out_sz) {
     if (n >= out_sz) n = out_sz - 1;
   }
 
+  /* Subscribers */
+  n += snprintf(out + n, out_sz - n, ",\"subscribers\":[");
+  if (n >= out_sz) n = out_sz - 1;
+  for (int i = 0; i < app->subscriber_count; i++) {
+    subscriber_t *s = &app->subscribers[i];
+    char id_esc[HOST_LEN * 2], ip_esc[HOST_LEN * 2];
+    json_escape(s->identity, id_esc, sizeof(id_esc));
+    json_escape(s->ip, ip_esc, sizeof(ip_esc));
+    int age_ms = (int)((now - s->last_seen_mono) * 1000.0);
+    n += snprintf(out + n, out_sz - n, "%s{\"identity\":\"%s\",\"ip\":\"%s\",\"video_port\":%d,\"age_ms\":%d}",
+                  i ? "," : "", id_esc, ip_esc, s->video_port, age_ms);
+    if (n >= out_sz) n = out_sz - 1;
+  }
+  n += snprintf(out + n, out_sz - n, "]");
+  if (n >= out_sz) n = out_sz - 1;
+
+  /* Subscribe video capability */
+  n += snprintf(out + n, out_sz - n, ",\"has_subscribe_video\":%s",
+                app->cfg.subscribe_video_cmd[0] ? "true" : "false");
+  if (n >= out_sz) n = out_sz - 1;
+
+  /* Menu.ini actions */
+  n += snprintf(out + n, out_sz - n, ",\"actions\":[");
+  if (n >= out_sz) n = out_sz - 1;
+  for (int i = 0; i < app->action_count; i++) {
+    char se[64], ne[128];
+    json_escape(app->actions[i].section, se, sizeof(se));
+    json_escape(app->actions[i].name, ne, sizeof(ne));
+    n += snprintf(out + n, out_sz - n, "%s{\"section\":\"%s\",\"name\":\"%s\"}",
+                  i ? "," : "", se, ne);
+    if (n >= out_sz) n = out_sz - 1;
+  }
+  n += snprintf(out + n, out_sz - n, "]");
+  if (n >= out_sz) n = out_sz - 1;
+
+  /* Config commands */
+  n += snprintf(out + n, out_sz - n, ",\"cmds\":[");
+  if (n >= out_sz) n = out_sz - 1;
+  for (int i = 0; i < app->cfg.cmd_count; i++) {
+    char ne[128];
+    json_escape(app->cfg.cmds[i].name, ne, sizeof(ne));
+    n += snprintf(out + n, out_sz - n, "%s{\"name\":\"%s\"}", i ? "," : "", ne);
+    if (n >= out_sz) n = out_sz - 1;
+  }
+  n += snprintf(out + n, out_sz - n, "]");
+  if (n >= out_sz) n = out_sz - 1;
+
+  /* Action running state */
+  n += snprintf(out + n, out_sz - n, ",\"action_running\":%s",
+                app->action_pid > 0 ? "true" : "false");
+  if (n >= out_sz) n = out_sz - 1;
+
   n += snprintf(out + n, out_sz - n, "}");
   if (n >= out_sz) n = out_sz - 1;
   return n;
@@ -1812,7 +2070,7 @@ static void webui_handle_request(app_state_t *app, const char *req, int req_len)
   }
 
   if (strcmp(method, "GET") == 0 && strcmp(path, "/state") == 0) {
-    char json[4096];
+    char json[16384];
     int n = webui_build_state_json(app, json, sizeof(json));
     if (n < 0) n = 0;
     if (n >= (int)sizeof(json)) n = (int)sizeof(json) - 1;
@@ -1833,6 +2091,74 @@ static void webui_handle_request(app_state_t *app, const char *req, int req_len)
     return;
   }
 
+  if (strcmp(method, "POST") == 0 && strcmp(path, "/subscribe") == 0) {
+    char tmp[512];
+    int copy_n = body_len;
+    if (copy_n >= (int)sizeof(tmp)) copy_n = (int)sizeof(tmp) - 1;
+    memcpy(tmp, body, (size_t)copy_n);
+    tmp[copy_n] = '\0';
+
+    /* Parse identity, ip, video_port from JSON body */
+    char identity[HOST_LEN] = "";
+    char ip[HOST_LEN] = "";
+    int video_port = 5600;
+
+    const char *pp = strstr(tmp, "\"identity\"");
+    if (pp) { pp += 10; while (*pp && (*pp == ' ' || *pp == ':')) pp++; if (*pp == '"') parse_string(pp, identity, sizeof(identity)); }
+    pp = strstr(tmp, "\"ip\"");
+    if (pp) { pp += 4; while (*pp && (*pp == ' ' || *pp == ':')) pp++; if (*pp == '"') parse_string(pp, ip, sizeof(ip)); }
+    pp = strstr(tmp, "\"video_port\"");
+    if (pp) { pp += 12; while (*pp && (*pp == ' ' || *pp == ':')) pp++; parse_json_int(pp, &video_port); }
+
+    /* Default ip to connecting client */
+    if (!ip[0]) snprintf(ip, sizeof(ip), "%s", web->client_ip);
+    /* Default identity to ip */
+    if (!identity[0]) snprintf(identity, sizeof(identity), "%s", ip);
+
+    subscriber_t *s = subscriber_find_or_create(app, identity);
+    snprintf(s->ip, sizeof(s->ip), "%s", ip);
+    s->video_port = video_port;
+    s->last_seen_mono = monotonic_s();
+    LOGI("Subscriber registered: %s (%s:%d)", s->identity, s->ip, s->video_port);
+
+    char resp[128];
+    int rn = snprintf(resp, sizeof(resp), "{\"ok\":true,\"subscribers\":%d}", app->subscriber_count);
+    webui_send_response(web->client_fd, "200 OK", "application/json", resp, rn);
+    return;
+  }
+
+  if (strcmp(method, "POST") == 0 && strcmp(path, "/subscribe_video") == 0) {
+    if (!app->cfg.subscribe_video_cmd[0]) {
+      webui_send_response(web->client_fd, "400 Bad Request", "application/json",
+                          "{\"error\":\"subscribe_video_cmd not configured\"}", 46);
+      return;
+    }
+
+    char tmp[512];
+    int copy_n = body_len;
+    if (copy_n >= (int)sizeof(tmp)) copy_n = (int)sizeof(tmp) - 1;
+    memcpy(tmp, body, (size_t)copy_n);
+    tmp[copy_n] = '\0';
+
+    char ip[HOST_LEN] = "";
+    int port = 5600;
+
+    const char *pp = strstr(tmp, "\"ip\"");
+    if (pp) { pp += 4; while (*pp && (*pp == ' ' || *pp == ':')) pp++; if (*pp == '"') parse_string(pp, ip, sizeof(ip)); }
+    pp = strstr(tmp, "\"port\"");
+    if (pp) { pp += 6; while (*pp && (*pp == ' ' || *pp == ':')) pp++; parse_json_int(pp, &port); }
+
+    /* Default ip to connecting client */
+    if (!ip[0]) snprintf(ip, sizeof(ip), "%s", web->client_ip);
+
+    if (subscribe_video_exec(app, ip, port) == 0)
+      webui_send_response(web->client_fd, "200 OK", "application/json", "{\"ok\":true}", 11);
+    else
+      webui_send_response(web->client_fd, "500 Internal Server Error", "application/json",
+                          "{\"error\":\"action failed\"}", 24);
+    return;
+  }
+
   webui_send_response(web->client_fd, "404 Not Found", "application/json", "{\"error\":\"not found\"}", 21);
 }
 
@@ -1847,6 +2173,7 @@ static void webui_poll(app_state_t *app) {
     if (cfd >= 0) {
       web->client_fd = cfd;
       web->req_len = 0;
+      inet_ntop(AF_INET, &cli_addr.sin_addr, web->client_ip, sizeof(web->client_ip));
     }
   } else {
     char *buf = web->req_buf;
@@ -3462,6 +3789,9 @@ static int run_controller(app_state_t *app) {
 
       app->dirty = 0;
     }
+
+    /* Expire stale subscribers */
+    subscriber_expire(app, monotonic_s());
 
     /* Sync hello timer and peer timeout */
     if (app->sync.enabled) {

--- a/waybeam_hub/waybeam_hub_c.html
+++ b/waybeam_hub/waybeam_hub_c.html
@@ -21,7 +21,7 @@
       background: #1f2d4f;
     }
     .wrap { max-width: 800px; margin: 20px auto; padding: 0 16px; }
-    h1 { margin: 0 0 14px; font-size: 22px; }
+    h1 { margin: 0 0 0; font-size: 22px; }
     h3 { margin: 0 0 10px; font-size: 15px; }
     .card {
       background: linear-gradient(180deg, #182943 0%, var(--panel) 100%);
@@ -41,6 +41,7 @@
       font-size: 14px;
     }
     button:hover { background: #3a5078; }
+    button:disabled { opacity: 0.4; cursor: not-allowed; }
     pre {
       background: var(--bg);
       color: var(--muted);
@@ -97,61 +98,153 @@
       background: #23c7ff;
       transition: width 80ms linear;
     }
+    .tabs {
+      display: flex;
+      gap: 0;
+      margin: 10px 0 14px;
+      border-bottom: 2px solid var(--border);
+    }
+    .tab-btn {
+      padding: 8px 18px;
+      cursor: pointer;
+      background: none;
+      color: var(--muted);
+      border: none;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      font-size: 14px;
+      font-weight: 600;
+      border-radius: 0;
+    }
+    .tab-btn:hover { color: var(--text); background: none; }
+    .tab-btn.active {
+      color: var(--primary);
+      border-bottom-color: var(--primary);
+    }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    select {
+      padding: 8px 12px;
+      background: #2d3f5d;
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 14px;
+      min-width: 200px;
+    }
+    .cmd-section-label {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 600;
+      margin-right: 4px;
+    }
+    .cmd-status {
+      margin-bottom: 10px;
+      padding: 8px 12px;
+      background: var(--bg);
+      border-radius: 8px;
+      font-size: 13px;
+      color: var(--muted);
+    }
   </style>
 </head>
 <body>
 <div class="wrap">
   <h1>Waybeam Hub (C)</h1>
-
-  <div class="card">
-    <strong>Status:</strong> <span id="status">connecting...</span><br />
-    <strong>Source:</strong> <span id="source">-</span><br />
-    <strong>Section:</strong> <span id="section">-</span><br />
-    <strong>Selected:</strong> <span id="selected">-</span>
+  <div class="tabs">
+    <button class="tab-btn active" onclick="switchTab('dashboard')">Dashboard</button>
+    <button class="tab-btn" onclick="switchTab('commands')">Commands</button>
   </div>
 
-  <div class="card">
-    <div class="row">
-      <button onclick="send('menu')">Menu</button>
-      <button onclick="send('up')">Up</button>
-      <button onclick="send('down')">Down</button>
-      <button onclick="send('select')">Select</button>
+  <div id="tab-dashboard" class="tab-content active">
+    <div class="card">
+      <strong>Status:</strong> <span id="status">connecting...</span><br />
+      <strong>Source:</strong> <span id="source">-</span><br />
+      <strong>Section:</strong> <span id="section">-</span><br />
+      <strong>Selected:</strong> <span id="selected">-</span>
+    </div>
+
+    <div class="card">
+      <div class="row">
+        <button onclick="send('menu')">Menu</button>
+        <button onclick="send('up')">Up</button>
+        <button onclick="send('down')">Down</button>
+        <button onclick="send('select')">Select</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>CRSF Input <span id="crsf-link" class="pill off">OFF</span></h3>
+      <div id="crsf-summary" class="state">No CRSF data.</div>
+      <div class="crsf-grid" id="crsf-grid"></div>
+    </div>
+
+    <div class="card" id="peer-card" style="display:none">
+      <h3>Peer Hub <span id="peer-pill" class="pill off">OFFLINE</span></h3>
+      <div class="state">
+        <strong>Role:</strong> <span id="peer-role">-</span>
+        <strong>Runtime:</strong> <span id="peer-runtime">-</span><br/>
+        <strong>Status:</strong> <span id="peer-hub-status">-</span><br/>
+        <strong>Section:</strong> <span id="peer-section">-</span>
+        <strong>Selected:</strong> <span id="peer-selected">-</span>
+      </div>
+      <div id="peer-actions" class="row" style="margin-top:8px"></div>
+      <div id="peer-result" style="margin-top:8px;display:none">
+        <strong>Last result:</strong> <span id="peer-result-text" class="state"></span>
+      </div>
+    </div>
+
+    <div class="card">
+      <strong>Raw state</strong>
+      <pre id="raw">{}</pre>
     </div>
   </div>
 
-  <div class="card">
-    <h3>CRSF Input <span id="crsf-link" class="pill off">OFF</span></h3>
-    <div id="crsf-summary" class="state">No CRSF data.</div>
-    <div class="crsf-grid" id="crsf-grid"></div>
-  </div>
-
-  <div class="card" id="peer-card" style="display:none">
-    <h3>Peer Hub <span id="peer-pill" class="pill off">OFFLINE</span></h3>
-    <div class="state">
-      <strong>Role:</strong> <span id="peer-role">-</span>
-      <strong>Runtime:</strong> <span id="peer-runtime">-</span><br/>
-      <strong>Status:</strong> <span id="peer-hub-status">-</span><br/>
-      <strong>Section:</strong> <span id="peer-section">-</span>
-      <strong>Selected:</strong> <span id="peer-selected">-</span>
+  <div id="tab-commands" class="tab-content">
+    <div class="cmd-status">
+      <strong>Status:</strong> <span id="cmd-status">-</span>
     </div>
-    <div id="peer-actions" class="row" style="margin-top:8px"></div>
-    <div id="peer-result" style="margin-top:8px;display:none">
-      <strong>Last result:</strong> <span id="peer-result-text" class="state"></span>
-    </div>
-  </div>
 
-  <div class="card">
-    <strong>Raw state</strong>
-    <pre id="raw">{}</pre>
+    <div class="card" id="cmd-actions-card" style="display:none">
+      <h3>Menu Actions</h3>
+      <div class="row" id="cmd-actions"></div>
+    </div>
+
+    <div class="card" id="cmd-cmds-card" style="display:none">
+      <h3>Config Commands</h3>
+      <div class="row" id="cmd-cmds"></div>
+    </div>
+
+    <div class="card" id="cmd-subscribe-card" style="display:none">
+      <h3>Subscribe Video</h3>
+      <div class="row">
+        <select id="cmd-subscriber-select" onchange="document.getElementById('cmd-subscribe-btn').disabled=!this.value">
+          <option value="">No subscribers available</option>
+        </select>
+        <button id="cmd-subscribe-btn" onclick="subscribeVideo()" disabled>Subscribe</button>
+      </div>
+    </div>
   </div>
 </div>
 
 <script>
+  function switchTab(name) {
+    var tabs = document.querySelectorAll('.tab-btn');
+    var contents = document.querySelectorAll('.tab-content');
+    for (var i = 0; i < tabs.length; i++) {
+      tabs[i].className = 'tab-btn' + (tabs[i].textContent.toLowerCase().indexOf(name) >= 0 || (name === 'dashboard' && i === 0) || (name === 'commands' && i === 1) ? ' active' : '');
+    }
+    tabs[0].className = 'tab-btn' + (name === 'dashboard' ? ' active' : '');
+    tabs[1].className = 'tab-btn' + (name === 'commands' ? ' active' : '');
+    document.getElementById('tab-dashboard').className = 'tab-content' + (name === 'dashboard' ? ' active' : '');
+    document.getElementById('tab-commands').className = 'tab-content' + (name === 'commands' ? ' active' : '');
+  }
+
   async function send(command) {
     await fetch('/command', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command })
+      body: JSON.stringify({ command: command })
     });
     await refresh();
   }
@@ -262,6 +355,135 @@
     await refresh();
   }
 
+  function renderCommands(data) {
+    var running = data.action_running;
+
+    /* Status */
+    document.getElementById('cmd-status').textContent = data.status || '-';
+
+    /* Menu Actions */
+    var actCard = document.getElementById('cmd-actions-card');
+    var actDiv = document.getElementById('cmd-actions');
+    var actions = Array.isArray(data.actions) ? data.actions : [];
+    if (actions.length > 0) {
+      actCard.style.display = '';
+      actDiv.innerHTML = '';
+      for (var i = 0; i < actions.length; i++) {
+        var btn = document.createElement('button');
+        btn.innerHTML = '<span class="cmd-section-label">[' + actions[i].section + ']</span> ' + actions[i].name;
+        btn.disabled = running;
+        btn.onclick = (function(s, n) {
+          return function() { runAction(s, n); };
+        })(actions[i].section, actions[i].name);
+        actDiv.appendChild(btn);
+      }
+    } else {
+      actCard.style.display = 'none';
+    }
+
+    /* Config Commands */
+    var cmdCard = document.getElementById('cmd-cmds-card');
+    var cmdDiv = document.getElementById('cmd-cmds');
+    var cmds = Array.isArray(data.cmds) ? data.cmds : [];
+    if (cmds.length > 0) {
+      cmdCard.style.display = '';
+      cmdDiv.innerHTML = '';
+      for (var i = 0; i < cmds.length; i++) {
+        var btn = document.createElement('button');
+        btn.textContent = cmds[i].name;
+        btn.disabled = running;
+        btn.onclick = (function(n) {
+          return function() { runCmd(n); };
+        })(cmds[i].name);
+        cmdDiv.appendChild(btn);
+      }
+    } else {
+      cmdCard.style.display = 'none';
+    }
+
+    /* Subscribe Video — only rebuild dropdown when list changes */
+    var subCard = document.getElementById('cmd-subscribe-card');
+    var subBtn = document.getElementById('cmd-subscribe-btn');
+    if (data.has_subscribe_video) {
+      subCard.style.display = '';
+      var sel = document.getElementById('cmd-subscriber-select');
+      var subs = Array.isArray(data.subscribers) ? data.subscribers : [];
+      var key = subs.map(function(s) { return s.identity + '|' + s.ip + ':' + s.video_port; }).join(',');
+      if (key !== _lastSubKey) {
+        _lastSubKey = key;
+        var prev = sel.value;
+        if (subs.length === 0) {
+          sel.innerHTML = '<option value="">No subscribers available</option>';
+        } else {
+          sel.innerHTML = '<option value="">-- select subscriber --</option>';
+          for (var i = 0; i < subs.length; i++) {
+            var s = subs[i];
+            var val = s.ip + ':' + s.video_port;
+            var opt = document.createElement('option');
+            opt.value = val;
+            opt.textContent = s.identity + ' (' + val + ')';
+            sel.appendChild(opt);
+          }
+        }
+        if (prev) sel.value = prev;
+      }
+      if (!_subBtnTimer) subBtn.disabled = !sel.value;
+    } else {
+      subCard.style.display = 'none';
+    }
+  }
+
+  async function runAction(section, name) {
+    await fetch('/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'run_action', section: section, name: name })
+    });
+    await refresh();
+  }
+
+  async function runCmd(name) {
+    await fetch('/command', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'run_cmd', name: name })
+    });
+    await refresh();
+  }
+
+  var _subBtnTimer = null;
+  var _lastSubKey = '';
+  async function subscribeVideo() {
+    var sel = document.getElementById('cmd-subscriber-select');
+    var btn = document.getElementById('cmd-subscribe-btn');
+    var val = sel.value;
+    if (!val) return;
+    var parts = val.split(':');
+    var ip = parts[0], port = parseInt(parts[1], 10);
+
+    btn.disabled = true;
+    btn.textContent = 'Subscribing...';
+    try {
+      var res = await fetch('/subscribe_video', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ip: ip, port: port })
+      });
+      var ok = res.ok;
+      btn.textContent = ok ? 'OK' : 'Error';
+      btn.style.borderColor = ok ? '#0f5f40' : '#6c1c27';
+    } catch (e) {
+      btn.textContent = 'Error';
+      btn.style.borderColor = '#6c1c27';
+    }
+    if (_subBtnTimer) clearTimeout(_subBtnTimer);
+    _subBtnTimer = setTimeout(function() {
+      btn.disabled = false;
+      btn.textContent = 'Subscribe';
+      btn.style.borderColor = '';
+    }, 3000);
+  }
+
   async function refresh() {
     try {
       var res = await fetch('/state');
@@ -272,6 +494,7 @@
       document.getElementById('selected').textContent = data.selected_label || '-';
       renderCrsf(data);
       renderPeer(data);
+      renderCommands(data);
       document.getElementById('raw').textContent = JSON.stringify(data, null, 2);
     } catch (e) {}
   }

--- a/waybeam_hub/waybeam_hub_c.html
+++ b/waybeam_hub/waybeam_hub_c.html
@@ -230,10 +230,6 @@
 <script>
   function switchTab(name) {
     var tabs = document.querySelectorAll('.tab-btn');
-    var contents = document.querySelectorAll('.tab-content');
-    for (var i = 0; i < tabs.length; i++) {
-      tabs[i].className = 'tab-btn' + (tabs[i].textContent.toLowerCase().indexOf(name) >= 0 || (name === 'dashboard' && i === 0) || (name === 'commands' && i === 1) ? ' active' : '');
-    }
     tabs[0].className = 'tab-btn' + (name === 'dashboard' ? ' active' : '');
     tabs[1].className = 'tab-btn' + (name === 'commands' ? ' active' : '');
     document.getElementById('tab-dashboard').className = 'tab-content' + (name === 'dashboard' ? ' active' : '');
@@ -370,7 +366,11 @@
       actDiv.innerHTML = '';
       for (var i = 0; i < actions.length; i++) {
         var btn = document.createElement('button');
-        btn.innerHTML = '<span class="cmd-section-label">[' + actions[i].section + ']</span> ' + actions[i].name;
+        var span = document.createElement('span');
+        span.className = 'cmd-section-label';
+        span.textContent = '[' + actions[i].section + ']';
+        btn.appendChild(span);
+        btn.appendChild(document.createTextNode(' ' + actions[i].name));
         btn.disabled = running;
         btn.onclick = (function(s, n) {
           return function() { runAction(s, n); };
@@ -478,6 +478,7 @@
     }
     if (_subBtnTimer) clearTimeout(_subBtnTimer);
     _subBtnTimer = setTimeout(function() {
+      _subBtnTimer = null;
       btn.disabled = false;
       btn.textContent = 'Subscribe';
       btn.style.borderColor = '';


### PR DESCRIPTION
## Summary

- **Commands tab** in the vehicle WebUI with two command sources: menu.ini actions and a new `"cmd"` config section for custom shell commands
- **Subscriber system** with `/subscribe` endpoint, expiry tracking, and identity-based deduplication
- **Subscribe video dropdown** that redirects the video stream to a selected subscriber via configurable command template
- Extended `/state` JSON with `actions[]`, `cmds[]`, `subscribers[]`, `action_running`, `has_subscribe_video`, and `identity`
- Increased `/state` JSON buffer to 16KB and HTML serving buffer to 32KB
- Fixed `parse_cmd_object` overflow path to correctly skip key:value pairs when exceeding MAX_CMD_ENTRIES

## Changes

| File | Description |
|---|---|
| `waybeam_hub/waybeam_hub.c` | Backend: cmd_entry_t config parsing, subscriber lifecycle, run_action/run_cmd handlers, subscribe_video execution, state JSON extensions |
| `waybeam_hub/waybeam_hub_c.html` | Frontend: two-tab layout (Dashboard/Commands), action/cmd buttons, subscriber dropdown with stable rebuild, button state feedback |

## Test plan

- [ ] Native compile clean (`gcc -Wall -Wextra`)
- [ ] ARM cross-compile clean
- [ ] `curl /state | jq '{actions,cmds,action_running,subscribers}'` returns expected data
- [ ] Commands tab: action buttons and cmd buttons execute correctly
- [ ] Subscribe video dropdown populates from subscribers, selection triggers video redirect
- [ ] Dashboard tab unchanged from before
- [ ] Config with >16 cmd entries parsed without error (extras ignored)
- [ ] Deploy and verify on device at 192.168.1.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)