### PR TITLE
Change default OSD external UDP port from 5005 to 7777

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -33,7 +33,7 @@ static void usage(const char *prog) {
             "  --osd-plane-id N             (force OSD plane id; default auto)\n"
             "  --osd-refresh-ms N           (default: 500)\n"
             "  --osd-external              (enable external OSD feed listener)\n"
-            "  --osd-external-udp-port N   (UDP port for external OSD data; default: 5005)\n"
+            "  --osd-external-udp-port N   (UDP port for external OSD data; default: 7777)\n"
             "  --osd-external-bind ADDR    (bind address for external OSD data; default: 0.0.0.0)\n"
             "  --no-osd-external           (disable external OSD feed)\n"
             "  --record-video [PATH]        (enable MP4 capture; optional PATH or directory, default /media)\n"
@@ -251,7 +251,7 @@ void cfg_defaults(AppCfg *c) {
     c->osd_external.enable = 0;
     c->osd_external.enable_set = 0;
     strcpy(c->osd_external.bind_address, "0.0.0.0");
-    c->osd_external.udp_port = 5005;
+    c->osd_external.udp_port = 7777;
 
     c->gst_log = 0;
 


### PR DESCRIPTION
## Summary
Updated the default UDP port for external OSD (On-Screen Display) data feed from 5005 to 7777.

## Changes
- Updated the usage/help text to reflect the new default port number
- Changed the default port value in the configuration initialization from 5005 to 7777

## Details
This change affects the `--osd-external-udp-port` configuration option. The new default port of 7777 will be used when users enable the external OSD feed listener without explicitly specifying a port number. Both the user-facing documentation (help text) and the actual default configuration value have been updated to maintain consistency.

https://claude.ai/code/session_014jg3uWo8GgzTf5J8byAxPG